### PR TITLE
Removing link to accessories spreadsheet

### DIFF
--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1360,11 +1360,6 @@ twitterDescription += '. Click to view more stats!'
                                 </div>
                             </div>
                         <% } %>
-                        <a href="https://hypixel.net/threads/2461091/" style="margin-top: 35px" target="_blank" rel="nofollow" class="external-app">
-                            <div class="external-app-icon icon-google-sheets"></div>
-                            <div class="external-app-name">QOL Sheet <span class="grey-text">by Clowns</span></div>
-                            <div class="external-app-description">Check what accessories you're missing and which the next one you should go for is.</div>
-                        </a>
                     <% } %>
                 </div>
             </div>


### PR DESCRIPTION
Since the spreadsheet was discontinued, the link can be removed.