### PR TITLE
Expertise kills

### DIFF
--- a/src/constants/misc.js
+++ b/src/constants/misc.js
@@ -110,6 +110,9 @@ module.exports = {
         'Thorns VI'
     ],
 
+    
+    expertise_kills_ladder : [50,100,250,500,1000,2500,5500,10000,15000],
+
     // Player stats on a completely new profile
     base_stats: {
         damage: 0,

--- a/src/constants/misc.js
+++ b/src/constants/misc.js
@@ -110,8 +110,18 @@ module.exports = {
         'Thorns VI'
     ],
 
-    
-    expertise_kills_ladder : [50,100,250,500,1000,2500,5500,10000,15000],
+    // Number of kills required for each level of expertise
+    expertise_kills_ladder: [
+        50,
+        100,
+        250,
+        500,
+        1000,
+        2500,
+        5500,
+        10000,
+        15000
+    ],
 
     // Player stats on a completely new profile
     base_stats: {

--- a/src/lib.js
+++ b/src/lib.js
@@ -419,7 +419,6 @@ async function getItems(base64, customTextures = false, packs, cacheOnly = false
 
             if(helper.hasPath(item, 'tag', 'ExtraAttributes', 'expertise_kills')){
                 let { expertise_kills } = item.tag.ExtraAttributes;
-                const expertiseKillsLadder = [50,100,250,500,1000,2500,5500,10000,15000];
 
                 if(expertise_kills > 0 && lore_raw){
                     item.lore += "<br><br>" + helper.renderLore(`§7Expertise Kills: §c${expertise_kills}`);
@@ -427,7 +426,7 @@ async function getItems(base64, customTextures = false, packs, cacheOnly = false
                         item.lore += "<br>" + helper.renderLore(`§8MAXED OUT!`);
                     else{
                         let toNextLevel = 0;
-                        for (var e of expertiseKillsLadder){
+                        for (const e of constants.expertise_kills_ladder){
                             if(expertise_kills < e){
                                 toNextLevel = e - expertise_kills;
                                 break;

--- a/src/lib.js
+++ b/src/lib.js
@@ -418,7 +418,7 @@ async function getItems(base64, customTextures = false, packs, cacheOnly = false
             }
 
             let hasExpertiseKills = false;
-            let toNextLevel = 0;
+            let toNextLevel = 15000;
 
             if(helper.hasPath(item, 'tag', 'ExtraAttributes', 'expertise_kills')){
                 let { expertise_kills } = item.tag.ExtraAttributes;

--- a/src/lib.js
+++ b/src/lib.js
@@ -419,6 +419,7 @@ async function getItems(base64, customTextures = false, packs, cacheOnly = false
 
             if(helper.hasPath(item, 'tag', 'ExtraAttributes', 'expertise_kills')){
                 let { expertise_kills } = item.tag.ExtraAttributes;
+                const expertiseKillsLadder = [50,100,250,500,1000,2500,5500,10000,15000];
 
                 if(expertise_kills > 0 && lore_raw){
                     item.lore += "<br><br>" + helper.renderLore(`§7Expertise Kills: §c${expertise_kills}`);
@@ -426,8 +427,7 @@ async function getItems(base64, customTextures = false, packs, cacheOnly = false
                         item.lore += "<br>" + helper.renderLore(`§8MAXED OUT!`);
                     else{
                         let toNextLevel = 0;
-                        killsLadder = [50,100,250,500,1000,2500,5500,10000,15000];
-                        for (var e of killsLadder){
+                        for (var e of expertiseKillsLadder){
                             if(expertise_kills < e){
                                 toNextLevel = e - expertise_kills;
                                 break;

--- a/src/lib.js
+++ b/src/lib.js
@@ -417,6 +417,26 @@ async function getItems(base64, customTextures = false, packs, cacheOnly = false
                 }
             }
 
+            let hasExpertiseKills = false;
+            let toNextLevel = 0;
+
+            if(helper.hasPath(item, 'tag', 'ExtraAttributes', 'expertise_kills')){
+                let { expertise_kills } = item.tag.ExtraAttributes;
+
+                if(expertise_kills > 0 && lore_raw){
+                    hasExpertiseKills = true;
+                    killsLadder = [50,100,250,500,1000,2500,5500,10000,15000];
+                    for (var e of killsLadder){
+                        if(expertise_kills < e){
+                            toNextLevel = e - expertise_kills;
+                            break;
+                        }
+                    }
+                    item.lore += "<br><br>" + helper.renderLore(`§7Expertise Kills: §c${expertise_kills}`);
+                    item.lore += "<br>" + helper.renderLore(`§8${toNextLevel} kills to tier up!`);
+                }
+            }
+
             if(helper.hasPath(item, 'tag', 'ExtraAttributes', 'timestamp')){
                 item.lore += "<br>";
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -418,22 +418,25 @@ async function getItems(base64, customTextures = false, packs, cacheOnly = false
             }
 
             let hasExpertiseKills = false;
-            let toNextLevel = 15000;
 
             if(helper.hasPath(item, 'tag', 'ExtraAttributes', 'expertise_kills')){
                 let { expertise_kills } = item.tag.ExtraAttributes;
 
                 if(expertise_kills > 0 && lore_raw){
                     hasExpertiseKills = true;
-                    killsLadder = [50,100,250,500,1000,2500,5500,10000,15000];
-                    for (var e of killsLadder){
-                        if(expertise_kills < e){
-                            toNextLevel = e - expertise_kills;
-                            break;
-                        }
-                    }
                     item.lore += "<br><br>" + helper.renderLore(`§7Expertise Kills: §c${expertise_kills}`);
-                    item.lore += "<br>" + helper.renderLore(`§8${toNextLevel} kills to tier up!`);
+                    if (expertise_kills >= 15000)
+                        item.lore += "<br>" + helper.renderLore(`§8Maxed!`);
+                    else{
+                        let toNextLevel = 0;
+                        killsLadder = [50,100,250,500,1000,2500,5500,10000,15000];
+                        for (var e of killsLadder){
+                            if(expertise_kills < e){
+                                toNextLevel = e - expertise_kills;
+                                break;
+                            }
+                        }
+                        item.lore += "<br>" + helper.renderLore(`§8${toNextLevel} kills to tier up!`);}
                 }
             }
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -426,7 +426,7 @@ async function getItems(base64, customTextures = false, packs, cacheOnly = false
                     hasExpertiseKills = true;
                     item.lore += "<br><br>" + helper.renderLore(`§7Expertise Kills: §c${expertise_kills}`);
                     if (expertise_kills >= 15000)
-                        item.lore += "<br>" + helper.renderLore(`§8Maxed!`);
+                        item.lore += "<br>" + helper.renderLore(`§8MAXED OUT!`);
                     else{
                         let toNextLevel = 0;
                         killsLadder = [50,100,250,500,1000,2500,5500,10000,15000];

--- a/src/lib.js
+++ b/src/lib.js
@@ -417,13 +417,10 @@ async function getItems(base64, customTextures = false, packs, cacheOnly = false
                 }
             }
 
-            let hasExpertiseKills = false;
-
             if(helper.hasPath(item, 'tag', 'ExtraAttributes', 'expertise_kills')){
                 let { expertise_kills } = item.tag.ExtraAttributes;
 
                 if(expertise_kills > 0 && lore_raw){
-                    hasExpertiseKills = true;
                     item.lore += "<br><br>" + helper.renderLore(`§7Expertise Kills: §c${expertise_kills}`);
                     if (expertise_kills >= 15000)
                         item.lore += "<br>" + helper.renderLore(`§8MAXED OUT!`);


### PR DESCRIPTION
This code adds expertise_kills to the item lore including the amount of kills needed to the next Expertise level.
![grafik](https://user-images.githubusercontent.com/19228364/93064731-2970fb00-f678-11ea-909f-6fce7ef8b58b.png)
(This has been almost fully tested (exept for the case with a maxed rod with over 15000 kills, but I'm prettyconfident that works too)