### PR TITLE
new minion slots and all five profile upgrades

### DIFF
--- a/src/constants/misc.js
+++ b/src/constants/misc.js
@@ -129,7 +129,7 @@ module.exports = {
         15000
     ],
 
-    // api name of the profile upgrades
+    // api names and their max value from the profile upgrades
     profile_upgrades: {
         'island_size' : 10,
         'minion_slots' : 5,

--- a/src/constants/misc.js
+++ b/src/constants/misc.js
@@ -134,7 +134,7 @@ module.exports = {
         'island_size',
         'minion_slots',
         'guests_count',
-        '',
+        'coop_slots',
         'coins_allowance',
     ],
 

--- a/src/constants/misc.js
+++ b/src/constants/misc.js
@@ -130,13 +130,13 @@ module.exports = {
     ],
 
     // api name of the profile upgrades
-    profile_upgrades: [
-        'island_size',
-        'minion_slots',
-        'guests_count',
-        'coop_slots',
-        'coins_allowance',
-    ],
+    profile_upgrades: {
+        'island_size' : 10,
+        'minion_slots' : 5,
+        'guests_count' : 5,
+        'coop_slots' : 3,
+        'coins_allowance' : 5,
+    },
 
     // Player stats on a completely new profile
     base_stats: {

--- a/src/constants/misc.js
+++ b/src/constants/misc.js
@@ -129,6 +129,15 @@ module.exports = {
         15000
     ],
 
+    // api name of the profile upgrades
+    profile_upgrades: [
+        'island_size',
+        'minion_slots',
+        'guests_count',
+        '',
+        'coins_allowance',
+    ],
+
     // Player stats on a completely new profile
     base_stats: {
         damage: 0,

--- a/src/lib.js
+++ b/src/lib.js
@@ -1732,7 +1732,6 @@ module.exports = {
 
         output.dungeons = await module.exports.getDungeons(userProfile, hypixelProfile);
 
-
         output.fishing = {
             total: userProfile.stats.items_fished || 0,
             treasure: userProfile.stats.items_fished_treasure || 0,

--- a/src/lib.js
+++ b/src/lib.js
@@ -2438,7 +2438,7 @@ module.exports = {
         output.island_size = upgrade_stages[0];
         output.minion_slots = upgrade_stages[1];
         output.guests_count = upgrade_stages[2];
-        // output. = upgrade_stages[3];
+        output.coop_slots = upgrade_stages[3];
         output.coins_allowance = upgrade_stages[4];
         return output;
     },

--- a/src/lib.js
+++ b/src/lib.js
@@ -2430,8 +2430,11 @@ module.exports = {
         let upgrade_stages = new Array(constants.profile_upgrades.length).fill(0);
         output.profile_upgrades = {};
         if(helper.hasPath(profile, 'community_upgrades', 'upgrade_states'))
-            for (const u of profile.community_upgrades.upgrade_states)
-                upgrade_stages[constants.profile_upgrades.indexOf(u.upgrade)]++;
+            for (const u of profile.community_upgrades.upgrade_states){
+                let i = constants.profile_upgrades.indexOf(u.upgrade);
+                if (i >= 0)
+                    upgrade_stages[i]++;
+            }
         output.island_size = upgrade_stages[0];
         output.minion_slots = upgrade_stages[1];
         output.guests_count = upgrade_stages[2];

--- a/src/lib.js
+++ b/src/lib.js
@@ -2431,13 +2431,9 @@ module.exports = {
         const output = {};
         for (const upgrade in constants.profile_upgrades)
             output[upgrade] = 0;
-        output['fasttracked'] = 0;
         if (helper.hasPath(profile, 'community_upgrades', 'upgrade_states'))
-            for (const u of profile.community_upgrades.upgrade_states){
+            for (const u of profile.community_upgrades.upgrade_states)
                 output[u.upgrade] = Math.max(output[u.upgrade] || 0, u.tier);
-                if (u.fasttracked)
-                    output['fasttracked'] += 1;
-            }
         return output;
     },
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -2426,7 +2426,7 @@ module.exports = {
     },
 
     getProfileUpgrades: async (profile) => {
-        let output = {};
+        const output = {};
         for (const upgrade of constants.profile_upgrades)
             output[upgrade] = 0;
         if (helper.hasPath(profile, 'community_upgrades', 'upgrade_states'))

--- a/src/lib.js
+++ b/src/lib.js
@@ -1732,6 +1732,8 @@ module.exports = {
 
         output.dungeons = await module.exports.getDungeons(userProfile, hypixelProfile);
 
+        output.profile_upgrades = await module.exports.getProfileUpgrades(profile);
+
         output.fishing = {
             total: userProfile.stats.items_fished || 0,
             treasure: userProfile.stats.items_fished_treasure || 0,
@@ -2423,6 +2425,21 @@ module.exports = {
         return output;
     },
 
+    getProfileUpgrades: async (profile) => {
+        let output = {};
+        let upgrade_stages = new Array(constants.profile_upgrades.length).fill(0);
+        output.profile_upgrades = {};
+        if(helper.hasPath(profile, 'community_upgrades', 'upgrade_states'))
+            for (const u of profile.community_upgrades.upgrade_states)
+                upgrade_stages[constants.profile_upgrades.indexOf(u.upgrade)]++;
+        output.island_size = upgrade_stages[0];
+        output.minion_slots = upgrade_stages[1];
+        output.guests_count = upgrade_stages[2];
+        // output. = upgrade_stages[3];
+        output.coins_allowance = upgrade_stages[4];
+        return output;
+    },
+
     getProfile: async (db, paramPlayer, paramProfile, options = { cacheOnly: false }) => {
         if(paramPlayer.length != 32){
             try{
@@ -2586,6 +2603,9 @@ module.exports = {
 
                 if(helper.hasPath(_profile, 'banking'))
                     insertCache.banking = _profile.banking;
+                
+                if(helper.hasPath(_profile, 'community_upgrades'))
+                    insertCache.community_upgrades = _profile.community_upgrades;
 
                 db
                 .collection('profileCache')

--- a/src/lib.js
+++ b/src/lib.js
@@ -1732,7 +1732,6 @@ module.exports = {
 
         output.dungeons = await module.exports.getDungeons(userProfile, hypixelProfile);
 
-        output.profile_upgrades = await module.exports.getProfileUpgrades(profile);
 
         output.fishing = {
             total: userProfile.stats.items_fished || 0,
@@ -1752,6 +1751,7 @@ module.exports = {
         misc.protector = {};
         misc.damage = {};
         misc.burrows = {};
+        misc.profile_upgrades = {};
         misc.auctions_sell = {};
         misc.auctions_buy = {};
 
@@ -1777,6 +1777,8 @@ module.exports = {
             if(key in userProfile.stats) 
                 misc.burrows[key.replace("mythos_burrows_", "")] = { total: userProfile.stats[key] };
 
+        misc.profile_upgrades = await module.exports.getProfileUpgrades(profile);
+        
         const auctions_buy = ["auctions_bids", "auctions_highest_bid", "auctions_won", "auctions_gold_spent"];
         const auctions_sell = ["auctions_fees", "auctions_gold_earned"];
 
@@ -2427,7 +2429,7 @@ module.exports = {
 
     getProfileUpgrades: async (profile) => {
         const output = {};
-        for (const upgrade of constants.profile_upgrades)
+        for (const upgrade in constants.profile_upgrades)
             output[upgrade] = 0;
         if (helper.hasPath(profile, 'community_upgrades', 'upgrade_states'))
             for (const u of profile.community_upgrades.upgrade_states)

--- a/src/lib.js
+++ b/src/lib.js
@@ -2431,9 +2431,13 @@ module.exports = {
         const output = {};
         for (const upgrade in constants.profile_upgrades)
             output[upgrade] = 0;
+        output['fasttracked'] = 0;
         if (helper.hasPath(profile, 'community_upgrades', 'upgrade_states'))
-            for (const u of profile.community_upgrades.upgrade_states)
+            for (const u of profile.community_upgrades.upgrade_states){
                 output[u.upgrade] = Math.max(output[u.upgrade] || 0, u.tier);
+                if (u.fasttracked)
+                    output['fasttracked'] += 1;
+            }
         return output;
     },
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -2427,19 +2427,11 @@ module.exports = {
 
     getProfileUpgrades: async (profile) => {
         let output = {};
-        let upgrade_stages = new Array(constants.profile_upgrades.length).fill(0);
-        output.profile_upgrades = {};
-        if(helper.hasPath(profile, 'community_upgrades', 'upgrade_states'))
-            for (const u of profile.community_upgrades.upgrade_states){
-                let i = constants.profile_upgrades.indexOf(u.upgrade);
-                if (i >= 0)
-                    upgrade_stages[i]++;
-            }
-        output.island_size = upgrade_stages[0];
-        output.minion_slots = upgrade_stages[1];
-        output.guests_count = upgrade_stages[2];
-        output.coop_slots = upgrade_stages[3];
-        output.coins_allowance = upgrade_stages[4];
+        for (const upgrade of constants.profile_upgrades)
+            output[upgrade] = 0;
+        if (helper.hasPath(profile, 'community_upgrades', 'upgrade_states'))
+            for (const u of profile.community_upgrades.upgrade_states)
+                output[u.upgrade] = Math.max(output[u.upgrade] || 0, u.tier);
         return output;
     },
 

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -2306,7 +2306,6 @@ twitterDescription += '. Click to view more stats!'
                             <% for(const upgrade in constants.profile_upgrades){ %>
                             <% max = calculated.misc.profile_upgrades[upgrade] == constants.profile_upgrades[upgrade] ? 'golden-text' : '' %><span class="stat-name <%= max %>"><%= helper.capitalizeFirstLetter(upgrade.split("_").join(" ")); %>: </span><span class="stat-value <%= max %>""><%= calculated.misc.profile_upgrades[upgrade] %> / <%= constants.profile_upgrades[upgrade] %></span><br>
                             <% } %>
-                            <span class="stat-name"><%= helper.capitalizeFirstLetter('fast-tracked'.split("_").join(" ")); %>: </span><span class="stat-value""><%= calculated.misc.profile_upgrades['fasttracked'] %></span><br>
                         </p>
                     <% } %>
                     <% if('auctions_sell' in calculated.misc){ %>

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -2030,6 +2030,7 @@ twitterDescription += '. Click to view more stats!'
                 <p class="stat-raw-values">
                     <% max = uniqueMinions == 572 ? 'golden-text' : '' %><span class="stat-name <%= max %>">Unique Minions: </span><span class="stat-value <%= max %>"><%= uniqueMinions %> / 572</span><span class="grey-text"> (<%= Math.floor(uniqueMinions / 572 * 100) %>%)</span><br>
                     <% max = calculated.minion_slots.currentSlots == 24 ? 'golden-text' : '' %><span class="stat-name <%= max %>">Minion Slots: </span><span class="stat-value <%= max %>""><%= calculated.minion_slots.currentSlots %></span><span class="grey-text"> (<%= calculated.minion_slots.toNextSlot %> to next slot)</span><br>
+                    <span class="grey-text">obtained <%= calculated.profile_upgrades.minion_slots %> more through profile upgrades!</span><br>
                     <% max = maxedMinions == _.size(constants.minions) ? 'golden-text' : '' %><span class="stat-name <%= max %>">Maxed Minions: </span><span class="stat-value <%= max %>"><%= maxedMinions %> / <%= _.size(constants.minions) %></span><br>
                     <% if(skippedMinions > 0){ %>
                     <span class="stat-name">Skipped Minion Tiers: </span><span class="stat-value"><%= skippedMinions %></span><br>

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -2030,7 +2030,7 @@ twitterDescription += '. Click to view more stats!'
                 <p class="stat-raw-values">
                     <% max = uniqueMinions == 572 ? 'golden-text' : '' %><span class="stat-name <%= max %>">Unique Minions: </span><span class="stat-value <%= max %>"><%= uniqueMinions %> / 572</span><span class="grey-text"> (<%= Math.floor(uniqueMinions / 572 * 100) %>%)</span><br>
                     <% max = calculated.minion_slots.currentSlots == 24 ? 'golden-text' : '' %><span class="stat-name <%= max %>">Minion Slots: </span><span class="stat-value <%= max %>""><%= calculated.minion_slots.currentSlots %></span><span class="grey-text"> (<%= calculated.minion_slots.toNextSlot %> to next slot)</span><br>
-                    <span class="grey-text">obtained <%= calculated.profile_upgrades.minion_slots %> more through profile upgrades!</span><br>
+                    <% max = calculated.profile_upgrades.minion_slots == 5 ? 'golden-text' : '' %><span class="stat-name <%= max %>">Bonus Minion Slots: </span><span class="stat-value <%= max %>""><%= calculated.profile_upgrades.minion_slots %> / 5</span><br>
                     <% max = maxedMinions == _.size(constants.minions) ? 'golden-text' : '' %><span class="stat-name <%= max %>">Maxed Minions: </span><span class="stat-value <%= max %>"><%= maxedMinions %> / <%= _.size(constants.minions) %></span><br>
                     <% if(skippedMinions > 0){ %>
                     <span class="stat-name">Skipped Minion Tiers: </span><span class="stat-value"><%= skippedMinions %></span><br>

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -2306,6 +2306,7 @@ twitterDescription += '. Click to view more stats!'
                             <% for(const upgrade in constants.profile_upgrades){ %>
                             <% max = calculated.misc.profile_upgrades[upgrade] == constants.profile_upgrades[upgrade] ? 'golden-text' : '' %><span class="stat-name <%= max %>"><%= helper.capitalizeFirstLetter(upgrade.split("_").join(" ")); %>: </span><span class="stat-value <%= max %>""><%= calculated.misc.profile_upgrades[upgrade] %> / <%= constants.profile_upgrades[upgrade] %></span><br>
                             <% } %>
+                            <span class="stat-name"><%= helper.capitalizeFirstLetter('fasttracked'.split("_").join(" ")); %>: </span><span class="stat-value""><%= calculated.misc.profile_upgrades['fasttracked'] %></span><br>
                         </p>
                     <% } %>
                     <% if('auctions_sell' in calculated.misc){ %>

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -2030,7 +2030,7 @@ twitterDescription += '. Click to view more stats!'
                 <p class="stat-raw-values">
                     <% max = uniqueMinions == 572 ? 'golden-text' : '' %><span class="stat-name <%= max %>">Unique Minions: </span><span class="stat-value <%= max %>"><%= uniqueMinions %> / 572</span><span class="grey-text"> (<%= Math.floor(uniqueMinions / 572 * 100) %>%)</span><br>
                     <% max = calculated.minion_slots.currentSlots == 24 ? 'golden-text' : '' %><span class="stat-name <%= max %>">Minion Slots: </span><span class="stat-value <%= max %>""><%= calculated.minion_slots.currentSlots %></span><span class="grey-text"> (<%= calculated.minion_slots.toNextSlot %> to next slot)</span><br>
-                    <% max = calculated.misc.profile_upgrades.minion_slots == 5 ? 'golden-text' : '' %><span class="stat-name <%= max %>">Bonus Minion Slots: </span><span class="stat-value <%= max %>""><%= calculated.misc.profile_upgrades.minion_slots %> / 5</span><br>
+                    <% max = calculated.misc.profile_upgrades.minion_slots == 5 ? 'golden-text' : '' %><span class="stat-name <%= max %>">Bonus Minion Slots: </span><span class="stat-value <%= max %>""><%= calculated.misc.profile_upgrades.minion_slots %> / <%= constants.profile_upgrades['minion_slots'] %></span><br>
                     <% max = maxedMinions == _.size(constants.minions) ? 'golden-text' : '' %><span class="stat-name <%= max %>">Maxed Minions: </span><span class="stat-value <%= max %>"><%= maxedMinions %> / <%= _.size(constants.minions) %></span><br>
                     <% if(skippedMinions > 0){ %>
                     <span class="stat-name">Skipped Minion Tiers: </span><span class="stat-value"><%= skippedMinions %></span><br>

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -2030,7 +2030,7 @@ twitterDescription += '. Click to view more stats!'
                 <p class="stat-raw-values">
                     <% max = uniqueMinions == 572 ? 'golden-text' : '' %><span class="stat-name <%= max %>">Unique Minions: </span><span class="stat-value <%= max %>"><%= uniqueMinions %> / 572</span><span class="grey-text"> (<%= Math.floor(uniqueMinions / 572 * 100) %>%)</span><br>
                     <% max = calculated.minion_slots.currentSlots == 24 ? 'golden-text' : '' %><span class="stat-name <%= max %>">Minion Slots: </span><span class="stat-value <%= max %>""><%= calculated.minion_slots.currentSlots %></span><span class="grey-text"> (<%= calculated.minion_slots.toNextSlot %> to next slot)</span><br>
-                    <% max = calculated.profile_upgrades.minion_slots == 5 ? 'golden-text' : '' %><span class="stat-name <%= max %>">Bonus Minion Slots: </span><span class="stat-value <%= max %>""><%= calculated.profile_upgrades.minion_slots %> / 5</span><br>
+                    <% max = calculated.misc.profile_upgrades.minion_slots == 5 ? 'golden-text' : '' %><span class="stat-name <%= max %>">Bonus Minion Slots: </span><span class="stat-value <%= max %>""><%= calculated.misc.profile_upgrades.minion_slots %> / 5</span><br>
                     <% max = maxedMinions == _.size(constants.minions) ? 'golden-text' : '' %><span class="stat-name <%= max %>">Maxed Minions: </span><span class="stat-value <%= max %>"><%= maxedMinions %> / <%= _.size(constants.minions) %></span><br>
                     <% if(skippedMinions > 0){ %>
                     <span class="stat-name">Skipped Minion Tiers: </span><span class="stat-value"><%= skippedMinions %></span><br>
@@ -2300,11 +2300,11 @@ twitterDescription += '. Click to view more stats!'
                             <% } %>
                         </p>
                     <% } %>
-                    <% if('profile_upgrades' in calculated){ %>
+                    <% if('profile_upgrades' in calculated.misc){ %>
                         <div class="minion-category-header"><div class="minion-category-icon"><div class="item-icon icon-154_0"></div></div><span>profile upgrades</span></div>
                         <p class="stat-raw-values">
-                            <% for(const upgrade of constants.profile_upgrades){ %>
-                            <span class="stat-name"><%= helper.capitalizeFirstLetter(upgrade.split("_").join(" ")); %>: </span><span class="stat-value"><%= calculated.profile_upgrades[upgrade] %></span><br>
+                            <% for(const upgrade in constants.profile_upgrades){ %>
+                            <% max = calculated.misc.profile_upgrades[upgrade] == constants.profile_upgrades[upgrade] ? 'golden-text' : '' %><span class="stat-name <%= max %>"><%= helper.capitalizeFirstLetter(upgrade.split("_").join(" ")); %>: </span><span class="stat-value <%= max %>""><%= calculated.misc.profile_upgrades[upgrade] %> / <%= constants.profile_upgrades[upgrade] %></span><br>
                             <% } %>
                         </p>
                     <% } %>

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -2300,6 +2300,14 @@ twitterDescription += '. Click to view more stats!'
                             <% } %>
                         </p>
                     <% } %>
+                    <% if('profile_upgrades' in calculated){ %>
+                        <div class="minion-category-header"><div class="minion-category-icon"><div class="item-icon icon-154_0"></div></div><span>profile upgrades</span></div>
+                        <p class="stat-raw-values">
+                            <% for(const upgrade of constants.profile_upgrades){ %>
+                            <span class="stat-name"><%= helper.capitalizeFirstLetter(upgrade.split("_").join(" ")); %>: </span><span class="stat-value"><%= calculated.profile_upgrades[upgrade] %></span><br>
+                            <% } %>
+                        </p>
+                    <% } %>
                     <% if('auctions_sell' in calculated.misc){ %>
                         <div class="minion-category-header"><div class="minion-category-icon"><div class="item-icon icon-266_0"></div></div><span>auctions sold</span></div>
                         <p class="stat-raw-values">

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -2306,7 +2306,7 @@ twitterDescription += '. Click to view more stats!'
                             <% for(const upgrade in constants.profile_upgrades){ %>
                             <% max = calculated.misc.profile_upgrades[upgrade] == constants.profile_upgrades[upgrade] ? 'golden-text' : '' %><span class="stat-name <%= max %>"><%= helper.capitalizeFirstLetter(upgrade.split("_").join(" ")); %>: </span><span class="stat-value <%= max %>""><%= calculated.misc.profile_upgrades[upgrade] %> / <%= constants.profile_upgrades[upgrade] %></span><br>
                             <% } %>
-                            <span class="stat-name"><%= helper.capitalizeFirstLetter('fasttracked'.split("_").join(" ")); %>: </span><span class="stat-value""><%= calculated.misc.profile_upgrades['fasttracked'] %></span><br>
+                            <span class="stat-name"><%= helper.capitalizeFirstLetter('fast-tracked'.split("_").join(" ")); %>: </span><span class="stat-value""><%= calculated.misc.profile_upgrades['fasttracked'] %></span><br>
                         </p>
                     <% } %>
                     <% if('auctions_sell' in calculated.misc){ %>


### PR DESCRIPTION
This adds the minion slots from the profile upgrades to the Minions section,
![grafik](https://user-images.githubusercontent.com/19228364/94755126-bb287a00-0393-11eb-8923-1190d1471325.png)
(This also adds all 5 profile upgrades to the profile object even thogh 4 of them are unused for now)
EDIT: now it also adds the profile upgrades to the misc section.
![grafik](https://user-images.githubusercontent.com/19228364/94828400-b56d7b80-0409-11eb-9182-1e6bced80970.png)
The bonus minion slots are now in 2 sections (minions and profile upgrades). 
Question is if the Profile upgrades one should be deleted or if it should stay there
