### PR TITLE
run scrollbar detection in later

### DIFF
--- a/public/resources/js/stats.js
+++ b/public/resources/js/stats.js
@@ -1049,7 +1049,12 @@ document.addEventListener('DOMContentLoaded', function(){
     });
 
     setTimeout(resize, 1000);
-    
+});
+
+
+
+//this is run after flow
+document.addEventListener('load', function () {
     // checks if the scrollbar has a width should be true with desktop style scrollbars
     if (window.innerWidth > document.documentElement.clientWidth) {
         document.documentElement.classList.add('style-scrollbar');


### PR DESCRIPTION
run scrollbar detection in `load` instead of `DOMContentLoaded`

see #74 for more info