### PR TITLE
prevent overscroll bubbling on stats popup

### DIFF
--- a/public/resources/css/index.css
+++ b/public/resources/css/index.css
@@ -990,6 +990,7 @@ html.no-transform #info_box.opened{
     max-height: calc(100vh - 200px);
     overflow-y: auto;
     font-size: 15px;
+    overscroll-behavior-y: contain;
 }
 
 #stats_content .item-lore a{


### PR DESCRIPTION
this PR stops the user from accidentally scrolling the main page when hovering over the popup that appears after clicking on an item