### PR TITLE
use backdrop-filter instead of --bg_blur-webp when supported

### DIFF
--- a/public/resources/css/index.css
+++ b/public/resources/css/index.css
@@ -550,6 +550,12 @@ header{
     text-shadow: 0px 0px 3px rgba(0,0,0,0.5);
 }
 
+@supports ((-webkit-backdrop-filter: blur(16px)) or (backdrop-filter: blur(16px))) {
+    #bg_blur{
+        display: none;
+    }
+}
+
 #bg_blur{
     background: var(--bg_blur-webp) no-repeat center center fixed;
     background-size: cover;
@@ -580,6 +586,8 @@ html.no-webp #bg_blur{
     -moz-user-select: none;
     -ms-user-select: none;
      user-select: none;
+    -webkit-backdrop-filter: blur(16px) brightness(0.5);
+    backdrop-filter: blur(16px) brightness(0.5);
 }
 
 #base_stats_container{


### PR DESCRIPTION
87% of browsers support `backdrop-filter` according to [caniuse](https://caniuse.com/?search=backdrop-filter).

This CSS property allows us to add background blur without the need for a second picture.

This PR uses `backdrop-filter` on browsers that support it meaning that the browser doesn't need to fetch the pre-blurred image.
On browsers that do not support `backdrop-filter` (Firefox), the page will fall back to the old system.