### PR TITLE
Added pet skins (cleaned)

### DIFF
--- a/src/constants/pets.js
+++ b/src/constants/pets.js
@@ -383,6 +383,91 @@ module.exports = {
         }
     },
 
+    pet_skins: {
+        "ENDERMAN": {
+            "ENDERMAN": {
+                name: "Spooky",
+                head: "/head/ea84cc8818c293484fdaafc8fa2f0bf39e55733a247d68023df2c6c6b9b671d0",
+            },
+        },
+        "GUARDIAN": {
+            "GUARDIAN": {
+                name: "Watcher",
+                head: "/head/37cc76e7af29f5f3fbfd6ece794160811eff96f753459fa61d7ad176a064e3c5",
+            },
+        },
+        "TIGER": {
+            "TIGER_TWILIGHT": {
+                name: "Twilight",
+                head: "/head/896211dc599368dbd9056c0116ab61063991db793be93066a858eb4e9ce56438",
+            },
+        },
+        "RABBIT": {
+            "RABBIT": {
+                name: "Pretty",
+                head: "/head/a34631d940fddb689ddef6a3b352c50220c460dba05cd18dc83192b59dc647f8",
+            },
+        },
+        "WITHER_SKELETON": {
+            "WITHER": {
+                name: "Dark",
+                head: "/head/224c2d14a0219af5ccfcaa36e8a333e271724ed61276611f9529e16c10273a0d",
+            },
+        },
+        "ROCK": {
+            "ROCK_COOL": {
+                name: "Cool",
+                head: "/head/fefcdbb7d95502acc1ae35a32a40ce4dec8f4c9f0da26c9d9fe7c2c3eb748f6",
+            },
+            "ROCK_SMILE": {
+                name: "Smile",
+                head: "/head/713c8b2916a275db4c1762cf5f13d7b95b91d60baf5164a447d6efa7704cf11b",
+            },
+            "ROCK_THINKING": {
+                name: "Thinking",
+                head: "/head/dd2f781f03c365bbc5dd1e7186ab38dc69465e836c9fe066a9a844f34a4da92",
+            },
+            "ROCK_LAUGH": {
+                name: "Laughing",
+                head: "/head/8cc1ef513d5f616675242174acde7b9d6259a47c4fe8f6e4b6e20920319d7073",
+            },
+            "ROCK_DERP": {
+                name: "Derp",
+                head: "/head/c4f89fbd12c209f7f26c1f34a1bd7f47635814759c09688dd212b205c73a8c02",
+            },
+            "ROCK_EMBARASSED": {
+                name: "Embarassed",
+                head: "/head/27ff34992e66599e8529008be3fb577cb0ab545294253e25a0cc988e416c849",
+            },
+        },
+        "SHEEP": {
+            "SHEEP_WHITE": {
+                name: "White",
+                head: "/head/b92a1a5c325f25f7438a0abb4f86ba6cf75552d02c7349a7292981459b31d2f7",
+            },
+            "SHEEP_PURPLE": {
+                name: "Purple",
+                head: "/head/99a88cf7dd33063587c6b540e6130abc5d07f1a65c47573ab3c1ad3ccec8857f",
+            },
+            "SHEEP_BLACK": {
+                name: "Black",
+                head: "/head/aa9dcda642a807cd2daa4aa6be87cef96e08a8c8f5cec2657dda4266c6a884c2",
+            },
+            "SHEEP_PINK": {
+                name: "Pink",
+                head: "/head/afa7747684dcb96192d90342cea62742ec363da07cb5e6e25eecec888cd2076",
+            },
+            "SHEEP_LIGHT_BLUE": {
+                name: "Light Blue",
+                head: "/head/722220de1a863bc5d9b9e7a6a3b03214c9f3d698ed3fe0d28220f3b93b7685c5",
+            },
+            "SHEEP_LIGHT_GREEN": {
+                name: "Light Green",
+                head: "/head/cf183ec2fe58faa43e568419b7a0dc446ece4ea0be52ec784c94e1d74b75939d",
+            },
+        }
+    },
+
     pet_value: {
         "common": 1,
         "uncommon": 2,

--- a/src/constants/pets.js
+++ b/src/constants/pets.js
@@ -435,8 +435,8 @@ module.exports = {
                 name: "Derp",
                 head: "/head/c4f89fbd12c209f7f26c1f34a1bd7f47635814759c09688dd212b205c73a8c02",
             },
-            "ROCK_EMBARASSED": {
-                name: "Embarassed",
+            "ROCK_EMBARRASSED": {
+                name: "Embarrassed",
                 head: "/head/27ff34992e66599e8529008be3fb577cb0ab545294253e25a0cc988e416c849",
             },
         },

--- a/src/constants/pets.js
+++ b/src/constants/pets.js
@@ -465,7 +465,13 @@ module.exports = {
                 name: "Light Green",
                 head: "/head/cf183ec2fe58faa43e568419b7a0dc446ece4ea0be52ec784c94e1d74b75939d",
             },
-        }
+        },
+        "SILVERFISH": {
+            "SILVERFISH": {
+                name: "Fortified",
+                head: "/head/d8552ff591042c4a38f8ba0626784ae28c4545a97d423fd9037c341035593273",
+            },
+        },
     },
 
     pet_value: {

--- a/src/lib.js
+++ b/src/lib.js
@@ -1964,8 +1964,14 @@ module.exports = {
 
             pet.texture_path = petData.head;
 
+            let petSkin = null;
+
+            if (pet.skin && constants.pet_skins?.[pet.type]?.[pet.skin]) {
+                pet.texture_path = constants.pet_skins[pet.type][pet.skin].head;
+                petSkin = constants.pet_skins[pet.type][pet.skin].name;
+            }
             let lore = [
-                `§8${helper.capitalizeFirstLetter(petData.type)} Pet`,
+                `§8${helper.capitalizeFirstLetter(petData.type)} Pet${petSkin ? `, ${petSkin} Skin` : ''}`,
             ];
 
             lore.push('');

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1521,9 +1521,27 @@ twitterDescription += '. Click to view more stats!'
 
                         for(const pet of calculated.pets)
                             totalPetXp += pet.exp;
+
+                        let totalUniqueSkins = 0
+                        for(const skins of Object.values(constants.pet_skins)) {
+                            totalUniqueSkins += Object.keys(skins).length
+                        }
+
+                        let userUniqueSkins = 0
+                        let userSkins = []
+                        for (const pet of calculated.pets) {
+                            if (
+                                pet.skin &&
+                                userSkins.indexOf(`${pet.type}/${pet.skin}`) === -1
+                            ) {
+                                userSkins.push(`${pet.type}/${pet.skin}`)
+                                userUniqueSkins++
+                            }
+                        }
                     %>
                     <p class="stat-raw-values">
                         <% max = uniquePets.length >= Object.keys(constants.pet_data).length ? 'golden-text': '' %><span class="stat-name <%= max %>">Unique Pets: </span><span class="stat-value <%= max %>"><%= uniquePets.length %> / <%= Object.keys(constants.pet_data).length %></span><br>
+                        <% max = userUniqueSkins >= totalUniqueSkins ? 'golden-text': '' %><span class="stat-name <%= max %>">Unique Pet Skins: </span><span class="stat-value <%= max %>"><%= userUniqueSkins %> / <%= totalUniqueSkins %></span><br>
                         <% max = calculated.petScore >= Math.max(...Object.keys(constants.pet_rewards)) ? 'golden-text' : '' %><span data-tippy-content="
                         Increase your pet score by collecting unique pets with a high rarity.<br><br>
                         <table>


### PR DESCRIPTION
PR to add support for pet skins:

![image](https://user-images.githubusercontent.com/2744227/99877136-45ef5d80-2bfc-11eb-8784-79879dc9fd6d.png)
Visible skins in the pets section

![image](https://user-images.githubusercontent.com/2744227/99877156-5b648780-2bfc-11eb-9f92-6f319520bd4a.png)
Added statistics for unique pet skins

![image](https://user-images.githubusercontent.com/2744227/99877168-73d4a200-2bfc-11eb-93c7-b21c68cab972.png)
Added skin name in the first line of the lore (same as in-game)

Full preview: https://i.imgur.com/6RtFpRu.png
Current SkyCrypt: https://i.imgur.com/aCLTCwX.png

I would just note that unfortunately I do not own all the skins so I am unable to test:
 - ~~Pink Sheep~~ tested, works
 - ~~Smiling Rock~~ tested, works
 - ~~Derpy Rock~~ tested, works
 - ~~Embarrassed Rock~~ tested, works
 - ~~"golden-text" counter for "Unique Pet Skins"~~ tested, works

But everything should work fine (unless there's some name mismatching between the skin item and the pet skin id).


Hopefully this time I made the PR correctly 🤞 