### PR TITLE
Add margin between enderchest pages

### DIFF
--- a/includes/resources.ejs
+++ b/includes/resources.ejs
@@ -11,7 +11,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/resources/img/app-icons/square-180.png">
     <link rel="apple-touch-icon" sizes="512x512" href="/resources/img/app-icons/square-512.png">
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Montserrat:400,500,600,700&display=swap"></noscript>
-    <link rel="stylesheet" href="/resources/css/index.css?v137">
+    <link rel="stylesheet" href="/resources/css/index.css?v138">
     <noscript><link rel="stylesheet" href="/resources/css/inventory.css?v13"></noscript>
 
     <script>

--- a/public/resources/css/index.css
+++ b/public/resources/css/index.css
@@ -3892,3 +3892,27 @@ body {
         background-color: rgb(20,20,20);
     }
 }
+
+/* Adding some extra margin between enderchest pages */
+.inventory-view[data-inventory-type=enderchest] .inventory-slot:nth-of-type(45n-8),
+.inventory-view[data-inventory-type=enderchest] .inventory-slot:nth-of-type(45n-7),
+.inventory-view[data-inventory-type=enderchest] .inventory-slot:nth-of-type(45n-6),
+.inventory-view[data-inventory-type=enderchest] .inventory-slot:nth-of-type(45n-5),
+.inventory-view[data-inventory-type=enderchest] .inventory-slot:nth-of-type(45n-4),
+.inventory-view[data-inventory-type=enderchest] .inventory-slot:nth-of-type(45n-3),
+.inventory-view[data-inventory-type=enderchest] .inventory-slot:nth-of-type(45n-2),
+.inventory-view[data-inventory-type=enderchest] .inventory-slot:nth-of-type(45n-1),
+.inventory-view[data-inventory-type=enderchest] .inventory-slot:nth-of-type(45n) {
+    margin-bottom: 1rem;
+}
+.inventory-view[data-inventory-type=enderchest] .inventory-slot:nth-last-of-type(1),
+.inventory-view[data-inventory-type=enderchest] .inventory-slot:nth-last-of-type(2),
+.inventory-view[data-inventory-type=enderchest] .inventory-slot:nth-last-of-type(3),
+.inventory-view[data-inventory-type=enderchest] .inventory-slot:nth-last-of-type(4),
+.inventory-view[data-inventory-type=enderchest] .inventory-slot:nth-last-of-type(5),
+.inventory-view[data-inventory-type=enderchest] .inventory-slot:nth-last-of-type(6),
+.inventory-view[data-inventory-type=enderchest] .inventory-slot:nth-last-of-type(7),
+.inventory-view[data-inventory-type=enderchest] .inventory-slot:nth-last-of-type(8),
+.inventory-view[data-inventory-type=enderchest] .inventory-slot:nth-last-of-type(9) {
+    margin-bottom: 1px;
+}


### PR DESCRIPTION
Small css change to add 1rem margin between enderchest pages to improve readability.

Here's the result:

![image](https://user-images.githubusercontent.com/2744227/100011157-9c61c500-2dd1-11eb-95ee-f7082354b50b.png)

![image](https://user-images.githubusercontent.com/2744227/100011193-ad123b00-2dd1-11eb-837e-f04d5e4c6075.png)
