### PR TITLE
Added Titanic Accessory Bag upgrade size

### DIFF
--- a/src/constants/misc.js
+++ b/src/constants/misc.js
@@ -265,6 +265,10 @@ module.exports = {
                 {
                     tier: 14,
                     slots: 45
+                },
+                {
+                    tier: 15,
+                    slots: 51
                 }
             ]
         },


### PR DESCRIPTION
New titanic accessory bag upgrade (45 -> 51 slots)