### PR TITLE
Pets minor fixes (sheep stats, ability damage suffix)

### DIFF
--- a/src/constants/petStats.js
+++ b/src/constants/petStats.js
@@ -9,11 +9,11 @@ function floor(num, decimals) {
 	return Math.floor(Math.pow(10, decimals) * num) / Math.pow(10, decimals);
 }
 
-function formatStat(stat, ability_damage = false) {
+function formatStat(stat) {
 	let statFloored = Math.floor(stat);
 	if (statFloored > 0)
 		return `§a+${statFloored}`;
-	else 
+	else
 		return `§a${statFloored}`;
 }
 
@@ -83,7 +83,7 @@ class Pet {
 					list.push(`§7True Defense: ${formatStat(newStats[stat])}`);
 					break;
 				case "ability_damage":
-					list.push(`§7Ability Damage: ${formatStat(newStats[stat], true)}`);
+					list.push(`§7Ability Damage: ${formatStat(newStats[stat])}%`);
 					break;
 				case "damage":
 					list.push(`§7Damage: ${formatStat(newStats[stat])}`);
@@ -361,7 +361,7 @@ class Bat extends Pet {
 			intelligence: this.level * 1,
 			speed: this.level * 0.05
 		};
-        if (this.rarity > 4) 
+        if (this.rarity > 4)
             stats.sea_creature_chance = this.level * 0.05;
 		return stats;
 	}
@@ -2311,7 +2311,7 @@ class Parrot extends Pet {
 class Sheep extends Pet {
 	get stats() {
 		return {
-			ability_damage: this.level * 0.5,
+			ability_damage: this.level * 0.2,
 			intelligence: this.level * 1
 		};
 	}

--- a/src/constants/petStats.js
+++ b/src/constants/petStats.js
@@ -2454,9 +2454,9 @@ module.exports = {
 		'Ghoul': Ghoul,
 		'Golem': Golem,
 		'Griffin': Griffin,
-		'Guardian': Guardian,
 		'Horse': Horse,
 		'Hound': Hound,
+		'Jerry': Jerry,
 		'Magma Cube': MagmaCube,
 		'Phoenix': Phoenix,
 		'Pigman': Pigman,
@@ -2485,9 +2485,10 @@ module.exports = {
 		//Alchemy
 		'Jellyfish': Jellyfish,
 		'Parrot': Parrot,
-		'Sheep': Sheep,
+        'Sheep': Sheep,
+        //Enchanting
+		'Guardian': Guardian,
 		//Other
-		'Jerry': Jerry,
-		'???': QuestionMark
+		'???': QuestionMark,
 	}
 }


### PR DESCRIPTION
PR mainly to fix sheep pet stats (from 50 ability damage to 20%)

In game:
![image](https://user-images.githubusercontent.com/2744227/101295661-3dfc0400-381f-11eb-9033-de69451400a4.png)

SkyCrypt:
![image](https://user-images.githubusercontent.com/2744227/101295671-566c1e80-381f-11eb-86c2-e73e9aa69627.png)

PR:
![image](https://user-images.githubusercontent.com/2744227/101295672-5bc96900-381f-11eb-824e-ab02c949d4e1.png)

I removed the ability_damage param from formatStat() since it wasn't used

Also sorted the pet stats export to match the correct pet types (jerry -> combat, guardian -> enchanting)... nothing important but I saw that and so... 🤷‍♂️ 