### PR TITLE
NameMC link in profile

### DIFF
--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1122,6 +1122,7 @@ twitterDescription += '. Click to view more stats!'
                 <a href="https://plancke.io/hypixel/player/stats/<%= calculated.display_name %>" target="_blank" rel="nofollow" class="additional-player-stat external-link">Plancke</a>
                 <a href="https://skyblock.matdoes.dev/profile/<%= calculated.display_name %>/<%= calculated.profile.cute_name == 'Deleted' ? calculated.profile.profile_id : calculated.profile.cute_name %>" target="_blank" rel="nofollow" class="additional-player-stat external-link">matdoes.dev</a>
                 <a href="https://auctions.craftlink.xyz/players/<%= calculated.uuid %>" target="_blank" rel="nofollow" class="additional-player-stat external-link">HyAuctions</a>
+                <a href="https://namemc.com/profile/<%= calculated.uuid %>" target="_blank" rel="nofollow" class="additional-player-stat external-link">NameMC</a>
                 <div id="additional_socials">
                     <div data-copy-text="<%= calculated.uuid %>" class="copy-text additional-player-stat">Copy UUID</div>
                     <% if('DISCORD' in calculated.social){ %><div data-copy-text="<%= calculated.social.DISCORD %>" class="additional-player-stat copy-text external-discord external-icon"><%= calculated.social.DISCORD %></div><% } %>
@@ -2430,12 +2431,12 @@ twitterDescription += '. Click to view more stats!'
                                         };
                                         break;
                                     }
-                                } 
+                                }
 
                                 tooltip += `<span class="stat-name">Rarity: </span><span class="stat-value piece-${ progress.rarity }-fg">${ helper.capitalizeFirstLetter(progress.rarity) }</span><br><span class="stat-name">Progress: </span>`;
                                 if(progress.maxed)
                                     tooltip += `<span class="stat-value golden-text">Maxed!</span>`;
-                                else 
+                                else
                                     tooltip += `<span class="stat-value">${ progress.percentage.toLocaleString() }%</span>`;
                                 %>
                             <span <%- tooltip ? `data-tippy-content='${tooltip}'` : "" %>>
@@ -2517,9 +2518,9 @@ twitterDescription += '. Click to view more stats!'
         let items = JSON.parse(`<%- JSON.stringify(items).replace(/\\/g, '\\\\') %>`);
         let calculated = JSON.parse(`<%- JSON.stringify(calculated).replace(/\\/g, '\\\\') %>`);
         <%
-            const clientConstants = { 
-                minecraft_formatting: constants.minecraft_formatting, 
-                special_enchants: constants.special_enchants 
+            const clientConstants = {
+                minecraft_formatting: constants.minecraft_formatting,
+                special_enchants: constants.special_enchants
             }
         %>
         const constants = JSON.parse(`<%- JSON.stringify(clientConstants).replace(/\\/g, '\\\\') %>`);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2744227/101770569-e690b900-3ae8-11eb-9928-4d84061b8c47.png)

![image](https://user-images.githubusercontent.com/2744227/101770584-ebee0380-3ae8-11eb-8326-0f8aa15dc167.png)

I added it visible by default, I don't know if it should be hidden (and visible after clicking the ">" arrow)... I feel like there's a lot of links now; maybe we should hide some based on how often they are used? (do you have stats about this?)