### PR TITLE
Average skill level to 2 decimals to fix rounding issue

### DIFF
--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1278,7 +1278,7 @@ twitterDescription += '. Click to view more stats!'
                     <div class='tippy-explanation'>Average skill level over all skills except Carpentry and Runecrafting<% if('runecrafting' in calculated.levels){ %>, includes progress to next level<% } %>.</div>
                     <% if('runecrafting' in calculated.levels){ %><span class='stat-name'>Average Level without progress: </span><span class='stat-value'><%= calculated.average_level_no_progress.toFixed(2) %></span>
                     <div class='tippy-explanation'>Average skill level without including partial level progress.</div><% } %>
-                    "><span class="stat-name">Average Skill Level: </span><span class="stat-value"><%= Math.floor(calculated.average_level * 10) / 10 %></span></span></div>
+                    "><span class="stat-name">Average Skill Level: </span><span class="stat-value"><%= calculated.average_level.toFixed(2) %></span></span></div>
                     <div class="additional-stat">
                         <span class="stat-name">Fairy Souls: </span><span class="stat-value"><%= calculated.fairy_souls.collected %> / <%= calculated.fairy_souls.total %></span>
                     </div>
@@ -2430,12 +2430,12 @@ twitterDescription += '. Click to view more stats!'
                                         };
                                         break;
                                     }
-                                } 
+                                }
 
                                 tooltip += `<span class="stat-name">Rarity: </span><span class="stat-value piece-${ progress.rarity }-fg">${ helper.capitalizeFirstLetter(progress.rarity) }</span><br><span class="stat-name">Progress: </span>`;
                                 if(progress.maxed)
                                     tooltip += `<span class="stat-value golden-text">Maxed!</span>`;
-                                else 
+                                else
                                     tooltip += `<span class="stat-value">${ progress.percentage.toLocaleString() }%</span>`;
                                 %>
                             <span <%- tooltip ? `data-tippy-content='${tooltip}'` : "" %>>
@@ -2517,9 +2517,9 @@ twitterDescription += '. Click to view more stats!'
         let items = JSON.parse(`<%- JSON.stringify(items).replace(/\\/g, '\\\\') %>`);
         let calculated = JSON.parse(`<%- JSON.stringify(calculated).replace(/\\/g, '\\\\') %>`);
         <%
-            const clientConstants = { 
-                minecraft_formatting: constants.minecraft_formatting, 
-                special_enchants: constants.special_enchants 
+            const clientConstants = {
+                minecraft_formatting: constants.minecraft_formatting,
+                special_enchants: constants.special_enchants
             }
         %>
         const constants = JSON.parse(`<%- JSON.stringify(clientConstants).replace(/\\/g, '\\\\') %>`);


### PR DESCRIPTION
https://sky.shiiyu.moe/stats/El_Oxo/Grapes

From:
![image](https://user-images.githubusercontent.com/2744227/101900375-a8120180-3baf-11eb-8ba8-a6d6c6823bea.png)

To:
![image](https://user-images.githubusercontent.com/2744227/101900395-b2cc9680-3baf-11eb-84c2-a28a31b2d657.png)

Honestly it's not a big change but I always found it annoying.... but I agree that having 1 more decimals outside might not please everyone so I think you should vote on this one and then decide what style you prefer.