### PR TITLE
Fix missing ferocy stat on a bunch of pets

### DIFF
--- a/src/constants/petStats.js
+++ b/src/constants/petStats.js
@@ -13,7 +13,7 @@ function formatStat(stat, ability_damage = false) {
 	let statFloored = Math.floor(stat);
 	if (statFloored > 0)
 		return `§a+${statFloored}`;
-	else 
+	else
 		return `§a${statFloored}`;
 }
 
@@ -361,7 +361,7 @@ class Bat extends Pet {
 			intelligence: this.level * 1,
 			speed: this.level * 0.05
 		};
-        if (this.rarity > 4) 
+        if (this.rarity > 4)
             stats.sea_creature_chance = this.level * 0.05;
 		return stats;
 	}
@@ -834,7 +834,8 @@ class Ghoul extends Pet {
 	get stats() {
 		return {
 			intelligence: this.level * 0.75,
-			health: this.level * 1
+            health: this.level * 1,
+            ferocity: this.level * 0.05,
 		};
 	}
 
@@ -1057,7 +1058,8 @@ class Hound extends Pet {
 	get stats() {
 		return {
 			strength: this.level * 0.4,
-			bonus_attack_speed: this.level * 0.15
+			bonus_attack_speed: this.level * 0.15,
+            ferocity: this.level * 0.05,
 		};
 	}
 
@@ -1222,7 +1224,8 @@ class Pigman extends Pet {
 	get stats() {
 		return {
 			strength: this.level * 0.5,
-			defense: this.level * 0.5
+            defense: this.level * 0.5,
+            ferocity: this.level * 0.05,
 		};
 	}
 
@@ -1851,7 +1854,8 @@ class Monkey extends Pet {
 class Ocelot extends Pet {
 	get stats() {
 		return {
-			speed: this.level * 0.5
+            speed: this.level * 0.5,
+            ferocity: this.level * 0.1,
 		};
 	}
 
@@ -2115,7 +2119,8 @@ class Megalodon extends Pet {
 	get stats() {
 		return {
 			strength: this.level * 0.5,
-			magic_find: this.level * 0.1
+            magic_find: this.level * 0.1,
+            ferocity: this.level * 0.05,
 		};
 	}
 


### PR DESCRIPTION
Bug report:
![image](https://user-images.githubusercontent.com/2744227/101901236-0986a000-3bb1-11eb-9bb4-d8d3d046dc5b.png)

Checked the pets in game and fixed the missing ferocity (if you need screenshot as proof of every pet let me know).