### PR TITLE
Fix navbar overflow

### DIFF
--- a/includes/resources.ejs
+++ b/includes/resources.ejs
@@ -10,7 +10,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/resources/img/app-icons/square-180.png">
     <link rel="apple-touch-icon" sizes="512x512" href="/resources/img/app-icons/square-512.png">
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Montserrat:400,500,600,700&display=swap"></noscript>
-    <link rel="stylesheet" href="/resources/css/index.css?v144">
+    <link rel="stylesheet" href="/resources/css/index.css?v145">
     <noscript><link rel="stylesheet" href="/resources/css/inventory.css?v13"></noscript>
 
     <script>
@@ -94,9 +94,9 @@
                 switch (color) {
                     case 'icon':
                     case 'line':
-                    case 'link': 
+                    case 'link':
                         element.style.setProperty(`--${color}-rgb`, convertHex(value));
-                    default: 
+                    default:
                         element.style.setProperty(`--${color}-hex`, value);
                 }
             }
@@ -104,10 +104,10 @@
             const resource_link = "/resources/";
 
             let bgs = theme.backgrounds;
-            for (bg in bgs) 
-                for (img in bgs[bg]) 
+            for (bg in bgs)
+                for (img in bgs[bg])
                     element.style.setProperty(`--${bg}-${img}`, `url(${bgs[bg][img].replace("../", resource_link)})`);
-            
+
             if (theme.logo) {
                 const logoURL = theme.logo.replace("../", resource_link)
                 element.style.setProperty('--logo-square', `url(${logoURL})`);
@@ -126,7 +126,7 @@
         /**
          * checks if the scrollbar has a width and sets the style-scrollbar class accordingly
          */
-        function checkScrollbarStyle() {   
+        function checkScrollbarStyle() {
             outerDiv = document.createElement("div");
             outerDiv.style.position = 'fixed';
             innerDiv = document.createElement("div");

--- a/public/resources/css/index.css
+++ b/public/resources/css/index.css
@@ -1,12 +1,12 @@
 :root{
     /* Icon Green (used for Skill Icons, Underlines etc.) */
-    --icon-hex: #0BCA51; --icon-rgb: 11, 202, 81; 
+    --icon-hex: #0BCA51; --icon-rgb: 11, 202, 81;
 
     /* Line Green (used for Navigation Bar) */
     --line-hex: #0BDA51; --line-rgb: 11, 218, 81;
 
     /* Link Green (used for Links, Unclaimed Slayers, Crafted Minions etc.) */
-    --link-hex: #0BEA51; --link-rgb: 11, 234, 81; 
+    --link-hex: #0BEA51; --link-rgb: 11, 234, 81;
 
     /* Hover Green (used only for link hovers) */
     --hover-hex: #09EF70;
@@ -18,7 +18,7 @@
     --maxedbar-hex: #CE8F12;
 
     /* Maxed Gold (used for Maxed things etc.) */
-    --maxed-hex: #DD980E; 
+    --maxed-hex: #DD980E;
 
     /* Golden Text (used for Golden Text) */
     --gold-hex: #FDBB3C;
@@ -27,7 +27,7 @@
     --logo-square: url(/resources/img/logo_square.svg);
 
     /* Normal Backgrounds */
-    --bg-png: url(/resources/img/bg.png?v3); 
+    --bg-png: url(/resources/img/bg.png?v3);
     --bg-webp: url(/resources/img/bg.webp?v3);
 
     /* Blurred Backgrounds */
@@ -187,7 +187,7 @@ header > *{
     vertical-align: top;
     border-radius: 3px;
     height: 20px;
-    width: 32px;    
+    width: 32px;
     flex-shrink: 0;
     cursor: pointer;
     user-select: none;
@@ -1387,7 +1387,7 @@ a.additional-player-stat:hover{
     user-select: none !important;
 }
 
-.additional-player-stat.svg-icon {    
+.additional-player-stat.svg-icon {
     display: inline-grid;
     place-items: center;
 }
@@ -1439,7 +1439,7 @@ a.additional-player-stat:hover{
 
 #basic_stats{
     display: inline-grid;
-    grid-template-areas: 
+    grid-template-areas:
         "base skill"
         "base additional";
     grid-template-columns: 260px auto;
@@ -1506,6 +1506,7 @@ a.additional-player-stat:hover{
     width: 100%;
     padding-bottom: 6px;
     z-index: 3;
+    overflow-x: scroll;
 }
 
 #nav_bar.stuck #nav_bar_background{
@@ -3301,7 +3302,7 @@ body {
     }
 
     #basic_stats {
-        grid-template-areas: 
+        grid-template-areas:
             "skin base skill"
             "skin base additional";
         grid-template-columns: 150px 260px auto;
@@ -3419,7 +3420,7 @@ body {
     }
 
     #basic_stats {
-        grid-template-areas: 
+        grid-template-areas:
             "skin base"
             "skin additional"
             ". ."
@@ -3574,12 +3575,6 @@ body {
     }
 }
 
-@media (max-width: 900px){
-    #nav_items_container{
-        overflow-x: scroll;
-    }
-}
-
 @media (max-width: 800px){
 
     .slayer-drop .stat-name{
@@ -3601,7 +3596,7 @@ body {
         overflow-x: auto;
         margin-left: -30px;
         margin-right: -30px;
-    }    
+    }
 
     .collections > :first-child,
     .minions > :first-child,
@@ -3672,7 +3667,7 @@ body {
         padding-left: 26px;
         padding-right: 0;
     }
-    
+
     .social-button.patreon span {
         display: none;
     }
@@ -3806,7 +3801,7 @@ body {
     .race-containers,
     .floor-containers {
         scroll-snap-type: x proximity;
-    }    
+    }
 
     .slayer-containers > *,
     .race-containers > *,
@@ -3904,11 +3899,11 @@ body {
     .floor-containers {
         scroll-snap-type: x mandatory;
     }
-    
+
     .slayer-containers > *,
     .race-containers > * {
         scroll-snap-stop: always;
-    } 
+    }
 }
 
 @media (max-width: 400px){


### PR DESCRIPTION
Fix for navbar overflow reported by minhperry.
He's using a vietnamese browser that causes this issue **_but_** I noticed this issue also in chrome at smaller resolutions (see screenshots below)

The fix simply makes the navbar always scrollable horizontally if it needs more horizontal space.

Bumped css version from 144 to 145
VSCode automatically fixed random spaces after some css properties

Actual css fix is at lines:
L3577-L3582: removed the old media query
L1509: permanent `overflow-x: scroll`

![image](https://user-images.githubusercontent.com/2744227/104109147-31117b00-52cb-11eb-89e8-b8553d60e1a6.png)
![image](https://user-images.githubusercontent.com/2744227/104109161-6f0e9f00-52cb-11eb-8c66-2d6ec6a90def.png)

PS: Please do something about code formatting, it's a pain seeing random formatting, code indentation and spaces everywhere ;-;