### PR TITLE
Jerry pet damage fix when mythic

### DIFF
--- a/src/constants/petStats.js
+++ b/src/constants/petStats.js
@@ -2391,10 +2391,10 @@ class Jerry extends Pet {
 	}
 
 	get third() {
-		let mult = 0.1;
+		let mult = this.level > 4 ? 0.5 : 0.1;
 		return {
 			name: "§6Jerry",
-			desc: [`§7Actually adds ${Math.floor(this.level * mult)} damage to the Aspect of the Jerry`]
+			desc: [`§7Actually adds §c${Math.floor(this.level * mult)} damage §7to the Aspect of the Jerry`]
 		};
 	}
 


### PR DESCRIPTION
In my previous PR I didn't notice that making Jerry mythic also changes his 3rd perk multiplier:

![image](https://user-images.githubusercontent.com/2744227/104248507-ea0dbc00-5469-11eb-846e-b488ac4ec713.png)
![image](https://user-images.githubusercontent.com/2744227/104248521-f1cd6080-5469-11eb-9a99-e4b52d765695.png)
