### PR TITLE
renderLore() fix in case the string doesn't start with a formatting §

### DIFF
--- a/includes/footer.ejs
+++ b/includes/footer.ejs
@@ -156,7 +156,7 @@
     });
 </script>
 <% if(page == 'stats'){ %>
-    <script src="/resources/js/stats.js?v71"></script>
+    <script src="/resources/js/stats.js?v72"></script>
 <% } %>
 
 <% if(page == 'api'){ %>

--- a/public/resources/js/stats.js
+++ b/public/resources/js/stats.js
@@ -145,6 +145,10 @@ document.addEventListener('DOMContentLoaded', function(){
         let output = "";
         let spansOpened = 0;
 
+        if (!text.startsWith("§")) {
+            text = `§7${text}`
+        }
+
         const parts = text.split("§");
 
         if(parts.length == 1)

--- a/src/helper.js
+++ b/src/helper.js
@@ -100,9 +100,9 @@ module.exports = {
                     user = doc;
         }
 
-        let skin_data = { 
-            skinurl: 'https://textures.minecraft.net/texture/3b60a1f6d562f52aaebbf1434f1de147933a3affe0e764fa49ea057536623cd3', 
-            model: 'slim' 
+        let skin_data = {
+            skinurl: 'https://textures.minecraft.net/texture/3b60a1f6d562f52aaebbf1434f1de147933a3affe0e764fa49ea057536623cd3',
+            model: 'slim'
         };
 
         if(user && module.exports.hasPath(user, 'skinurl')){
@@ -342,6 +342,10 @@ module.exports = {
     renderLore: (text, enchants = false) => {
         let output = "";
         let spansOpened = 0;
+
+        if (!text.startsWith("§")) {
+            text = `§7${text}`
+        }
 
         const parts = text.split("§");
 
@@ -592,7 +596,7 @@ module.exports = {
             };
 
             for(item in claimable)
-                if(module.exports.hasPath(player, item)) 
+                if(module.exports.hasPath(player, item))
                     rank.claimed_items[claimable[item]] = player[item];
         }catch(e){
             console.error(e);

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1131,7 +1131,7 @@ if(calculated.profile.game_mode == 'ironman'){
                 <% if(calculated.guild){ %><button class="additional-player-stat interactive-tooltip" data-tippy-content="
                 <% if(calculated.guild.rank){ %><span class='stat-name'>Rank: </span><span class='stat-value'><%= calculated.guild.rank %></span><br><br><% } %>
                 <span class='stat-name'>Guild Master: </span><a href='/stats/<%= calculated.guild.gm %>' class='no-underline stat-value'><%= calculated.guild.gmUser.display_name %></a><br>
-                <% if(calculated.guild.tag){ %><span class='stat-name'>Tag: </span><span class='stat-value'><%- helper.renderLore(calculated.guild.tag) %></span><br><% } %>
+                <% if(calculated.guild.tag){ %><span class='stat-name'>Tag: </span><span class='stat-value'><%- helper.renderLore('§f'+calculated.guild.tag) %></span><br><% } %>
                 <% if(calculated.guild.members){ %><span class='stat-name'>Members: </span><span class='stat-value'><%= calculated.guild.members %></span><br><% } %>
                 <% if(calculated.guild.level){ %><span class='stat-name'>Level: </span><span class='stat-value'><%= calculated.guild.level %></span><br><% } %>
                 ">Guild: <%= calculated.guild.name %></button><% } %>
@@ -2151,7 +2151,7 @@ if(calculated.profile.game_mode == 'ironman'){
                         <% }else{ %>
                             <span class="category-header-detail">(<%= maxOfType %> / <%= totalOfType %> max)</span>
                         <% } %>
-                    </div>                        
+                    </div>
                     <div class="minions">
                         <% for(const minion of minions){ %>
                             <div data-tippy-content="Crafted variants:<br><br>
@@ -2166,7 +2166,7 @@ if(calculated.profile.game_mode == 'ironman'){
                                 <div class="minion-icon" style="background-image: url(<%= minion.head %>)"></div>
                                 <span class="stat-name"><%= minion.name %> </span><span class="stat-value"><%= minion.maxLevel %></span>
                             </div>
-                        <% } %>                        
+                        <% } %>
                     </div>
                     <%
                 } %>
@@ -2537,8 +2537,8 @@ if(calculated.profile.game_mode == 'ironman'){
         let items = JSON.parse(`<%- JSON.stringify(items).replace(/\\/g, '\\\\') %>`);
         let calculated = JSON.parse(`<%- JSON.stringify(calculated).replace(/\\/g, '\\\\') %>`);
         <%
-            const clientConstants = { 
-                minecraft_formatting: constants.minecraft_formatting, 
+            const clientConstants = {
+                minecraft_formatting: constants.minecraft_formatting,
                 special_enchants: constants.special_enchants,
                 max_favorites: constants.max_favorites
             }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2744227/104363999-46c6b080-5516-11eb-9f04-b3b6e4570728.png)

This was caused by the fact that, in petStats, the Lion class per description doesn't start with a formatting § character.

the renderLore() then splits the text by § and gets the first character to transform into a color, if the color is undefined it skips the part:
```js
for(const part of parts){
            const code = part.substring(0, 1);
            const content = part.substring(1);

            const format = constants.minecraft_formatting[code];

            if(format === undefined)
                continue;
```

The fix simply adds a default gray color at the beginning `§7`

renderLore() was defined in 2 files: stats.js and helper.js, changed how it works in both.

The function seems to be used only to render petLore (now works), item lore (that should always start with a § anyway, so nothing changed here), and guild tag. For the guild tag case I forced the color to be white (as it looks now on the website online)

Note: I will be fixing the pets description so that they always start with §, but I think this function bug should be fixed anyway