### PR TITLE
Golden monkey skin + keep the unique pet skins counter correct until new skin release

### DIFF
--- a/src/constants/pets.js
+++ b/src/constants/pets.js
@@ -388,140 +388,169 @@ module.exports = {
             "ENDERMAN": {
                 name: "Spooky",
                 head: "/head/ea84cc8818c293484fdaafc8fa2f0bf39e55733a247d68023df2c6c6b9b671d0",
+                release: 1560284720000,
             },
         },
         "GUARDIAN": {
             "GUARDIAN": {
                 name: "Watcher",
                 head: "/head/37cc76e7af29f5f3fbfd6ece794160811eff96f753459fa61d7ad176a064e3c5",
+                release: 1560284720000,
             },
         },
         "TIGER": {
             "TIGER_TWILIGHT": {
                 name: "Twilight",
                 head: "/head/896211dc599368dbd9056c0116ab61063991db793be93066a858eb4e9ce56438",
+                release: 1560284720000,
             },
         },
         "RABBIT": {
             "RABBIT": {
                 name: "Pretty",
                 head: "/head/a34631d940fddb689ddef6a3b352c50220c460dba05cd18dc83192b59dc647f8",
+                release: 1560284720000,
             },
         },
         "WITHER_SKELETON": {
             "WITHER": {
                 name: "Dark",
                 head: "/head/224c2d14a0219af5ccfcaa36e8a333e271724ed61276611f9529e16c10273a0d",
+                release: 1560284720000,
             },
         },
         "ROCK": {
             "ROCK_COOL": {
                 name: "Cool",
                 head: "/head/fefcdbb7d95502acc1ae35a32a40ce4dec8f4c9f0da26c9d9fe7c2c3eb748f6",
+                release: 1560284720000,
             },
             "ROCK_SMILE": {
                 name: "Smile",
                 head: "/head/713c8b2916a275db4c1762cf5f13d7b95b91d60baf5164a447d6efa7704cf11b",
+                release: 1560284720000,
             },
             "ROCK_THINKING": {
                 name: "Thinking",
                 head: "/head/dd2f781f03c365bbc5dd1e7186ab38dc69465e836c9fe066a9a844f34a4da92",
+                release: 1560284720000,
             },
             "ROCK_LAUGH": {
                 name: "Laughing",
                 head: "/head/8cc1ef513d5f616675242174acde7b9d6259a47c4fe8f6e4b6e20920319d7073",
+                release: 1560284720000,
             },
             "ROCK_DERP": {
                 name: "Derp",
                 head: "/head/c4f89fbd12c209f7f26c1f34a1bd7f47635814759c09688dd212b205c73a8c02",
+                release: 1560284720000,
             },
             "ROCK_EMBARRASSED": {
                 name: "Embarrassed",
                 head: "/head/27ff34992e66599e8529008be3fb577cb0ab545294253e25a0cc988e416c849",
+                release: 1560284720000,
             },
         },
         "SHEEP": {
             "SHEEP_WHITE": {
                 name: "White",
                 head: "/head/b92a1a5c325f25f7438a0abb4f86ba6cf75552d02c7349a7292981459b31d2f7",
+                release: 1560284720000,
             },
             "SHEEP_PURPLE": {
                 name: "Purple",
                 head: "/head/99a88cf7dd33063587c6b540e6130abc5d07f1a65c47573ab3c1ad3ccec8857f",
+                release: 1560284720000,
             },
             "SHEEP_BLACK": {
                 name: "Black",
                 head: "/head/aa9dcda642a807cd2daa4aa6be87cef96e08a8c8f5cec2657dda4266c6a884c2",
+                release: 1560284720000,
             },
             "SHEEP_PINK": {
                 name: "Pink",
                 head: "/head/afa7747684dcb96192d90342cea62742ec363da07cb5e6e25eecec888cd2076",
+                release: 1560284720000,
             },
             "SHEEP_LIGHT_BLUE": {
                 name: "Light Blue",
                 head: "/head/722220de1a863bc5d9b9e7a6a3b03214c9f3d698ed3fe0d28220f3b93b7685c5",
+                release: 1560284720000,
             },
             "SHEEP_LIGHT_GREEN": {
                 name: "Light Green",
                 head: "/head/cf183ec2fe58faa43e568419b7a0dc446ece4ea0be52ec784c94e1d74b75939d",
+                release: 1560284720000,
             },
             "SHEEP_NEON_YELLOW": {
                 name: "Neon Yellow",
                 head: "/head/94263428c23da9165b2639a8f2428ff4835227945c9e1038461cf644d67cc82a",
+                release: 1560284720000,
             },
             "SHEEP_NEON_RED": {
                 name: "Neon Red",
                 head: "/head/4918be142a20b2b39bc582f421f6ae87b3184b5c9523d16fbe6d69530107886a",
+                release: 1560284720000,
             },
             "SHEEP_NEON_BLUE": {
                 name: "Neon Blue",
                 head: "/head/e55b3fe9311c99342ea565483cbf9e969a258faf7afa30270fb9a0929377acfd",
+                release: 1560284720000,
             },
             "SHEEP_NEON_GREEN": {
                 name: "Neon Green",
                 head: "/head/2c14d66911554bd0882339074bf6b8110c2d3509b69e7a6144e4d5a7164bacc8",
+                release: 1560284720000,
             },
         },
         "SILVERFISH": {
             "SILVERFISH": {
                 name: "Fortified",
                 head: "/head/d8552ff591042c4a38f8ba0626784ae28c4545a97d423fd9037c341035593273",
+                release: 1560284720000,
             },
         },
         "ELEPHANT": {
             "ELEPHANT_PINK": {
                 name: "Pink",
                 head: "/head/570eef474ec0e56cc34c2307eaa39f024612f8cd7248e7d5b14169ebd307c742",
+                release: 1560284720000,
             },
             "ELEPHANT_BLUE": {
                 name: "Blue",
                 head: "/head/4b62969c005815d0409136380febc5ac468aaba9bda4db80954fa5426ee0a323",
+                release: 1560284720000,
             },
             "ELEPHANT_ORANGE": {
                 name: "Orange",
                 head: "/head/554a34a80c474206d3700b8fced6b44fab0b0ed0b05c1293ff0c5d86eda251d1",
+                release: 1560284720000,
             },
         },
         "JERRY": {
             "JERRY_RED_ELF": {
                 name: "Red Elf",
                 head: "/head/1d82f9c36e824c1e37963a849bf5abd76d3b349125023504af58369086089ee9",
+                release: 1560284720000,
             },
             "JERRY_GREEN_ELF": {
                 name: "Green Elf",
                 head: "/head/4ec5455f43426ca1874b5c7b4a492ec3722a502f8b9599e758e133fed8b3c1e4",
+                release: 1560284720000,
             },
         },
         "BABY_YETI": {
             "YETI_GROWN_UP": {
                 name: "Grown-up",
                 head: "/head/f5f29a975529276d916fc67998833c11ee178ff21e5941afdfb0fa7010f8374e",
+                release: 1560284720000,
             },
         },
         "MONKEY": {
             "MONKEY_GOLDEN": {
                 name: "Golden",
                 head: "/head/e9281c4d87d68526b0749d4361e6ef786c8a35717aa053da704b1d53410d37a6",
+                release: 1610557200000,
             },
         },
     },

--- a/src/constants/pets.js
+++ b/src/constants/pets.js
@@ -518,6 +518,12 @@ module.exports = {
                 head: "/head/f5f29a975529276d916fc67998833c11ee178ff21e5941afdfb0fa7010f8374e",
             },
         },
+        "MONKEY": {
+            "MONKEY_GOLDEN": {
+                name: "Golden",
+                head: "/head/e9281c4d87d68526b0749d4361e6ef786c8a35717aa053da704b1d53410d37a6",
+            },
+        },
     },
 
     pet_value: {

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1555,8 +1555,11 @@ if(calculated.profile.game_mode == 'ironman'){
                             totalPetXp += pet.exp;
 
                         let totalUniqueSkins = 0
+                        const currentTime = new Date().getTime()
                         for(const skins of Object.values(constants.pet_skins)) {
-                            totalUniqueSkins += Object.keys(skins).length
+                            totalUniqueSkins += Object.values(skins).filter(
+                                s => s.release < currentTime
+                            ).length
                         }
 
                         let userUniqueSkins = 0
@@ -2151,7 +2154,7 @@ if(calculated.profile.game_mode == 'ironman'){
                         <% }else{ %>
                             <span class="category-header-detail">(<%= maxOfType %> / <%= totalOfType %> max)</span>
                         <% } %>
-                    </div>                        
+                    </div>
                     <div class="minions">
                         <% for(const minion of minions){ %>
                             <div data-tippy-content="Crafted variants:<br><br>
@@ -2166,7 +2169,7 @@ if(calculated.profile.game_mode == 'ironman'){
                                 <div class="minion-icon" style="background-image: url(<%= minion.head %>)"></div>
                                 <span class="stat-name"><%= minion.name %> </span><span class="stat-value"><%= minion.maxLevel %></span>
                             </div>
-                        <% } %>                        
+                        <% } %>
                     </div>
                     <%
                 } %>
@@ -2537,8 +2540,8 @@ if(calculated.profile.game_mode == 'ironman'){
         let items = JSON.parse(`<%- JSON.stringify(items).replace(/\\/g, '\\\\') %>`);
         let calculated = JSON.parse(`<%- JSON.stringify(calculated).replace(/\\/g, '\\\\') %>`);
         <%
-            const clientConstants = { 
-                minecraft_formatting: constants.minecraft_formatting, 
+            const clientConstants = {
+                minecraft_formatting: constants.minecraft_formatting,
                 special_enchants: constants.special_enchants,
                 max_favorites: constants.max_favorites
             }


### PR DESCRIPTION
Support for new Golen Monkey skin.

Every pet_skin now has a release property (timestamp in milliseconds) which represent when it was first released in skyblock, this will be used to correctly display the "Unique Pet Skins" counter/stat above pets.

Please note than I'm lazy and instead of putting the correct timestamp for every pet I used skyblock release time for all the old pets 😛 