### PR TITLE
Fix: max minions not counted towards max minions in skill sub-category

### DIFF
--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -2154,7 +2154,7 @@ if(calculated.profile.game_mode == 'ironman'){
                     const minions = calculated.minions.filter(a => a.type == type && a.maxLevel > 0).sort((a, b) => b.maxLevel - a.maxLevel);
 
                     const totalOfType = _.size(_.pickBy(constants.minions, a => a.type == type));
-                    const maxOfType = minions.filter(a => a.maxLevel == 11).length;
+                    const maxOfType = minions.filter(a => a.maxLevel == a.tiers).length;
 
                     if(minions.length == 0)
                         continue;


### PR DESCRIPTION
The code for calculating max minions was updated in the overall stat above but not in the skill sub-category

Before:
![image](https://user-images.githubusercontent.com/2744227/105618894-00623300-5ded-11eb-9776-016befb74538.png)

After:
![image](https://user-images.githubusercontent.com/2744227/105618899-0bb55e80-5ded-11eb-923c-246af353ad33.png)
