### PR TITLE
fix slayer bar styling

### DIFF
--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -632,29 +632,30 @@ header > * {
             bottom: 0;
             background-color: var(--skillbar-hex);
         }
-        .skill-progress-bar {
-            position: absolute;
-            top: 0;
-            left: 0;
-            bottom: 0;
-            background-color: var(--skillbar-hex);
-            border-top-right-radius: 7px;
-            border-bottom-right-radius: 7px;
-        }
-
-        .skill-progress-text {
-            position: absolute;
-            left: 0;
-            top: 0;
-            bottom: 0;
-            right: 0;
-            text-align: center;
-            font-weight: 600;
-            font-size: 12px;
-            line-height: 14px;
-            text-shadow: 0px 0px 3px rgba(0, 0, 0, 0.5);
-        }
     }
+}
+
+.skill-progress-bar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    background-color: var(--skillbar-hex);
+    border-top-right-radius: 7px;
+    border-bottom-right-radius: 7px;
+}
+
+.skill-progress-text {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    text-align: center;
+    font-weight: 600;
+    font-size: 12px;
+    line-height: 14px;
+    text-shadow: 0px 0px 3px rgba(0, 0, 0, 0.5);
 }
 
 .slayer-bar.maxed-slayer .skill-progress-bar {


### PR DESCRIPTION
this PR fixes a mistake I made in #250 
# before:
![image](https://user-images.githubusercontent.com/44071655/106400793-ac5bdd80-63ee-11eb-8191-bbbeaa85e0bb.png)
# after:
![image](https://user-images.githubusercontent.com/44071655/106400796-b1b92800-63ee-11eb-9ff5-37fd3cd73f1a.png)

