### PR TITLE
Fix large backpacks

### DIFF
--- a/includes/footer.ejs
+++ b/includes/footer.ejs
@@ -153,7 +153,7 @@
     });
 </script>
 <% if(page == 'stats'){ %>
-    <script src="/resources/js/stats.js?v73"></script>
+    <script src="/resources/js/stats.js?v74"></script>
 <% } %>
 
 <% if(page == 'api'){ %>

--- a/public/resources/js/stats.js
+++ b/public/resources/js/stats.js
@@ -229,6 +229,8 @@ document.addEventListener('DOMContentLoaded', function(){
         if (type === 'inventory') {
             inventory = inventory.slice(9, 36).concat(inventory.slice(0, 9));
             pagesize = 3 * 9;
+        } else if (type === 'backpack') {
+            pagesize = 6 * 9;
         }
 
         inventory.forEach(function(item, index){

--- a/public/resources/js/stats.js
+++ b/public/resources/js/stats.js
@@ -451,10 +451,6 @@ document.addEventListener('DOMContentLoaded', function(){
                 backpackContents.appendChild(inventorySlot);
 
                 backpackContents.appendChild(document.createTextNode(" "));
-
-                if ((index + 1) % 27 == 0) {
-                    backpackContents.appendChild(document.createElement("hr"));
-                }
             });
 
             [].forEach.call(document.querySelectorAll('.contains-backpack .item-icon.is-enchanted'), handleEnchanted);

--- a/public/resources/js/stats.js
+++ b/public/resources/js/stats.js
@@ -281,7 +281,7 @@ document.addEventListener('DOMContentLoaded', function(){
 
             inventoryView.appendChild(document.createTextNode(" "));
 
-            if ((index + 1) % pagesize == 0) {
+            if ((index + 1) % pagesize == 0 && pagesize !== inventory.length) {
                 inventoryView.appendChild(document.createElement("hr"));
             }
         });

--- a/public/resources/js/stats.js
+++ b/public/resources/js/stats.js
@@ -261,7 +261,7 @@ document.addEventListener('DOMContentLoaded', function(){
 
                 inventoryItem.className = 'rich-item inventory-item';
 
-                if(type == 'backpack')
+                if(type === 'backpack')
                     inventoryItem.setAttribute('data-backpack-item-index', index);
                 else
                     inventoryItem.setAttribute('data-item-index', item.item_index);

--- a/public/resources/js/stats.js
+++ b/public/resources/js/stats.js
@@ -453,7 +453,7 @@ document.addEventListener('DOMContentLoaded', function(){
                 backpackContents.appendChild(document.createTextNode(" "));
 
                 if ((index + 1) % 27 == 0) {
-                    inventoryView.appendChild(document.createElement("hr"));
+                    backpackContents.appendChild(document.createElement("hr"));
                 }
             });
 


### PR DESCRIPTION
this PR fixes a bug reported by @sav#2222 on discord.

there are three fixes in this PR:
- backpacks with more than 27 slots no longer fail to preview
- backpacks with more than 27 slots are no longer broken up into pages
- there is no longer extra space on some inventories with full pages