### PR TITLE
fix hover on item stack

### DIFF
--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -1802,7 +1802,7 @@ a.additional-player-stat:hover {
     right: 0;
     top: 0;
     bottom: 0;
-    z-index: 10;
+    z-index: 20;
     transition: background-color 0.2s;
     border-radius: 5px;
 }


### PR DESCRIPTION
if you hover over an item it SkyCrypt shows some info but if you accidentally hover over the number of items in the stack (`.item-count`) then the info goes away. This PR fixes that

note: if this PR is merged it will not take effect for most users until something increments the index.css version on resources.ejs line 13 but it also won't hurt anything if the index.css version is not incremented