### PR TITLE
remove optional feilds

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,5 @@ jobs:
     - uses: actions/stale@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'Stale issue message'
-        stale-pr-message: 'Stale pull request message'
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'


### PR DESCRIPTION
according to https://github.com/actions/stale/blob/main/README.md the message feilds are optional and removing them would alow us to use the default rather than the current unhelpfull message