### PR TITLE
fix iOS background

### DIFF
--- a/includes/footer.ejs
+++ b/includes/footer.ejs
@@ -157,5 +157,5 @@
 <% } %>
 
 <% if(page == 'api'){ %>
-    <link rel="stylesheet" href="/resources/css/api.css?v0">
+    <link rel="stylesheet" href="/resources/css/api.css?v9">
 <% } %>

--- a/includes/resources.ejs
+++ b/includes/resources.ejs
@@ -10,7 +10,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/resources/img/app-icons/square-180.png">
     <link rel="apple-touch-icon" sizes="512x512" href="/resources/img/app-icons/square-512.png">
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Montserrat:400,500,600,700&display=swap"></noscript>
-    <link rel="stylesheet" href="/resources/css/index.css?v149">
+    <link rel="stylesheet" href="/resources/css/index.css?v150">
     <noscript><link rel="stylesheet" href="/resources/css/inventory.css?v13"></noscript>
 
     <script>

--- a/public/resources/scss/api.scss
+++ b/public/resources/scss/api.scss
@@ -10,6 +10,10 @@ html {
     font-family: "Montserrat", sans-serif;
     color: white;
     overflow-x: hidden;
+
+    &::before {
+        content: none;
+    }
 }
 
 @media (max-width: 480px) {

--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -51,6 +51,20 @@ html {
     font-family: "Montserrat", sans-serif;
     color: white;
     overflow-x: hidden;
+
+    @supports (-webkit-touch-callout: none) {
+        background-image: none;
+        &:before {
+            content: "";
+            position: fixed;
+            top: 0;
+            bottom: 0;
+            right: 0;
+            left: 0;
+            background: var(--bg-webp) no-repeat center center;
+            background-size: cover;
+        }
+    }
 }
 
 body {


### PR DESCRIPTION
on iOS, the background is zoomed in and scrolls with the page. this is because iOS doesn't support `background-attachment: fixed;` to work around this I have added an alternative way of getting a fixed background for iOS devices.

# screenshots
## before:
![IMG_0159](https://user-images.githubusercontent.com/44071655/107845578-78979500-6daa-11eb-887f-535d8ed38c34.PNG)
## after:
![IMG_0160](https://user-images.githubusercontent.com/44071655/107845569-72091d80-6daa-11eb-8bfd-33df2524fa6e.PNG)