### PR TITLE
Better flash

### DIFF
--- a/public/resources/js/stats.js
+++ b/public/resources/js/stats.js
@@ -625,13 +625,13 @@ document.addEventListener('DOMContentLoaded', function(){
                 if(stat == 'sea_creature_chance')
                     continue;
 
-                let element = document.querySelector('.basic-stat[data-stat=' + stat + '] .stat-value');
+                const element = document.querySelector('.basic-stat[data-stat=' + stat + '] .stat-value');
 
                 if(!element)
                     continue;
 
-                let currentValue = parseInt(element.innerHTML);
-                let newValue = stats[stat];
+                const currentValue = parseInt(element.innerHTML);
+                const newValue = stats[stat];
 
                 if(newValue != currentValue){
                     anime({
@@ -702,13 +702,13 @@ document.addEventListener('DOMContentLoaded', function(){
                 easing: 'easeOutCubic'
             });
 
-            let _element = document.querySelector('.basic-stat[data-stat=sea_creature_chance] .stat-value');
+            const _element = document.querySelector('.basic-stat[data-stat=sea_creature_chance] .stat-value');
 
             if(!_element)
                 return;
 
-            let currentValue = parseInt(_element.innerHTML);
-            let newValue = stats['sea_creature_chance'];
+            const currentValue = parseInt(_element.innerHTML);
+            const newValue = stats['sea_creature_chance'];
 
             if(newValue != currentValue){
                 anime({

--- a/public/resources/js/stats.js
+++ b/public/resources/js/stats.js
@@ -590,14 +590,16 @@ document.addEventListener('DOMContentLoaded', function(){
             e.preventDefault();
         });
 
+        const activeWeaponElement = document.querySelector('.stat-active-weapon');
+
         element.addEventListener('click', function(e){
             if(element.parentNode.classList.contains('piece-selected')){
                 element.parentNode.classList.remove("piece-selected");
 
                 stats = calculated.stats;
 
-                document.querySelector('.stat-active-weapon').className = 'stat-value stat-active-weapon piece-common-fg';
-                document.querySelector('.stat-active-weapon').innerHTML = 'None';
+                activeWeaponElement.className = 'stat-value stat-active-weapon piece-common-fg';
+                activeWeaponElement.innerHTML = 'None';
             }else{
                 [].forEach.call(document.querySelectorAll('.stat-weapons .piece'), function(_element){
                     _element.classList.remove("piece-selected");
@@ -605,8 +607,8 @@ document.addEventListener('DOMContentLoaded', function(){
 
                 element.parentNode.classList.add("piece-selected");
 
-                document.querySelector('.stat-active-weapon').className = 'stat-value stat-active-weapon piece-' + item.rarity + '-fg';
-                document.querySelector('.stat-active-weapon').innerHTML = item.display_name;
+                activeWeaponElement.className = 'stat-value stat-active-weapon piece-' + item.rarity + '-fg';
+                activeWeaponElement.innerHTML = item.display_name;
 
                 stats = weaponStats;
             }
@@ -669,14 +671,16 @@ document.addEventListener('DOMContentLoaded', function(){
             e.preventDefault();
         });
 
+        const activeRodElement = document.querySelector('.stat-active-rod');
+
         element.addEventListener('click', function(e){
             if(element.parentNode.classList.contains('piece-selected')){
                 element.parentNode.classList.remove("piece-selected");
 
                 stats = calculated.stats;
 
-                document.querySelector('.stat-active-rod').className = 'stat-value stat-active-rod piece-common-fg';
-                document.querySelector('.stat-active-rod').innerHTML = 'None';
+                activeRodElement.className = 'stat-value stat-active-rod piece-common-fg';
+                activeRodElement.innerHTML = 'None';
             }else{
                 [].forEach.call(document.querySelectorAll('.stat-fishing .piece'), function(_element){
                     _element.classList.remove("piece-selected");
@@ -684,8 +688,8 @@ document.addEventListener('DOMContentLoaded', function(){
 
                 element.parentNode.classList.add("piece-selected");
 
-                document.querySelector('.stat-active-rod').className = 'stat-value stat-active-rod piece-' + item.rarity + '-fg';
-                document.querySelector('.stat-active-rod').innerHTML = item.display_name;
+                activeRodElement.className = 'stat-value stat-active-rod piece-' + item.rarity + '-fg';
+                activeRodElement.innerHTML = item.display_name;
 
                 stats = weaponStats;
             }

--- a/public/resources/js/stats.js
+++ b/public/resources/js/stats.js
@@ -566,6 +566,13 @@ document.addEventListener('DOMContentLoaded', function(){
         });
     });
 
+    function flashForUpdate(element) {
+        element.classList.add('updated');
+        element.addEventListener('animationend', () => {
+            element.classList.remove('updated');
+        });
+    }
+
     [].forEach.call(document.querySelectorAll('.stat-weapons .select-weapon'), function(element){
         let itemId = element.parentNode.getAttribute('data-item-id');
         let filterItems;
@@ -613,13 +620,7 @@ document.addEventListener('DOMContentLoaded', function(){
                 stats = weaponStats;
             }
 
-            anime({
-                targets: '.stat-active-weapon',
-                backgroundColor: ['rgba(255,255,255,1)', 'rgba(255,255,255,0)'],
-                duration: 500,
-                round: 1,
-                easing: 'easeOutCubic'
-            });
+            flashForUpdate(activeWeaponElement);
 
             for(let stat in stats){
                 if(stat == 'sea_creature_chance')
@@ -634,14 +635,8 @@ document.addEventListener('DOMContentLoaded', function(){
                 const newValue = stats[stat];
 
                 if(newValue != currentValue){
-                    anime({
-                        targets: '.basic-stat[data-stat=' + stat + '] .stat-value',
-                        innerHTML: newValue,
-                        backgroundColor: ['rgba(255,255,255,1)', 'rgba(255,255,255,0)'],
-                        duration: 500,
-                        round: 1,
-                        easing: 'easeOutCubic'
-                    });
+                    element.innerHTML = newValue;
+                    flashForUpdate(element);
                 }
             }
         });
@@ -694,13 +689,7 @@ document.addEventListener('DOMContentLoaded', function(){
                 stats = weaponStats;
             }
 
-            anime({
-                targets: '.stat-active-rod',
-                backgroundColor: ['rgba(255,255,255,1)', 'rgba(255,255,255,0)'],
-                duration: 500,
-                round: 1,
-                easing: 'easeOutCubic'
-            });
+            flashForUpdate(activeRodElement);
 
             const _element = document.querySelector('.basic-stat[data-stat=sea_creature_chance] .stat-value');
 
@@ -711,14 +700,8 @@ document.addEventListener('DOMContentLoaded', function(){
             const newValue = stats['sea_creature_chance'];
 
             if(newValue != currentValue){
-                anime({
-                    targets: '.basic-stat[data-stat=sea_creature_chance] .stat-value',
-                    innerHTML: newValue,
-                    backgroundColor: ['rgba(255,255,255,1)', 'rgba(255,255,255,0)'],
-                    duration: 500,
-                    round: 1,
-                    easing: 'easeOutCubic'
-                });
+                _element.innerHTML = newValue;
+                flashForUpdate(_element);
             }
         });
     });

--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -1884,6 +1884,23 @@ a.additional-player-stat:hover {
     background-color: white !important;
 }
 
+@keyframes flash {
+    from {
+        background-color: rgb(255, 255, 255, 1);
+    }
+
+    to {
+        background-color: rgba(255, 255, 255, 0);
+    }
+}
+
+.updated {
+    animation-name: flash;
+    animation-duration: 0.5s;
+    animation-timing-function: ease-out;
+    border-radius: 2px;
+}
+
 .piece-shine {
     position: absolute;
     top: 0;

--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -1530,6 +1530,10 @@ a.additional-player-stat:hover {
     margin-left: 2px;
 }
 
+.percent::after {
+    content: '%';
+}
+
 .basic-stat {
     background-size: 24px 24px;
     background-repeat: no-repeat;

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -916,21 +916,21 @@ const skill_component = (skill, icon, level, extra = {}) => { %>
     </div>
 <% };
 
-const stat_component = stat => {
+const stat_component = (stat) => {
     const bonusStats = stats[stat.name] - calculated.base_stats[stat.name]
     %>
     <div data-stat="<%= stat.name %>" class="basic-stat stat-<%= stat.name.replace(/\_/g, "-") %>">
         <span data-tippy-content="
-        <span class='stat-name'>Base <%= helper.titleCase(stat.name.replace(/\_/g, " ")) %>: </span><span class='stat-value'><%= calculated.base_stats[stat.name].toLocaleString() %><%= stat.suffix || '' %></span>
+        <span class='stat-name'>Base <%= helper.titleCase(stat.name.replace(/\_/g, " ")) %>: </span><span class='stat-value<%= stat.percent ? ' percent' : ''%>'><%= calculated.base_stats[stat.name].toLocaleString() %></span>
         <div class='tippy-explanation'><% if(stat.baseExplanation){ %><%= stat.baseExplanation %><% } %></div><br>
-        <span class='stat-name'>Bonus <%= helper.titleCase(stat.name.replace(/\_/g, " ")) %>: </span><span class='stat-value'><%= bonusStats > 0 ? '+' : '' %><%= bonusStats.toLocaleString() %><%= stat.suffix || '' %></span>
+        <span class='stat-name'>Bonus <%= helper.titleCase(stat.name.replace(/\_/g, " ")) %>: </span><span class='stat-value<%= stat.percent ? ' percent' : ''%>'><%= bonusStats > 0 ? '+' : '' %><%= bonusStats.toLocaleString() %></span>
         <div class='tippy-explanation'>Additional bonuses from Armor, held items, Accessories and active Pets.</div>
         <% if(Array.isArray(stat.extraStats)){
             for(const extraStat of stat.extraStats){ %>
-        <br><span class='stat-name'><%= extraStat.stat %>: </span><span class='stat-value'><%= extraStat.value.toLocaleString() %><%= extraStat.suffix || '' %></span>
+        <br><span class='stat-name'><%= extraStat.stat %>: </span><span class='stat-value<%= extraStat.percent ? ' percent' : ''%>'><%= extraStat.value.toLocaleString() %></span>
         <div class='tippy-explanation'><% if(stat.baseExplanation){ %><%= extraStat.explanation %><% } %></div>
         <% }} %>
-        "><span class="stat-name"><%= stat.prettyName || helper.titleCase(stat.name.replace(/\_/g, " ")) %> </span><span class="stat-value"><%= stats[stat.name].toLocaleString() %><%= stat.suffix || '' %></span></span></div>
+        "><span class="stat-name"><%= stat.prettyName || helper.titleCase(stat.name.replace(/\_/g, " ")) %> </span><span class="stat-value<%= stat.percent ? ' percent' : ''%>"><%= stats[stat.name].toLocaleString() %></span></span></div>
 <% };
 
 let description = "";
@@ -1187,7 +1187,7 @@ if(calculated.profile.game_mode == 'ironman'){
                         {
                             stat: 'Damage Reduction',
                             value: (stats.defense / (stats.defense + 100) * 100).toFixed(1),
-                            suffix: '%'
+                            percent: true
                         },
                         {
                             stat: 'Effective Health',
@@ -1204,26 +1204,26 @@ if(calculated.profile.game_mode == 'ironman'){
 
                 <%- stat_component({
                     name: 'speed',
-                    suffix: '%',
+                    percent: true,
                     baseExplanation: "Increased by collecting Fairy Souls and leveling up in Wolf Slayer."
                 }); %>
 
                 <%- stat_component({
                     name: 'crit_chance',
-                    suffix: '%',
+                    percent: true,
                     baseExplanation: "Increased by leveling your Combat skill and leveling up in Spider Slayer."
                 }); %>
 
                 <%- stat_component({
                     name: 'crit_damage',
-                    suffix: '%',
+                    percent: true,
                     baseExplanation: "Increased by leveling up in Spider or Wolf Slayer."
                 }); %>
 
                 <%- stat_component({
                     name: 'bonus_attack_speed',
                     prettyName: 'Attack Speed',
-                    suffix: '%',
+                    percent: true,
                     baseExplanation: null
                 }); %>
 
@@ -1235,7 +1235,7 @@ if(calculated.profile.game_mode == 'ironman'){
                 <%- stat_component({
                     name: 'sea_creature_chance',
                     prettyName: 'SC Chance',
-                    suffix: '%',
+                    percent: true,
                     baseExplanation: null
                 }); %>
 
@@ -1261,14 +1261,14 @@ if(calculated.profile.game_mode == 'ironman'){
                         {
                             stat: 'Chance for 1 more',
                             value: stats.ferocity % 100,
-                            suffix: '%'
+                            percent: true
                         }
                     ]
                 }); %>
 
                 <%- stat_component({
                     name: 'ability_damage',
-                    suffix: '%',
+                    percent: true,
                     baseExplanation: "Increased by leveling your Enchanting Skill."
                 }); %>
                 <!--<div data-stat="fairy_souls" class="basic-stat stat-fairy-souls">
@@ -1487,19 +1487,13 @@ if(calculated.profile.game_mode == 'ironman'){
                             %>
 
                             <span class="stat-name <%= maxTalis %>">Unique Accessories: </span>
-                            <span class="stat-value <%= maxTalis %>">
-                                <%= items.talismans.filter(a => a.isUnique).length %> / <%= UNIQUE_ACCESSORIES %>
-                            </span>
+                            <span class="stat-value <%= maxTalis %>"><%= items.talismans.filter(a => a.isUnique).length %> / <%= UNIQUE_ACCESSORIES %></span>
                             <br>
                             <span class="stat-name <%= maxTalis %>">Completion: </span>
-                            <span class="stat-value <%= maxTalis %>">
-                                <%= Math.round(items.talismans.filter(a => a.isUnique).length / UNIQUE_ACCESSORIES * 100) %>%
-                            </span>
+                            <span class="stat-value percent <%= maxTalis %>"><%= Math.round(items.talismans.filter(a => a.isUnique).length / UNIQUE_ACCESSORIES * 100) %></span>
                             <br>
                             <span class="stat-name <%= maxRecombTalis %>">Recombobulated: </span>
-                            <span class="stat-value <%= maxRecombTalis %>">
-                                <%= items.talismans.filter(a => a.isUnique && a.extra?.recombobulated).length %> / <%= UNIQUE_ACCESSORIES %>
-                            </span>
+                            <span class="stat-value <%= maxRecombTalis %>"><%= items.talismans.filter(a => a.isUnique && a.extra?.recombobulated).length %> / <%= UNIQUE_ACCESSORIES %></span>
                         </p>
                         <% if(items.talismans.filter(a => !a.isInactive).length > 0){ %>
                             <div class="accessory-list">
@@ -1914,7 +1908,7 @@ if(calculated.profile.game_mode == 'ironman'){
                         <%- stat_component({
                             name: 'sea_creature_chance',
                             prettyName: 'SC Chance',
-                            suffix: '%',
+                            percent: true,
                             baseExplanation: null
                         }); %>
 
@@ -2062,7 +2056,7 @@ if(calculated.profile.game_mode == 'ironman'){
 
                     <p class="stat-raw-values">
                         <%= skill_component('Catacombs', 'head-964e1c3e315c8d8fffc37985b6681c5bd16a6f97ffd07199e8a05efbef103793', calculated.dungeons.catacombs.level) %><br>
-                        <span class="stat-name">Dungeon Item Boost: </span><span class="stat-value"><%= calculated.dungeons.catacombs.bonuses.item_boost %>%</span><br>
+                        <span class="stat-name">Dungeon Item Boost: </span><span class="stat-value percent"><%= calculated.dungeons.catacombs.bonuses.item_boost %></span><br>
                     </p>
 
                     <p class="stat-raw-values">
@@ -2670,7 +2664,7 @@ if(calculated.profile.game_mode == 'ironman'){
                                 if(progress.maxed)
                                     tooltip += `<span class="stat-value golden-text">Maxed!</span>`;
                                 else
-                                    tooltip += `<span class="stat-value">${ progress.percentage.toLocaleString() }%</span>`;
+                                    tooltip += `<span class="stat-value percent">${ progress.percentage.toLocaleString() }</span>`;
                                 %>
                             <span <%- tooltip ? `data-tippy-content='${tooltip}'` : "" %>>
                                 <span class="stat-name"><%= helper.capitalizeFirstLetter(key.split("_").join(" ")); %>: </span><span class="stat-value"><%= calculated.misc.milestones[key].toLocaleString() %></span></span><br>


### PR DESCRIPTION
this PR redoes the way that an element is flashed when it is updated by selecting a different weapon so that the anime dependence is no longer needed for it and it uses CSS instead of js so it should run smoother.

eventually, anime can be removed if [scrollIntoViewOptions](https://caniuse.com/mdn-api_element_scrollintoview_scrollintoviewoptions) ever becomes widespread