### PR TITLE
trim input on client side

### DIFF
--- a/includes/resources.ejs
+++ b/includes/resources.ejs
@@ -49,7 +49,7 @@
             function handleSubmit(submitEvent) {
                 submitEvent.preventDefault();
                 const formData = new FormData(submitEvent.srcElement);
-                const urlSegments =  formData.get('ign').split('/');
+                const urlSegments =  formData.get('ign').trim().split('/');
                 let error;
                 switch(urlSegments.length) {
                     case 2:


### PR DESCRIPTION
this PR addresses a minor inconvenience reported by `Obese Microwave#0451` on discord.

### the problem:
autocorrect on mobile will sometimes add a space after some works which is then converted to an underscore by the server.

### my solution:
trim extra whitespace from the form input.

### problems with my solution:
this will make it slightly harder to type username with underscores at the end or beginning on mobile