### PR TITLE
better iOS landscape

### DIFF
--- a/includes/footer.ejs
+++ b/includes/footer.ejs
@@ -153,7 +153,7 @@
     });
 </script>
 <% if(page == 'stats'){ %>
-    <script src="/resources/js/stats.js?v75"></script>
+    <script src="/resources/js/stats.js?v76"></script>
 <% } %>
 
 <% if(page == 'api'){ %>

--- a/includes/header.ejs
+++ b/includes/header.ejs
@@ -6,7 +6,6 @@
         document.getElementById('not_supported').className = 'show-not-supported';
     }
 </script>
-<% if(page !== 'index') { %>
 <div id="status-bar" style="display: none;"></div>
 <script>
     const iOS = [
@@ -21,7 +20,6 @@
         document.querySelector('#status-bar').style.removeProperty('display');
     }
 </script>
-<% } %>
 <header>
     <div data-tippy-content="Supporting LGBTQ+ rights all around the year! ❤️<br><br>Click for a surprise. :)" class="pride-flag logo"></div>
     <a href="/" id="site_name">SkyCrypt</a>

--- a/includes/header.ejs
+++ b/includes/header.ejs
@@ -58,7 +58,6 @@
     </div>
 </div>
 <div id="themes_box" class="themes-closed">
-    <div onclick="toggleThemes()" id="themes_close"></div>
     <% for(const theme_id in extra.themes){
         const theme = extra.themes[theme_id];
         if(theme.hidden) continue; %>
@@ -72,7 +71,6 @@
     <% } %>
 </div>
 <div id="packs_box" class="packs-closed">
-    <div onclick="togglePacks()" id="packs_close"></div>
     <div class="resource-pack">
         <img class="pack-icon" src="/resources/img/pack.png">
         <a class="pack-name" href="/" target="_blank">Default</a><br>

--- a/includes/resources.ejs
+++ b/includes/resources.ejs
@@ -10,7 +10,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/resources/img/app-icons/square-180.png">
     <link rel="apple-touch-icon" sizes="512x512" href="/resources/img/app-icons/square-512.png">
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Montserrat:400,500,600,700&display=swap"></noscript>
-    <link rel="stylesheet" href="/resources/css/index.css?v149">
+    <link rel="stylesheet" href="/resources/css/index.css?v150">
     <noscript><link rel="stylesheet" href="/resources/css/inventory.css?v13"></noscript>
 
     <script>

--- a/includes/resources.ejs
+++ b/includes/resources.ejs
@@ -1,5 +1,5 @@
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width,initial-scale=1.0<%= page === 'index' ? ',viewport-fit=cover' : ''%>">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0<%= page !== 'api' ? ',viewport-fit=cover' : ''%>">
     <meta property="og:site_name" content="SkyCrypt">
     <link rel="sitemap" href="/sitemap.xml">
     <link rel="manifest" href="/manifest.webmanifest" crossorigin="use-credentials">

--- a/public/resources/js/stats.js
+++ b/public/resources/js/stats.js
@@ -1092,7 +1092,7 @@ document.addEventListener('DOMContentLoaded', function(){
 
             anime({
                 targets: window.document.scrollingElement || window.document.body || window.document.documentElement,
-                scrollTop: positionY[newActiveTab.getAttribute('data-target')] - 60,
+                scrollTop: positionY[newActiveTab.getAttribute('data-target')] - 110,
                 duration: 350,
                 easing: 'easeOutCubic',
                 complete: function(){

--- a/public/resources/js/stats.js
+++ b/public/resources/js/stats.js
@@ -512,6 +512,9 @@ document.addEventListener('DOMContentLoaded', function(){
     let oldWidth = null;
     let oldheight = null;
 
+    const navBar = document.querySelector('#nav_bar');
+    let navBarHeight;
+
     function resize(){
         if (playerModel) {
             if(window.innerWidth <= 1570 && (oldWidth === null || oldWidth > 1570))
@@ -529,6 +532,8 @@ document.addEventListener('DOMContentLoaded', function(){
             else
                 skinViewer.setSize(playerModel.offsetHeight / 2, playerModel.offsetHeight);
         }
+
+        navBarHeight = parseFloat(getComputedStyle(navBar).top);
 
         updateStatsPositions();
 
@@ -1205,9 +1210,8 @@ document.addEventListener('DOMContentLoaded', function(){
 
     window.addEventListener('resize', resize);
 
-    const navBar = document.querySelector('#nav_bar')
     function onScroll() {
-        if(navBar.getBoundingClientRect().top <= 48) {
+        if (navBar.getBoundingClientRect().top <= navBarHeight ) {
             navBar.classList.add('stuck')
         } else {
             navBar.classList.remove('stuck')

--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -3506,7 +3506,7 @@ body {
     }
 
     .stat-header {
-        padding-left: 30px;
+        padding-left: 0;
     }
 
     .collections,
@@ -3514,14 +3514,14 @@ body {
     .sea-creatures {
         white-space: nowrap;
         overflow-x: auto;
-        margin-left: -30px;
-        margin-right: -30px;
+        margin-left: calc(-1 * var(--padding));
+        margin-right: calc(-1 * var(--padding));
 
         > :first-child {
-            margin-inline-start: 30px;
+            margin-inline-start: var(--padding);
         }
         > :last-child {
-            margin-inline-end: 30px;
+            margin-inline-end: var(--padding);
         }
     }
 

--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -3311,7 +3311,7 @@ body {
 
     #player_profile {
         font-size: 25px;
-        margin: 25px;
+        margin: 25px 0;
     }
 
     #player_profile .text-stats-for {

--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -3243,6 +3243,8 @@ body {
     #wrapper,
     #bg_blur {
         width: 1120px;
+        margin-right: auto;
+        margin-left: auto;
     }
 
     #skin_display {

--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -556,78 +556,83 @@ header > * {
     }
 }
 
-.skill {
-    width: calc((70vw - 260px) / 2 - 60px);
-    display: inline-block;
-    position: relative;
-    height: 36px;
+.skill-bars {
+    max-width: 1200px;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 4px 24px;
 
-    &.maxed-skill {
-        --icon-hex: var(--maxed-hex);
-        --skillbar-hex: var(--maxedbar-hex);
-    }
-
-    .skill-icon {
-        width: 36px;
-        height: 36px;
-        background-color: var(--icon-hex);
-        border-radius: 50%;
+    .skill {
         position: relative;
-        z-index: 10;
-        filter: drop-shadow(2px 2px 2px rgba(0, 0, 0, 0.4));
-        overflow: hidden;
+        height: 36px;
 
-        .item-icon,
-        .head-icon {
-            position: absolute;
-            top: 5px;
-            left: 5px;
-            width: 128px;
-            height: 128px;
+        &.maxed-skill {
+            --icon-hex: var(--maxed-hex);
+            --skillbar-hex: var(--maxedbar-hex);
+        }
+
+        .skill-icon {
+            width: 36px;
+            height: 36px;
+            background-color: var(--icon-hex);
+            border-radius: 50%;
+            position: relative;
             z-index: 10;
-            transform: scale(0.2);
-            transform-origin: top left;
             filter: drop-shadow(2px 2px 2px rgba(0, 0, 0, 0.4));
+            overflow: hidden;
+
+            .item-icon,
+            .head-icon {
+                position: absolute;
+                top: 5px;
+                left: 5px;
+                width: 128px;
+                height: 128px;
+                z-index: 10;
+                transform: scale(0.2);
+                transform-origin: top left;
+                filter: drop-shadow(2px 2px 2px rgba(0, 0, 0, 0.4));
+            }
+
+            .head-icon {
+                top: 6px;
+                background-repeat: no-repeat;
+            }
         }
 
-        .head-icon {
-            top: 6px;
-            background-repeat: no-repeat;
-        }
-    }
-
-    .skill-name {
-        position: absolute;
-        left: 40px;
-        top: 0;
-        font-weight: 600;
-        font-size: 14px;
-        height: 22px;
-        line-height: 22px;
-
-        .skill-level {
-            color: rgba(255, 255, 255, 0.8);
-        }
-    }
-
-    .skill-bar {
-        position: absolute;
-        bottom: 0;
-        left: 36px;
-        right: 30px;
-        height: 14px;
-        background-color: rgba(255, 255, 255, 0.3);
-        border-top-right-radius: 7px;
-        border-bottom-right-radius: 7px;
-
-        &::before {
-            content: "";
+        .skill-name {
             position: absolute;
+            left: 40px;
             top: 0;
-            left: -18px;
-            width: 18px;
+            font-weight: 600;
+            font-size: 14px;
+            height: 22px;
+            line-height: 22px;
+
+            .skill-level {
+                color: rgba(255, 255, 255, 0.8);
+            }
+        }
+
+        .skill-bar {
+            position: absolute;
             bottom: 0;
-            background-color: var(--skillbar-hex);
+            left: 36px;
+            right: 0;
+            height: 14px;
+            background-color: rgba(255, 255, 255, 0.3);
+            border-top-right-radius: 7px;
+            border-bottom-right-radius: 7px;
+
+            &::before {
+                content: "";
+                position: absolute;
+                top: 0;
+                left: -18px;
+                width: 18px;
+                bottom: 0;
+                background-color: var(--skillbar-hex);
+            }
         }
     }
 }
@@ -1351,7 +1356,7 @@ a.additional-player-stat:hover {
 }
 
 #basic_stats {
-    display: inline-grid;
+    display: grid;
     grid-template-areas:
         "base skill"
         "base additional";
@@ -1387,7 +1392,6 @@ a.additional-player-stat:hover {
 
 #nav_bar {
     position: sticky;
-    width: 100%;
     top: calc(48px + env(safe-area-inset-top, 0));
     margin-left: calc(-1 * var(--padding));
     margin-right: calc(-1 * var(--padding));
@@ -3241,11 +3245,6 @@ body {
         width: 1120px;
     }
 
-    .skill {
-        width: calc((1120px - 410px) / 2 - 60px);
-        max-width: 100%;
-    }
-
     #skin_display {
         display: none;
     }
@@ -3389,16 +3388,6 @@ body {
         padding: var(--padding);
         box-sizing: border-box;
         padding-bottom: 15px;
-
-        .skill {
-            width: calc(50vw - 60px);
-            margin-left: 12px;
-            margin-right: 12px;
-        }
-
-        .skill-bar {
-            right: 0;
-        }
 
         .no-access {
             text-align: left;
@@ -3724,10 +3713,14 @@ body {
         display: block;
     }
 
+    .skill-bars {
+        grid-template-columns: 1fr;
+    }
+
     #other_skills {
         max-height: 0;
         overflow: hidden;
-        display: block;
+        transition: max-height 0.2s ease-in-out;
 
         &.show-skills {
             max-height: 500px;
@@ -3737,10 +3730,6 @@ body {
     #skill_levels_container .skill {
         width: 100%;
         margin: 0;
-    }
-
-    #skill_levels_container .skill-bar {
-        right: 0;
     }
 
     .wardrobe-set {

--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -513,11 +513,11 @@ header > * {
 }
 
 #wrapper {
-    position: absolute;
-    left: 30vw;
-    top: 45px;
-    right: 0;
-    padding-bottom: 30px;
+    margin-left: 30vw;
+    --padding: 30px;
+    padding: var(--padding);
+    padding-top: calc(48px + env(safe-area-inset-top, 0));
+    padding-bottom: calc(var(--padding) + env(safe-area-inset-bottom));
     min-height: 100%;
     box-sizing: border-box;
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
@@ -1389,8 +1389,10 @@ a.additional-player-stat:hover {
 
 #nav_bar {
     position: sticky;
-    top: 48px;
     width: 100%;
+    top: calc(48px + env(safe-area-inset-top, 0));
+    margin-left: calc(-1 * var(--padding));
+    margin-right: calc(-1 * var(--padding));
     text-align: center;
     padding-bottom: 6px;
     white-space: nowrap;
@@ -3242,9 +3244,7 @@ body {
 
     #wrapper,
     #bg_blur {
-        left: 50%;
         width: 1120px;
-        margin-left: -560px;
     }
 
     .skill {
@@ -3300,10 +3300,9 @@ body {
 
     #wrapper,
     #bg_blur {
-        left: 0;
-        right: 0;
-        margin-left: 0;
-        width: 100vw;
+        margin-left: env(safe-area-inset-left, 0);
+        margin-right: env(safe-area-inset-right, 0);
+        width: calc(100vw - env(safe-area-inset-left, 0) - env(safe-area-inset-right, 0));
     }
 
     .stat-fairy-souls {

--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -856,9 +856,12 @@ input[type="search"]::-webkit-search-cancel-button {
     padding: 6px;
     border-radius: 5px;
     background-color: rgba(255, 255, 255, 0.05);
-    margin-top: 15px;
     padding-left: 48px;
     font-size: 14px;
+
+    &:not(:first-of-type) {
+        margin-top: 15px;
+    }
 
     .pack-icon {
         top: 8px;
@@ -902,10 +905,13 @@ input[type="search"]::-webkit-search-cancel-button {
     padding: 6px;
     border-radius: 5px;
     background-color: rgba(255, 255, 255, 0.05);
-    margin-top: 15px;
     padding-left: 48px;
     font-size: 14px;
     
+    &:not(:first-of-type) {
+        margin-top: 15px;
+    }
+
     .theme-icon {
         top: 8px;
         left: 8px;

--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -739,16 +739,16 @@ input[type="search"]::-webkit-search-cancel-button {
     position: fixed;
     left: 20px;
     width: calc(30vw - 40px);
-    top: 48px;
+    top: calc(48px + env(safe-area-inset-top, 0));
     z-index: 1;
     background-color: rgba(30, 30, 30, 0.95);
-    padding: var(--padding);
+    padding: 30px;
     padding-top: 45px;
     box-sizing: border-box;
     transform: translateY(0%);
     transition: transform 0.3s;
     z-index: 100;
-    max-height: calc(100vh - 48px - var(--padding));
+    max-height: calc(100vh - 48px - env(safe-area-inset-top, 0) - env(safe-area-inset-bottom, 0));
     overflow-y: auto;
 
     &:not(.info-opened) {
@@ -835,7 +835,7 @@ input[type="search"]::-webkit-search-cancel-button {
     position: fixed;
     right: 20px;
     width: 440px;
-    top: 45px;
+    top: calc(48px + env(safe-area-inset-top, 0));
     z-index: 1;
     background-color: rgba(30, 30, 30, 0.95);
     padding: 20px;
@@ -844,6 +844,7 @@ input[type="search"]::-webkit-search-cancel-button {
     transition: transform 0.3s;
     z-index: 100;
     overflow-y: auto;
+    max-height: calc(100vh - 48px - env(safe-area-inset-top, 0) - env(safe-area-inset-bottom, 0));
 
     &.packs-opened {
         transform: translateY(0%);
@@ -880,7 +881,7 @@ input[type="search"]::-webkit-search-cancel-button {
     position: fixed;
     right: 20px;
     width: 440px;
-    top: 45px;
+    top: calc(48px + env(safe-area-inset-top, 0));
     z-index: 1;
     background-color: rgba(30, 30, 30, 0.95);
     padding: 20px;
@@ -889,6 +890,7 @@ input[type="search"]::-webkit-search-cancel-button {
     transition: transform 0.3s;
     z-index: 100;
     overflow-y: auto;
+    max-height: calc(100vh - 48px - env(safe-area-inset-top, 0) - env(safe-area-inset-bottom, 0));
 
     &.themes-opened {
         transform: translateY(0%);
@@ -903,7 +905,7 @@ input[type="search"]::-webkit-search-cancel-button {
     margin-top: 15px;
     padding-left: 48px;
     font-size: 14px;
-
+    
     .theme-icon {
         top: 8px;
         left: 8px;
@@ -3325,10 +3327,9 @@ body {
     }
 
     #info_box {
-        left: 0;
-        width: 100vw;
-        right: 0;
-        max-height: calc(100vh - 45px);
+        left: env(safe-area-inset-left, 0);
+        right: env(safe-area-inset-right, 0);
+        width: unset;
     }
 
     #wrapper,
@@ -3610,18 +3611,11 @@ body {
         grid-template-columns: 1fr;
     }
 
-    #themes_box {
-        left: 0;
-        width: 100vw;
-        right: 0;
-        max-height: calc(100vh - 45px);
-    }
-
+    #themes_box,
     #packs_box {
-        left: 0;
-        width: 100vw;
-        right: 0;
-        max-height: calc(100vh - 45px);
+        left: env(safe-area-inset-left, 0);
+        right: env(safe-area-inset-right, 0);
+        width: unset;
     }
 
     .inventory-slot .piece-icon {

--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -2162,7 +2162,6 @@ a.additional-player-stat:hover {
 }
 
 #inventory_container {
-    display: inline-block;
     background-color: rgba(0, 0, 0, 0.3);
     padding: 20px;
     position: relative;

--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -526,9 +526,6 @@ header > * {
     user-select: none;
     -webkit-backdrop-filter: blur(16px) brightness(0.5);
     backdrop-filter: blur(16px) brightness(0.5);
-    > * {
-        max-width: 100%;
-    }
 }
 
 #base_stats_container {
@@ -709,13 +706,13 @@ header > * {
     top: 48px;
     z-index: 1;
     background-color: rgba(30, 30, 30, 0.95);
-    padding: 30px;
+    padding: var(--padding);
     padding-top: 45px;
     box-sizing: border-box;
     transform: translateY(0%);
     transition: transform 0.3s;
     z-index: 100;
-    max-height: calc(100vh - 48px - 30px);
+    max-height: calc(100vh - 48px - var(--padding));
     overflow-y: auto;
 
     &:not(.info-opened) {
@@ -1033,7 +1030,7 @@ header > * {
 #player_profile {
     font-size: 36px;
     margin-top: 50px;
-    margin-left: 50px;
+    margin-left: 20px;
     margin-bottom: 20px;
 }
 
@@ -1359,8 +1356,9 @@ a.additional-player-stat:hover {
         "base skill"
         "base additional";
     grid-template-columns: 260px auto;
-    width: 100%;
-    padding: 30px;
+    padding: var(--padding);
+    margin-left: calc(-1 * var(--padding));
+    margin-right: calc(-1 * var(--padding));
     box-sizing: border-box;
     background-color: rgba(0, 0, 0, 0.3);
 }
@@ -1657,9 +1655,7 @@ a.additional-player-stat:hover {
 }
 
 .stat-content {
-    padding-left: 30px;
     box-sizing: border-box;
-    padding-right: 30px;
     margin-top: 25px;
 }
 
@@ -1703,7 +1699,7 @@ a.additional-player-stat:hover {
     font-size: 24px;
     text-shadow: 0px 0px 7px rgba(0, 0, 0, 0.3);
     position: relative;
-    padding-left: 35px;
+    padding-left: 5px;
     margin-bottom: 15px;
 
     span {
@@ -1713,7 +1709,6 @@ a.additional-player-stat:hover {
 
 .info-container {
     background-color: rgba(0, 0, 0, 0.3);
-    margin-left: 30px;
     margin-bottom: 0px;
     padding: 20px;
     padding-top: 55px;
@@ -3385,14 +3380,14 @@ body {
     }
 
     #base_stats_container {
-        padding: 30px;
+        padding: var(--padding);
         box-sizing: border-box;
         position: relative;
         padding-left: 0;
     }
 
     #skill_levels_container {
-        padding: 30px;
+        padding: var(--padding);
         box-sizing: border-box;
         padding-bottom: 15px;
 
@@ -3470,9 +3465,8 @@ body {
     }
 
     #inventory_container {
-        width: 100%;
-        margin-left: 0;
-        margin-right: 0;
+        margin-left: calc(-1 * var(--padding));
+        margin-right: calc(-1 * var(--padding));
         margin-top: 0;
         box-sizing: border-box;
         padding: 0;
@@ -3493,15 +3487,15 @@ body {
     .floor-containers {
         white-space: nowrap;
         overflow-x: auto;
-        margin-left: -30px;
-        margin-right: -30px;
+        margin-left: calc(-1 * var(--padding));
+        margin-right: calc(-1 * var(--padding));
         padding-bottom: 20px;
 
         > :first-child {
-            margin-inline-start: 30px;
+            margin-inline-start: var(--padding);
         }
         > :last-child {
-            margin-inline-end: 30px;
+            margin-inline-end: var(--padding);
         }
     }
 }

--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -781,11 +781,11 @@ input[type="search"]::-webkit-search-cancel-button {
         display: inline-block;
     }
 
-    #info_box .name {
+    .name {
         color: rgba(255, 255, 255, 0.7);
     }
 
-    #info_box .patron {
+    .patron {
         font-weight: 500;
     }
 }

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1089,7 +1089,7 @@ if(calculated.profile.game_mode == 'ironman'){
     <div id="skin_display">
         <div id="player_model"></div>
     </div>
-    <div id="wrapper" data-sticky-container>
+    <main id="wrapper" data-sticky-container>
         <div id="player_profile"><span class="text-stats-for">Stats for</span>
             <div tabindex="1" id="stats_for_player">
                 <%- calculated.rank_prefix %>

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1307,7 +1307,7 @@ if(calculated.profile.game_mode == 'ironman'){
                 <%
                     if('levels' in calculated){
                 %>
-                    <div id="other_skills">
+                    <div id="other_skills" class="skill-bars">
                         <%= skill_component('Taming', 'icon-383_0_12', calculated.levels.taming) %>
                         <%= skill_component('Farming', 'icon-294_0', calculated.levels.farming) %>
                         <%= skill_component('Mining', 'icon-274_0', calculated.levels.mining) %>
@@ -2049,19 +2049,23 @@ if(calculated.profile.game_mode == 'ironman'){
                 <p class="stat-sub-header">Classes</p>
 
                 <span class="stat-name">Selected Class: </span>
-                <span class="stat-value"><%= helper.titleCase(calculated.dungeons.selected_class) %></span><br>
-                <%= skill_component('Healer', 'icon-373_0', calculated.dungeons.classes.healer.experience) %>
-                <%= skill_component('Mage', 'icon-369_0', calculated.dungeons.classes.mage.experience) %>
-                <%= skill_component('Berserk', 'icon-267_0', calculated.dungeons.classes.berserk.experience) %>
-                <%= skill_component('Archer', 'icon-261_0', calculated.dungeons.classes.archer.experience) %>
-                <%= skill_component('Tank', 'icon-299_0', calculated.dungeons.classes.tank.experience) %>
+                <span class="stat-value"><%= helper.titleCase(calculated.dungeons.selected_class) %></span>
+                <div class="skill-bars">
+                    <%= skill_component('Healer', 'icon-373_0', calculated.dungeons.classes.healer.experience) %>
+                    <%= skill_component('Mage', 'icon-369_0', calculated.dungeons.classes.mage.experience) %>
+                    <%= skill_component('Berserk', 'icon-267_0', calculated.dungeons.classes.berserk.experience) %>
+                    <%= skill_component('Archer', 'icon-261_0', calculated.dungeons.classes.archer.experience) %>
+                    <%= skill_component('Tank', 'icon-299_0', calculated.dungeons.classes.tank.experience) %>
+                </div>
                 <% } %>
 
                 <% if (calculated.dungeons.catacombs.visited) { %>
                     <p class="stat-sub-header">Catacombs</p>
 
                     <p class="stat-raw-values">
-                        <%= skill_component('Catacombs', 'head-964e1c3e315c8d8fffc37985b6681c5bd16a6f97ffd07199e8a05efbef103793', calculated.dungeons.catacombs.level) %><br>
+                        <div class="skill-bars">
+                            <%= skill_component('Catacombs', 'head-964e1c3e315c8d8fffc37985b6681c5bd16a6f97ffd07199e8a05efbef103793', calculated.dungeons.catacombs.level) %><br>
+                        </div>
                         <span class="stat-name">Dungeon Item Boost: </span><span class="stat-value"><%= calculated.dungeons.catacombs.bonuses.item_boost %>%</span><br>
                     </p>
 

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -2749,7 +2749,7 @@ if(calculated.profile.game_mode == 'ironman'){
             </div>
         <% } %>
         </div>
-    </div>
+    </main>
     <%- include('../includes/footer'); %>
     <script>
         let items = JSON.parse(`<%- JSON.stringify(items).replace(/\\/g, '\\\\') %>`);


### PR DESCRIPTION
this PR redoes the way margin and padding are put on the right and left side of the stats page. this two main effects:
1. the overall layout of the stats page should be easier to maintain
2. iOS landscape looks way better

this PR also fixes several longstanding visual bugs with the info, themes, and packs boxes

## before:
![IMG_0168](https://user-images.githubusercontent.com/44071655/108636830-d8023e80-7455-11eb-96cf-4e92cb8a42cf.PNG)
## after:
![IMG_0167](https://user-images.githubusercontent.com/44071655/108636829-d6d11180-7455-11eb-957a-644b89539711.PNG)

