### PR TITLE
Styles when a user has skills API disabled + hides skill avg

### DIFF
--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -583,13 +583,18 @@ input[type="search"]::-webkit-search-cancel-button {
 
 #skill_levels_container {
     grid-area: skill;
-
-    &.no-access {
+    .skill-bars[data-api-enabled="false"] {
+        .xp-skill {
+            filter: grayscale(1) opacity(0.5);
+        }
+    }
+    .no-access {
         margin-top: 20px;
         font-weight: 500;
         font-size: 15px;
         color: rgba(255, 255, 255, 0.85);
         white-space: nowrap;
+        grid-column: 1 / -1;
     }
 }
 

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1287,7 +1287,7 @@ if(calculated.profile.game_mode == 'ironman'){
                 <% if('bank' in calculated){ %>
                     <div class="additional-stat"><span class="stat-name">Bank Account: </span><span class="stat-value"><%= helper.formatNumber(calculated.bank, true) %> Coin<%= Math.floor(calculated.bank) == 1 ? '': 's' %></span></div>
                 <% } %>
-                <% if('levels' in calculated){ %>
+                <% if('levels' in calculated && 'runecrafting' in calculated.levels){ %>
                     <div class="additional-stat"><span data-tippy-content="
                     <span class='stat-name'>Total Skill XP: </span><span class='stat-value'><%= Math.round(calculated.total_skill_xp).toLocaleString() %></span>
                     <div class='tippy-explanation'>Total XP gained in all skills except Carpentry and Runecrafting.</div>
@@ -1306,7 +1306,7 @@ if(calculated.profile.game_mode == 'ironman'){
                 <%
                     if('levels' in calculated){
                 %>
-                    <div id="other_skills" class="skill-bars">
+                    <div id="other_skills" class="skill-bars" data-api-enabled="<%= 'runecrafting' in calculated.levels %>">
                         <%= skill_component('Taming', 'icon-383_0_12', calculated.levels.taming) %>
                         <%= skill_component('Farming', 'icon-294_0', calculated.levels.farming) %>
                         <%= skill_component('Mining', 'icon-274_0', calculated.levels.mining) %>
@@ -1725,7 +1725,7 @@ if(calculated.profile.game_mode == 'ironman'){
                                 <% for(let i = 9; i < items.inventory.length; i++){ %>
                                     <% let item = items.inventory[i]; %>
                                     <%= inventorySlot(item); %>
-                                    
+
                                 <% } %>
                                 <hr>
                                 <% for(let i = 0; i < 9; i++){ %>
@@ -1838,9 +1838,9 @@ if(calculated.profile.game_mode == 'ironman'){
                         <div class="stat-sub-container sub-extendable">
                             <p class="stat-sub-header">Farming Crops</p>
                             <div class="stat-farming-crops">
-                                <%  
+                                <%
                                 const crops = Object.values(farming.crops).sort((a, b) => {
-                                    return b.contests - a.contests; 
+                                    return b.contests - a.contests;
                                 });
 
                                 for(const crop of crops){
@@ -1979,7 +1979,7 @@ if(calculated.profile.game_mode == 'ironman'){
                     <div class="stat-sub-container sub-floor-extendable">
                         <p class="stat-sub-header">Experiments</p>
                         <div class="stat-experiments floor-containers">
-                            <% for(let game in enchanting.experiments){ 
+                            <% for(let game in enchanting.experiments){
                             const game_data = enchanting.experiments[game]; %>
                             <div class="narrow-info-container">
                                 <div class="narrow-info-header">
@@ -1987,17 +1987,17 @@ if(calculated.profile.game_mode == 'ironman'){
                                 </div>
                                 <span>
                                     <p class="stat-raw-values">
-                                        <% 
+                                        <%
                                             const game_stats = helper.sortObject(game_data.stats);
-                                            for(let stat in game_stats){ 
+                                            for(let stat in game_stats){
                                         %>
                                             <span class="stat-name"><%= helper.titleCase(stat.replace('_', ' ')) %>: </span>
                                             <span class="stat-value"><%= (stat == 'last_attempt' || stat == 'last_claimed') ? game_stats[stat].text : game_stats[stat] %></span><br>
                                         <% } %>
                                     </p>
-                                    <% 
-                                    for(let tier in game_data.tiers) { 
-                                        const tier_data = game_data.tiers[tier]; 
+                                    <%
+                                    for(let tier in game_data.tiers) {
+                                        const tier_data = game_data.tiers[tier];
                                     %>
                                     <hr>
                                     <div class="collection">
@@ -2005,9 +2005,9 @@ if(calculated.profile.game_mode == 'ironman'){
                                         <div class="collection-stats">
                                             <div class="collection-name"><span class="stat-name"><%= tier_data.name %></span></div>
                                             <div class="collection-amount">
-                                                <% 
-                                                for(let info in tier_data) { 
-                                                    if(info == 'name' || info == 'icon') continue; 
+                                                <%
+                                                for(let info in tier_data) {
+                                                    if(info == 'name' || info == 'icon') continue;
                                                 %>
                                                 <small class="stat-name"><%= helper.titleCase(info.replace('_', ' ')) %>: </small><small class="stat-value"><%= tier_data[info] %></small><br>
                                                 <% } %>
@@ -2023,7 +2023,7 @@ if(calculated.profile.game_mode == 'ironman'){
                 </div>
                 <% } %>
 
-<br>    
+<br>
                 <p class='stat-raw-values'><small><i>
                 Please note that this section is still in the works and many things are now in development. Thanks for your support!
                 </i></small></p>

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1296,10 +1296,10 @@ if(calculated.profile.game_mode == 'ironman'){
                     <% if('runecrafting' in calculated.levels){ %><span class='stat-name'>Average Level without progress: </span><span class='stat-value'><%= calculated.average_level_no_progress.toFixed(2) %></span>
                     <div class='tippy-explanation'>Average skill level without including partial level progress.</div><% } %>
                     "><span class="stat-name">Average Skill Level: </span><span class="stat-value"><%= calculated.average_level.toFixed(2) %></span></span></div>
-                    <div class="additional-stat">
-                        <span class="stat-name">Fairy Souls: </span><span class="stat-value"><%= calculated.fairy_souls.collected %> / <%= calculated.fairy_souls.total %></span>
-                    </div>
                 <% } %>
+                <div class="additional-stat">
+                    <span class="stat-name">Fairy Souls: </span><span class="stat-value"><%= calculated.fairy_souls.collected %> / <%= calculated.fairy_souls.total %></span>
+                </div>
             </div>
 
             <div id="skill_levels_container">


### PR DESCRIPTION
Uses grayscale colors for skills when skills API is disabled (+ 0.5 opacity) and removes the avg skill.
(+ fixed the css selector for the ".no-access" text)
(+ my editor fixed random extra spaces in the .ejs file)

Before:
![image](https://user-images.githubusercontent.com/2744227/109388520-ecd44b80-7907-11eb-88e2-3aced7b22de1.png)

After:
![image](https://user-images.githubusercontent.com/2744227/109388568-39b82200-7908-11eb-923d-5527a81c7c0e.png)

