### PR TITLE
Obfuscate text

### DIFF
--- a/public/resources/js/stats.js
+++ b/public/resources/js/stats.js
@@ -189,7 +189,7 @@ document.addEventListener('DOMContentLoaded', function(){
             }
 
             if (formats.size > 0) {
-                output += ` class='${Array.from(formats, x => '§' + x).join(', ')}'`;
+                output += ` class='${Array.from(formats, x => '§' + x).join(' ')}'`;
             }
 
             output += `>${part}</span>`;

--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -40,7 +40,8 @@
 }
 
 .§k {
-    text-decoration: line-through wavy 0.25em;
+    background-color: currentColor;
+    border-radius: 0.25em;
 }
 .§l {
     font-weight: bold;
@@ -1772,7 +1773,7 @@ a.additional-player-stat:hover {
 }
 
 .color-mining-speed {
-    color: #FFAA00
+    color: #ffaa00;
 }
 
 .stat-container {

--- a/src/helper.js
+++ b/src/helper.js
@@ -371,7 +371,7 @@ module.exports = {
             }
 
             if (formats.size > 0) {
-                output += ` class='${Array.from(formats, x => '§' + x).join(', ')}'`;
+                output += ` class='${Array.from(formats, x => '§' + x).join(' ')}'`;
             }
 
             output += `>${part}</span>`;


### PR DESCRIPTION
this PR turns Obfuscated text (`§k`) into solid blocks of color and also fixes a minor bug where only the last formating code was being recognized
## Before:
![image](https://user-images.githubusercontent.com/44071655/110252564-0868d300-7f54-11eb-8a40-931d584d1231.png)
## After:
![image](https://user-images.githubusercontent.com/44071655/110252560-04d54c00-7f54-11eb-8761-a4fd70dd6de2.png)
