### PR TITLE
pet exp progression

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -2629,7 +2629,7 @@ module.exports = {
 
             lore.push(
                 '',
-                `§7Total XP: §e${helper.formatNumber(pet.exp, true, 10)} §6/ §e${helper.formatNumber(pet.level.xpMaxLevel, true, 10)}`,
+                `§7Total XP: §e${helper.formatNumber(pet.exp, true, 10)} §6/ §e${helper.formatNumber(pet.level.xpMaxLevel, true, 10)} §6(${Math.floor((pet.exp / pet.level.xpMaxLevel) * 100)}%)`,
                 `§7Candy Used: §e${pet.candyUsed || 0} §6/ §e10`
             );
 


### PR DESCRIPTION
Added the % progression (0 to 100) on pets tooltips:

![image](https://user-images.githubusercontent.com/2744227/111918393-2a4e7380-8a85-11eb-8755-17d24e8b2fcf.png)
![image](https://user-images.githubusercontent.com/2744227/111918401-333f4500-8a85-11eb-9da8-6eb424810166.png)
![image](https://user-images.githubusercontent.com/2744227/111918405-39cdbc80-8a85-11eb-86e8-f7778bb62b8b.png)

Also I decided to let it go above 100% because some people (like me) can find it useful or nice to see.