### PR TITLE
New slayer drops

### DIFF
--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -2650,7 +2650,7 @@ a.additional-player-stat:hover {
 
 .slayer-drops {
     margin-top: 10px;
-    height: 160px;
+    height: 200px;
     display: flex;
     flex-direction: column;
 }

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -52,7 +52,7 @@ const skillItems = {
     runecrafting: 'icon-378_0'
 };
 
-const MAX_MAGIC_FIND = 2.00;
+const MAX_MAGIC_FIND = 3.00;
 
 const romanize = num => {
 	if (!+num)
@@ -75,7 +75,8 @@ const slayerInfo = {
         drops: [
             {
                 chance: {
-                    4: 42 / 13000
+                    4: 42 / 13000,
+                    5: 42 / 13000,
                 },
                 levelReq: 6,
                 name: 'Snake Rune',
@@ -83,7 +84,8 @@ const slayerInfo = {
             },
             {
                 chance: {
-                    4: 21 / 13000
+                    4: 21 / 13000,
+                    5: 21 / 13000,
                 },
                 levelReq: 5,
                 name: 'Beheaded Horror',
@@ -91,13 +93,30 @@ const slayerInfo = {
             },
             {
                 chance: {
-                    4: 7 / 13000
+                    4: 7 / 13000,
+                    5: 7 / 13000,
                 },
                 levelReq: 7,
                 name: 'Scythe Blade',
                 id: 264,
                 damage: 0
-            }
+            },
+            {
+                chance: {
+                    5: 7 / 13000
+                },
+                levelReq: 7,
+                name: 'Shard of the Shredded',
+                icon: '/head/70c5cc728c869ecf3c6e0979e8aa09c10147ed770417e4ba541aac382f0'
+            },
+            {
+                chance: {
+                    5: 7 / 13000
+                },
+                levelReq: 7,
+                name: 'Warden Heart',
+                icon: '/head/d45f4d139c9e89262ec06b27aaad73fa488ab49290d2ccd685a2554725373c9b'
+            },
         ]
     },
     spider: {
@@ -1139,7 +1158,7 @@ if(calculated.profile.game_mode == 'ironman'){
                         </li>
                     <% } %>
                 </ul>
-            </span> 
+            </span>
             <div id="additional_player_stats">
                 <% /*
 
@@ -2256,7 +2275,7 @@ if(calculated.profile.game_mode == 'ironman'){
                                     <% } %>
                                 </div>
                             </div>
-                            <div class="slayer-section-header"><span data-tippy-content="Average drops based on Slayer boss kills. The number ranges from 0% Magic Find to 100% Magic Find.">Your Average Drops</span></div>
+                            <div class="slayer-section-header"><span data-tippy-content="Average drops based on Slayer boss kills. The number ranges from 0% Magic Find to 200% Magic Find.">Your Average Drops</span></div>
                             <div class="slayer-section slayer-drops">
                                 <%
                                 for(const drop of slayerInfo[slayerName].drops){


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2744227/111927541-6992b980-8ab1-11eb-9680-0164aa334e42.png)

Adds the 2 new drops from Revenant 5:
- Shard of the Shredded
- Warden Heart

Changes default average drops from 0-100% mf to 0-200% mf (I would use the magicfind calculated by the stats but it's highly inaccurate, for me it says 33 while in game it's 149)

**This is a DRAFT:**
- Actual drop chances are unknown, for now I inserted numbers that seems to match what I actually dropped in game
- There's a "bug" in _Shard of the Shredded_, it adds an "s" at the end while it should be added after _Shard_

Does anyone know how to obtain the real drop chances?