### PR TITLE
remove suport for browsers without javascript

### DIFF
--- a/includes/header.ejs
+++ b/includes/header.ejs
@@ -104,5 +104,16 @@
         </div>
     <% } %>
 </header>
+<noscript style="
+    position: fixed;
+    top: 48px;
+    width: 100%;
+    background-color: #000;
+    color: #ff4444;
+    font-size: 8vw;
+    z-index: 10000;
+">
+    please enable JavaScript!
+</noscript>
 
 

--- a/includes/resources.ejs
+++ b/includes/resources.ejs
@@ -17,9 +17,7 @@
     <link rel="apple-touch-startup-image" href="/resources/img/ios-launch-screen/iPhoneX.png" media="(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3)">
     <link rel="apple-touch-startup-image" href="/resources/img/ios-launch-screen/iPhone8Plus.png" media="(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3)">
     <link rel="apple-touch-startup-image" href="/resources/img/ios-launch-screen/iPhone8.png" media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)">
-    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Montserrat:400,500,600,700&display=swap"></noscript>
     <link rel="stylesheet" href="/resources/css/index.css?<%- fileHashes.css['index.css'] %> ">
-    <noscript><link rel="stylesheet" href="/resources/css/inventory.css?<%- fileHashes.css['inventory.css'] %>"></noscript>
 
     <script>
         const stylesheets = [


### PR DESCRIPTION
instead of supplying a bad experience to users with no javascript we just ask the user to enable it ![localhost_32464_(iPad)](https://user-images.githubusercontent.com/44071655/112407032-b2ce4d80-8ceb-11eb-8aa7-2885a3bb2beb.png)
