### PR TITLE
Fix master catacombs weight

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -859,7 +859,14 @@ function calcDungeonsClassLevelWithProgress(experience){
     return Math.min(level, 50);
 }
 
-function calcDungeonsWeight(type, level, experience){
+function calcDungeonsWeight(type, level, experience) {
+    if (type.startsWith('master_')) {
+        return {
+            weight: 0,
+            weight_overflow: 0,
+        }
+    }
+
     let percentageModifier = constants.dungeonsWeight[type];
     let level50Experience = 569809640
 
@@ -2006,7 +2013,7 @@ module.exports = {
             });
 
         const random = Math.random() < 0.01;
-        
+
 
         killsDeaths = killsDeaths.filter(a => {
             return ![


### PR DESCRIPTION
This will fix the current issue with profiles who played master_catacombs to have weight NaN.

The weight calculator uses the xp accumulated for each dungeon to calculate its weight, the problem here is that master_catacombs it's not actually a new dungeon, but instead an extension of catacombs (the xp gained goes to catacombs, not master_catacombs).

This fix simply adds a check if the dungeon is a "master" and simply returns 0 for the weight (that will be added to the total `calculated.dungeonWeight`.

There's a chance Senither will will do it differently, and in that case we update the code; but until then this fixes the NaN issue.