### PR TITLE
lazy load pack icons and theme logos

### DIFF
--- a/includes/header.ejs
+++ b/includes/header.ejs
@@ -64,7 +64,7 @@
             if(theme.hidden) continue; %>
         <label class="list-item">
             <% let icon = theme.logo.replace("../", "/resources/"); %>
-            <img class="icon" src="<%= icon %>" alt="">
+            <img class="icon" src="<%= icon %>" alt="" loading="lazy">
             <span class="name"><%= theme.name %></span>
             <div class="author">by <span><%= theme.author %></span></div>
             <input type="radio" name="theme" value="<%= theme_id %>">
@@ -85,7 +85,7 @@
             %>
             <% for(const pack of [defaultPack, ...extra.packs].filter(a => !a.hidden)) { %>
                 <label class="list-item">
-                    <img class="icon pack-icon" src="<%= pack.basePath + '/pack.png' %>" alt="">
+                    <img class="icon pack-icon" src="<%= pack.basePath + '/pack.png' %>" alt="" loading="lazy">
                     <a class="name" href="<%= pack.url %>" target="_blank" rel="noreferrer"><%= pack.name %> <% if(pack.version){ %><small><%= pack.version %></small><% } %></a><br>
                     <div class="author">by <span><%= pack.author %></span></div>
                     <button


### PR DESCRIPTION
make image icons in the packs and themes selectors not load until the user opens the selector this will result in a very small performance gain