### PR TITLE
fix blaze no armor error

### DIFF
--- a/src/constants/petStats.js
+++ b/src/constants/petStats.js
@@ -735,7 +735,7 @@ class Blaze extends Pet {
 
 	modifyArmor(helmet, hName, chest, cName, legs, lName, boots, bName) {
 		let mult = (1 + round(this.level * (this.rarity > 2 ? 0.4 : 0.3), 1) / 100);
-		if (helmet.extra?.hpbs > 0) {
+		if (helmet?.extra?.hpbs > 0) {
 			helmet.stats.defense += 2 * helmet.extra.hpbs;
 			helmet.stats.health += 4 * helmet.extra.hpbs;
 			helmet.extra.hpbs *= 2;
@@ -744,7 +744,7 @@ class Blaze extends Pet {
 			for (const stat in helmet.stats)
 				helmet.stats[stat] = round(helmet.stats[stat] * mult, 1);
 		}
-		if (chest.extra?.hpbs > 0) {
+		if (chest?.extra?.hpbs > 0) {
 			chest.stats.defense += 2 * chest.extra.hpbs;
 			chest.stats.health += 4 * chest.extra.hpbs;
 			chest.extra.hpbs *= 2;
@@ -753,7 +753,7 @@ class Blaze extends Pet {
 			for (const stat in chest.stats)
 				chest.stats[stat] = round(chest.stats[stat] * mult, 1);
 		}
-		if (legs.extra?.hpbs > 0) {
+		if (legs?.extra?.hpbs > 0) {
 			legs.stats.defense += 2 * legs.extra.hpbs;
 			legs.stats.health += 4 * legs.extra.hpbs;
 			legs.extra.hpbs *= 2;
@@ -762,7 +762,7 @@ class Blaze extends Pet {
 			for (const stat in legs.stats)
 				legs.stats[stat] = round(legs.stats[stat] * mult, 1);
 		}
-		if (boots.extra?.hpbs > 0) {
+		if (boots?.extra?.hpbs > 0) {
 			boots.stats.defense += 2 * boots.extra.hpbs;
 			boots.stats.health += 4 * boots.extra.hpbs;
 			boots.extra.hpbs *= 2;

--- a/src/lib.js
+++ b/src/lib.js
@@ -1761,16 +1761,21 @@ module.exports = {
             output.stats[stat] += output.pet_bonus[stat];
 
         // Apply pet bonus to armor
-        if(activePet && Date.now() - userProfile.last_save >= 7 * 60 * 1000 /* change to 1000 - its one for testing; 7 minutes*/) {
-            // We know they are not online so apply pets to armor
-            activePet.ref.modifyArmor(items.armor[3], getId(items.armor[3]),
-                                    items.armor[2], getId(items.armor[2]),
-                                    items.armor[1], getId(items.armor[1]),
-                                    items.armor[0], getId(items.armor[0]));
-            loreGenerator.makeLore(items.armor[0]);
-            loreGenerator.makeLore(items.armor[1]);
-            loreGenerator.makeLore(items.armor[2]);
-            loreGenerator.makeLore(items.armor[3]);
+        if(activePet) {
+            activePet.ref.modifyArmor(
+                items.armor.find(a => a.type === 'helmet'),
+                getId(items.armor.find(a => a.type === 'helmet')),
+                items.armor.find(a => a.type === 'chestplate'),
+                getId(items.armor.find(a => a.type === 'chestplate')),
+                items.armor.find(a => a.type === 'leggings'),
+                getId(items.armor.find(a => a.type === 'leggings')),
+                items.armor.find(a => a.type === 'boots'),
+                getId(items.armor.find(a => a.type === 'boots'))
+            )
+            loreGenerator.makeLore(items.armor.find(a => a.type === 'helmet'))
+            loreGenerator.makeLore(items.armor.find(a => a.type === 'chestplate'))
+            loreGenerator.makeLore(items.armor.find(a => a.type === 'leggings'))
+            loreGenerator.makeLore(items.armor.find(a => a.type === 'boots'))
         }
 
         // Apply Lapis Armor full set bonus of +60 HP


### PR DESCRIPTION
fixes #389 

Please note that I removed the check if the user has been offline for at least 7 minutes. I'm not sure why this was implemented in the first place, maybe because if the player is online the armour already has the correct stats? But running it either way doesn't cause any issue so... why not