### PR TITLE
Fix Technoblade PIG+++ color

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -500,7 +500,7 @@ module.exports = {
             result = "S";
         else
             result = "S+";
-        
+
         return result;
     },
 
@@ -551,7 +551,7 @@ module.exports = {
             output.plusColor = rank.plusColor;
         }
 
-        if(output.plusText && module.exports.hasPath(player, 'rankPlusColor'))
+        if(output.plusText && rankName !== 'PIG+++' && module.exports.hasPath(player, 'rankPlusColor'))
             output.plusColor = constants.color_names[player.rankPlusColor];
 
         return output;
@@ -565,7 +565,7 @@ module.exports = {
                 <div class="rank-tag nice-colors-dark">
                     <div class="rank-name" style="background-color: var(--§${rankColor})">${rankText}</div>
                     ${
-                        plusText ? 
+                        plusText ?
                         /*html*/`<div class="rank-plus" style="background-color: var(--§${plusColor})">${plusText}</div>`
                         : ''
                     }


### PR DESCRIPTION
fixes #391 

It was broken in PR #372 

While the PR code is correct, it seems like Hypixel ignores `"rankPlusColor": "DARK_PURPLE"` for PIG+++ rank, forcing it to be colour aqua. The old PR moved code that forced the +++ to be aqua into a constants file, and the color now gets overwritten by the `rankPlusColor` value found in the API.

This PR adds a check that ignores the `rankPlusColor` value from the API if the rank is PIG+++. I know it's not a super elegant solution but it's the only rank with this issue.... and only 1 player has it.... so.... 🤷‍♂️ 