### PR TITLE
Update max fairy soul count

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -43,7 +43,7 @@ const rarity_order = ['special', 'mythic', 'legendary', 'epic', 'rare', 'uncommo
 
 const petTiers = ['common', 'uncommon', 'rare', 'epic', 'legendary', 'mythic'];
 
-const MAX_SOULS = 222;
+const MAX_SOULS = 227;
 let TALISMAN_COUNT;
 const level50SkillExp = 55172425;
 const level60SkillExp = 111672425;


### PR DESCRIPTION
There are now 227 fairy souls as of Skyblock 0.11.4