### PR TITLE
spell fix: missing talis to accessories

### DIFF
--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1650,7 +1650,7 @@ const getRarityUpgradeClass = item => {
                                         <div style='background-image: url("<%= talisman.texture_path %>")' class="piece-icon item-icon custom-icon"></div>
                                     </div>
                                 <% } %>
-                                <p class="stat-sub-header">Missing Accessory Upgrades<span data-tippy-content='Missing accessories that are upgrades of a lower tier talisman.<br>s'></span></p>
+                                <p class="stat-sub-header">Missing Accessory Upgrades<span data-tippy-content='Missing accessories that are upgrades of a lower tier talisman.'></span></p>
                                 <% for(const [index, talisman] of calculated.missingTalismans.upgrades.entries()){ %>
                                     <div tabindex="0" data-upgrade-talisman-index="<%= index %>" class="rich-item piece piece-<%= talisman.rarity %>-bg missing-talisman">
                                         <div class="piece-hover-area"></div>

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1640,8 +1640,9 @@ const getRarityUpgradeClass = item => {
                             <% if(items.talismans.length == 1){ %>
                                 <br>
                             <% } %>
-                            <button class="stat-sub-header extender" aria-controls="missing-accessories" aria-expanded="false">Missing Talismans</button>
+                            <button class="stat-sub-header extender" aria-controls="missing-accessories" aria-expanded="false">Missing Accessories</button>
                             <div class="pieces extendable" id="missing-accessories">
+                                <br>
                                 <p class="stat-sub-header">Missing Accessories<span data-tippy-content='Missing accessories that are <b>not</b> upgrades of another talisman.'></span></p>
                                 <% for(const [index, talisman] of calculated.missingTalismans.missing.entries()){ %>
                                     <div tabindex="0" data-missing-talisman-index="<%= index %>" class="rich-item piece piece-<%= talisman.rarity %>-bg missing-talisman">


### PR DESCRIPTION
- "Missing Talismans" -> "Missing Accessories"
- Added a space after expanding the missing accessories

Before:
![image](https://user-images.githubusercontent.com/2744227/117555134-e297a180-b05c-11eb-8a68-f95064b20c1a.png)

After:
![image](https://user-images.githubusercontent.com/2744227/117555141-ee836380-b05c-11eb-86d4-588834337b33.png)
