### PR TITLE
Master Stars

### DIFF
--- a/public/resources/js/stats.js
+++ b/public/resources/js/stats.js
@@ -380,7 +380,7 @@ document.addEventListener('DOMContentLoaded', function(){
             statsContent.setAttribute("data-backpack-item-index", element.getAttribute('data-pet-index'));
 
         itemName.className = `item-name piece-${item.rarity || 'common'}-bg nice-colors-dark`;
-        itemNameContent.innerHTML = item.display_name || 'null';
+        itemNameContent.innerHTML = printItemDisplayName(item) || 'null';
 
         if(element.hasAttribute('data-pet-index'))
             itemNameContent.innerHTML = `[Lvl ${item.level.level}] ${item.display_name}`;
@@ -1042,7 +1042,7 @@ document.addEventListener('DOMContentLoaded', function(){
                 } else {
                     window.removeEventListener('scroll', this._onScroll);
                     scrollToTab();
-                }   
+                }
             }
         }
 
@@ -1056,7 +1056,7 @@ document.addEventListener('DOMContentLoaded', function(){
 
     const scrollMemory = new ScrollMemory();
 
-    const intersectingElements = new Map();    
+    const intersectingElements = new Map();
 
     const sectionObserver = new IntersectionObserver((entries, observer) => {
         for (const entry of entries) {
@@ -1074,7 +1074,7 @@ document.addEventListener('DOMContentLoaded', function(){
                 for (const link of navBarLinks) {
                     if (link.hash === newHash) {
                         link.setAttribute('aria-current', true);
-                        
+
                         if (!scrollMemory.isSmoothScrolling) {
                             scrollToTab(true, link);
                         }
@@ -1208,4 +1208,30 @@ document.addEventListener('DOMContentLoaded', function(){
     window.addEventListener('scroll', onScroll);
 
     setTimeout(resize, 1000);
+
+    function printItemDisplayName(item) {
+        let output = item.display_name
+
+        if (item.tag?.ExtraAttributes?.dungeon_item_level > 0) {
+            const itemLevel = item.tag.ExtraAttributes.dungeon_item_level
+            let newName = item.display_name.replace(/(✪+)/, '%STARS%')
+            let newStars = ''
+
+            switch (itemLevel) {
+                case 6:
+                case 7:
+                case 8:
+                case 9:
+                case 10:
+                    newStars = '⍟'.repeat(itemLevel - 5) + '✪'.repeat(Math.abs(itemLevel - 10))
+                    break;
+                default:
+                    newStars = '✪'.repeat(itemLevel)
+                    break;
+            }
+            output = newName.replace('%STARS%', newStars)
+        }
+
+        return output
+    }
 });

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1137,6 +1137,32 @@ const getRarityUpgradeClass = item => {
     return `piece-rarity-upgrade-${upgrades}`
 }
 
+const printItemDisplayName = item => {
+    let output = item.display_name
+
+    if (item.tag?.ExtraAttributes?.dungeon_item_level > 0) {
+        const itemLevel = item.tag.ExtraAttributes.dungeon_item_level
+        let newName = item.display_name.replace(/(✪+)/, '%STARS%')
+        let newStars = ''
+
+        switch (itemLevel) {
+            case 6:
+            case 7:
+            case 8:
+            case 9:
+            case 10:
+                newStars = '⍟'.repeat(itemLevel - 5) + '✪'.repeat(Math.abs(itemLevel - 10))
+                break;
+            default:
+                newStars = '✪'.repeat(itemLevel)
+                break;
+        }
+        output = newName.replace('%STARS%', newStars)
+    }
+
+    return output
+}
+
 %>
 <!DOCTYPE html>
 <html lang="en">
@@ -1547,7 +1573,7 @@ const getRarityUpgradeClass = item => {
                     <% }else{ %>
                         <% if(items.highest_rarity_sword){ %>
                         <p class="stat-raw-values">
-                            <span class="stat-name">Active Weapon: </span><span class="stat-active-weapon stat-value piece-<%= items.highest_rarity_sword.rarity %>-fg"><%= items.highest_rarity_sword.display_name %></span>
+                            <span class="stat-name">Active Weapon: </span><span class="stat-active-weapon stat-value piece-<%= items.highest_rarity_sword.rarity %>-fg"><%= printItemDisplayName(items.highest_rarity_sword) %></span>
                         </p>
                         <% }else if(items.weapons.length > 0){ %>
                         <p class="stat-raw-values">
@@ -1881,7 +1907,7 @@ const getRarityUpgradeClass = item => {
                         <p class="stat-sub-header">Mining Pickaxes</p>
                         <% if(items.highest_rarity_pickaxe){ %>
                             <p class="stat-raw-values">
-                                <span class="stat-name">Active Pickaxe: </span><span class="stat-active-pickaxe stat-value piece-<%= items.highest_rarity_pickaxe.rarity %>-fg"><%= items.highest_rarity_pickaxe.display_name %></span>
+                                <span class="stat-name">Active Pickaxe: </span><span class="stat-active-pickaxe stat-value piece-<%= items.highest_rarity_pickaxe.rarity %>-fg"><%= printItemDisplayName(items.highest_rarity_pickaxe) %></span>
                             </p>
                         <% }else{ %>
                             <p class="stat-raw-values">
@@ -1936,7 +1962,7 @@ const getRarityUpgradeClass = item => {
                         <p class="stat-sub-header">Farming Hoes</p>
                         <% if(items.highest_rarity_hoe){ %>
                             <p class="stat-raw-values">
-                                <span class="stat-name">Active Hoe: </span><span class="stat-active-hoe stat-value piece-<%= items.highest_rarity_hoe.rarity %>-fg"><%= items.highest_rarity_hoe.display_name %></span>
+                                <span class="stat-name">Active Hoe: </span><span class="stat-active-hoe stat-value piece-<%= items.highest_rarity_hoe.rarity %>-fg"><%= printItemDisplayName(items.highest_rarity_hoe) %></span>
                             </p>
                         <% }else{ %>
                             <p class="stat-raw-values">
@@ -2033,7 +2059,7 @@ const getRarityUpgradeClass = item => {
                         <p class="stat-sub-header">Fishing Rods</p>
                         <% if(items.highest_rarity_rod){ %>
                         <p class="stat-raw-values">
-                            <span class="stat-name">Active Rod: </span><span class="stat-active-rod stat-value piece-<%= items.highest_rarity_rod.rarity %>-fg"><%= items.highest_rarity_rod.display_name %></span>
+                            <span class="stat-name">Active Rod: </span><span class="stat-active-rod stat-value piece-<%= items.highest_rarity_rod.rarity %>-fg"><%= printItemDisplayName(items.highest_rarity_rod) %></span>
                         </p>
                         <% }else if(items.rods.length > 0){ %>
                         <p class="stat-raw-values">


### PR DESCRIPTION
### Absolutely WIP, do not merge.

This is just a proposal for how to implement the master stars (the method, the current function is ugly and needs to be rewritten).
With this proposed way there's a printItemDisplayName() function that can handle the scenario where an item has 6+ stars and convert them to another character (another character is a placeholder, it could be HTML elements to apply css styles, images or svg-fonts).

This solution has the negative aspect of having to copy and paste the function in both `stats.ejs` <-> `stats.js` to keep it always up to date but the positive aspect that it won't add to the backend item object `lib.js -> getItems()`

Another solution could be to add a new property `item.display_name_html` to the item object in the lib.js->getItems() that will be used directly from both `stats.ejs` and `stats.js`