### PR TITLE
lore left justify and pet lore wrap

### DIFF
--- a/public/resources/js/stats.js
+++ b/public/resources/js/stats.js
@@ -406,10 +406,7 @@ document.addEventListener('DOMContentLoaded', function(){
                 throw null;
 
             item.tag.display.Lore.forEach(function(line, index){
-                itemLore.innerHTML += renderLore(line);
-
-                if(index + 1 < item.tag.display.Lore.length)
-                    itemLore.innerHTML += '<br>';
+                itemLore.innerHTML += '<span class="lore-row">' + renderLore(line) + '</span>';
             });
         }catch(e){
 
@@ -439,8 +436,6 @@ document.addEventListener('DOMContentLoaded', function(){
             packContent.appendChild(packIcon);
             packContent.appendChild(packName);
             packContent.appendChild(packAuthor);
-
-            itemLore.appendChild(document.createElement('br'));
 
             itemLore.appendChild(packContent);
         }

--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -1082,7 +1082,6 @@ input[type="search"]::-webkit-search-cancel-button {
     position: fixed;
     right: calc(70vw + 20px);
     background-color: var(--lore_background-hex);
-    text-align: center;
     min-width: 360px;
     width: max-content;
     max-width: min(500px, 100vw - 40px);

--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -1116,7 +1116,6 @@ input[type="search"]::-webkit-search-cancel-button {
         overflow-y: auto;
         overscroll-behavior: contain;
         font-size: 15px;
-        overscroll-behavior-y: contain;
 
         a {
             text-decoration: none;

--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -1170,6 +1170,10 @@ input[type="search"]::-webkit-search-cancel-button {
             display: block;
             min-height: calc(1em * 1.2); // fallback for lh
             min-height: 1lh;
+
+            &.wrap {
+                max-width: 300px;
+            }
         }
     }
 

--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -1167,6 +1167,12 @@ input[type="search"]::-webkit-search-cancel-button {
     .item-lore {
         padding: 25px;
         font-weight: 600;
+
+        .lore-row {
+            display: block;
+            min-height: calc(1em * 1.2); // fallback for lh
+            min-height: 1lh;
+        }
     }
 
     .pack-credit {

--- a/src/constants/petStats.js
+++ b/src/constants/petStats.js
@@ -33,7 +33,7 @@ const symbols = {
 	ferocity: "⫽",
 	ability_damage: "✹",
 	mining_speed: "↑",
-    fortune: "☘",
+	fortune: "☘",
 }
 
 class Pet {
@@ -257,9 +257,9 @@ class Elephant extends Pet {
 			let mult = 0.01;
 			stats['health'] += round(this.level * mult * stats['defense'] / 10, 1);
 		}
-        if (this.rarity > 3) {
-            stats['farming fortune'] += round(this.level * 0.5)
-        }
+		if (this.rarity > 3) {
+			stats['farming fortune'] += round(this.level * 0.5)
+		}
 	}
 }
 
@@ -362,12 +362,12 @@ Mining Pets
 
 class Bat extends Pet {
 	get stats() {
-        let stats = {
+		let stats = {
 			intelligence: this.level * 1,
 			speed: this.level * 0.05
 		};
-        if (this.rarity > 4)
-            stats.sea_creature_chance = this.level * 0.05;
+		if (this.rarity > 4)
+			stats.sea_creature_chance = this.level * 0.05;
 		return stats;
 	}
 
@@ -878,8 +878,8 @@ class Ghoul extends Pet {
 	get stats() {
 		return {
 			intelligence: this.level * 0.75,
-            health: this.level * 1,
-            ferocity: this.level * 0.05,
+			health: this.level * 1,
+			ferocity: this.level * 0.05,
 		};
 	}
 
@@ -1103,7 +1103,7 @@ class Hound extends Pet {
 		return {
 			strength: this.level * 0.4,
 			bonus_attack_speed: this.level * 0.15,
-            ferocity: this.level * 0.05,
+			ferocity: this.level * 0.05,
 		};
 	}
 
@@ -1223,7 +1223,7 @@ class Phoenix extends Pet {
 
 	get abilities() {
 		let list = [this.first, this.second];
-		if (this.rarity > 3){
+		if (this.rarity > 3) {
 			list.push(this.third);
 			list.push(this.fourth);
 		}
@@ -1268,8 +1268,8 @@ class Pigman extends Pet {
 	get stats() {
 		return {
 			strength: this.level * 0.5,
-            defense: this.level * 0.5,
-            ferocity: this.level * 0.05,
+			defense: this.level * 0.5,
+			ferocity: this.level * 0.05,
 		};
 	}
 
@@ -1979,17 +1979,17 @@ class Monkey extends Pet {
 
 	modifyStats(stats) {
 		let mult = this.rarity > 2 ? 0.6 : this.rarity > 0 ? 0.5 : 0.4;
-        if (this.rarity > 3) {
-            stats['foraging fortune'] += round(this.level * mult)
-        }
+		if (this.rarity > 3) {
+			stats['foraging fortune'] += round(this.level * mult)
+		}
 	}
 }
 
 class Ocelot extends Pet {
 	get stats() {
 		return {
-            speed: this.level * 0.5,
-            ferocity: this.level * 0.1,
+			speed: this.level * 0.5,
+			ferocity: this.level * 0.1,
 		};
 	}
 
@@ -2253,8 +2253,8 @@ class Megalodon extends Pet {
 	get stats() {
 		return {
 			strength: this.level * 0.5,
-            magic_find: this.level * 0.1,
-            ferocity: this.level * 0.05,
+			magic_find: this.level * 0.1,
+			ferocity: this.level * 0.05,
 		};
 	}
 
@@ -2512,8 +2512,8 @@ class Jerry extends Pet {
 		let list = [this.first, this.second];
 		if (this.rarity > 3)
 			list.push(this.third);
-        if (this.rarity > 4)
-            list.push(this.fourth);
+		if (this.rarity > 4)
+			list.push(this.fourth);
 		return list;
 	}
 
@@ -2644,8 +2644,8 @@ module.exports = {
 		//Alchemy
 		'Jellyfish': Jellyfish,
 		'Parrot': Parrot,
-        'Sheep': Sheep,
-        //Enchanting
+		'Sheep': Sheep,
+		//Enchanting
 		'Guardian': Guardian,
 		//Other
 		'???': QuestionMark,

--- a/src/lib.js
+++ b/src/lib.js
@@ -2745,10 +2745,7 @@ module.exports = {
             pet.lore = '';
 
             for(const [index, line] of lore.entries()){
-                pet.lore += helper.renderLore(line);
-
-                if(index < lore.length)
-                    pet.lore += '<br>';
+                pet.lore += '<span class="lore-row">' + helper.renderLore(line) + '</span>';
             }
 
             pet.display_name = `${petName}${petSkin ? ' ✦' : ''}`;

--- a/src/lib.js
+++ b/src/lib.js
@@ -2745,7 +2745,7 @@ module.exports = {
             pet.lore = '';
 
             for(const [index, line] of lore.entries()){
-                pet.lore += '<span class="lore-row">' + helper.renderLore(line) + '</span>';
+                pet.lore += '<span class="lore-row wrap">' + helper.renderLore(line) + '</span>';
             }
 
             pet.display_name = `${petName}${petSkin ? ' ✦' : ''}`;


### PR DESCRIPTION
This PR left justifies the lore text and stops pet item lore from being too wide.

Before:
![image](https://user-images.githubusercontent.com/44071655/117884352-827e4680-b27a-11eb-95cc-9d56d3a256a5.png)
After:
![image](https://user-images.githubusercontent.com/44071655/117884310-78f4de80-b27a-11eb-884d-9bbfbf8cd64e.png)
