### PR TITLE
lazy load enable api video

### DIFF
--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1204,7 +1204,7 @@ const getRarityUpgradeClass = item => {
 <body class="page-stats">
     <%- include('../includes/header') %>
     <div id="dimmer">
-        <video id="enable_api" loop>
+        <video preload="none" id="enable_api" loop>
             <source type="video/webm" src="/resources/video/enable_api.webm"></source>
             <source type="video/mp4" src="/resources/video/enable_api.mp4"></source>
         </video>


### PR DESCRIPTION
the video that shows how to use the api is downloaded every time a user visits the site but this PR makes it so that the video is only downloaded when the user wants to watch the video