### PR TITLE
fix light theme bonus divider

### DIFF
--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -1697,7 +1697,7 @@ a.additional-player-stat:hover {
 }
 
 .bonus-divider {
-    color: rgb(255 255 255 / 60%);
+    color: rgba(var(--text-rgb),.6);
     font-weight: bold;
 }
 


### PR DESCRIPTION
## before:
![image](https://user-images.githubusercontent.com/44071655/119441330-f812f980-bcf3-11eb-865e-b001b222691e.png)
## after:
![image](https://user-images.githubusercontent.com/44071655/119441302-e9c4dd80-bcf3-11eb-85b9-5b085942f513.png)
