### PR TITLE
Add mythic enderman pet

### DIFF
--- a/src/constants/petStats.js
+++ b/src/constants/petStats.js
@@ -876,6 +876,14 @@ class Enderman extends Pet {
 			desc: [`§7Increases your odds to find a special Zealot by §a${round(this.level * mult, 1)}%.`]
 		};
 	}
+
+	get fourth() {
+		let mult = 0.4;
+		return {
+			name: "§6Enderman Slayer",
+			desc: [`§7Gain +§a${round(this.level * mult, 1)}% §7more combat xp from endermen`]
+		};
+	}
 }
 
 class Ghoul extends Pet {

--- a/src/constants/petStats.js
+++ b/src/constants/petStats.js
@@ -850,6 +850,8 @@ class Enderman extends Pet {
 			list.push(this.second);
 		if (this.rarity > 3)
 			list.push(this.third);
+		if (this.rarity > 4)
+			list.push(this.fourth);
 		return list;
 	}
 


### PR DESCRIPTION
Added the enderman pet's mythic ability which grants 0.4% more combat xp from endermen per level. "xp" and "endermen" are not capitalized in the ability in game.