### PR TITLE
Enderman slayer fix and `.narrow-info-container` refactor

### DIFF
--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -2633,10 +2633,11 @@ a.additional-player-stat:hover {
     padding-bottom: 30px;
 }
 
-.slayer-containers {
-    content-visibility: auto;
-    contain-intrinsic-size: 230px 424px;
-}
+// TODO do this after Average Drops is or isn't removed
+// .slayer-containers .narrow-info-container {
+//     content-visibility: auto;
+//     contain-intrinsic-size: ;
+// }
 
 .slayer-header {
     text-align: center;

--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -2604,20 +2604,20 @@ a.additional-player-stat:hover {
     background-image: url(/resources/img/icons/google-sheets.svg);
 }
 
+.narrow-info-container-wrapper {
+    display: flex;
+    gap: 20px;
+    flex-wrap: wrap;
+}
+
 .narrow-info-container {
     position: relative;
     min-width: 330px;
     padding: 20px;
     padding-top: 50px;
-    display: inline-block;
     background-color: rgba(var(--background-rgb), 0.3);
-    vertical-align: top;
     border-radius: 10px;
     overflow: hidden;
-
-    &:not(:last-of-type) {
-        margin-inline-end: 20px;
-    }
 }
 
 .race-containers .narrow-info-container {
@@ -2630,17 +2630,10 @@ a.additional-player-stat:hover {
 }
 
 .stat-dungeons .narrow-info-container {
-    min-width: 270px;
     padding-bottom: 30px;
-    margin: 10px;
-}
-
-.narrow-info-container.top-deaths {
-    margin-bottom: 15px;
 }
 
 .slayer-containers {
-    white-space: nowrap;
     content-visibility: auto;
     contain-intrinsic-size: 230px 424px;
 }
@@ -3701,10 +3694,8 @@ body {
         width: calc(100vw / 3 - 85px);
     }
 
-    .slayer-containers,
-    .race-containers,
-    .floor-containers {
-        white-space: nowrap;
+    .narrow-info-container-wrapper {
+        flex-wrap: nowrap;
         overflow-x: auto;
         margin-left: calc(-1 * var(--padding));
         margin-right: calc(-1 * var(--padding));
@@ -3715,6 +3706,15 @@ body {
         }
         > :last-child {
             margin-inline-end: var(--padding);
+        }
+        // because margin-inline-end gets eaten by the scroll container sometimes
+        &::after {
+            content: "";
+            position: relative;
+            flex-shrink: 0;
+            height: 1px;
+            width: 1px;
+            right: 21px; // compensate for the width and the gap
         }
     }
 }
@@ -3770,16 +3770,6 @@ body {
 
     .sea-creature-name {
         white-space: break-spaces;
-    }
-
-    .top-deaths {
-        margin-left: 0;
-        margin-top: 25px;
-    }
-
-    .stat-misc .kills-deaths-container .narrow-info-container {
-        width: calc(100vw - 60px);
-        margin-left: 0 !important;
     }
 
     .social-button.patreon {
@@ -3908,9 +3898,7 @@ body {
         transform: translate(-50%, -50%) scale(0.25);
     }
 
-    .slayer-containers,
-    .race-containers,
-    .floor-containers {
+    .narrow-info-container-wrapper {
         scroll-snap-type: x proximity;
 
         > * {
@@ -4002,14 +3990,11 @@ body {
         min-height: 100vh;
     }
 
-    .slayer-containers,
-    .race-containers,
-    .floor-containers {
+    .narrow-info-container-wrapper {
         scroll-snap-type: x mandatory;
     }
 
-    .slayer-containers > *,
-    .race-containers > * {
+    .narrow-info-container-wrapper:not(.floor-containers) > * {
         scroll-snap-stop: always;
     }
 }

--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -2612,7 +2612,8 @@ a.additional-player-stat:hover {
 
 .narrow-info-container {
     position: relative;
-    min-width: 330px;
+    box-sizing: border-box;
+    min-width: min(330px, 100vw);
     padding: 20px;
     padding-top: 50px;
     background-color: rgba(var(--background-rgb), 0.3);
@@ -2621,11 +2622,10 @@ a.additional-player-stat:hover {
 }
 
 .race-containers .narrow-info-container {
-    min-width: 230px;
+    min-width: 270px;
 }
 
 .stat-slayer .narrow-info-container {
-    min-width: 290px;
     padding-bottom: 30px;
 }
 
@@ -3720,10 +3720,6 @@ body {
 }
 
 @media (max-width: 800px) {
-    .stat-misc .kills-deaths-container .narrow-info-container {
-        min-width: auto;
-        width: 100%;
-    }
 
     .stat-header {
         padding-left: 0;

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -2172,7 +2172,7 @@ const getRarityUpgradeClass = item => {
 
                     <% const enchanting = calculated.enchanting; %>
                     <button class="stat-sub-header extender" aria-controls="Experiments" aria-expanded="false">Experiments</button>
-                    <div class="stat-experiments floor-containers extendable" id="Experiments">
+                    <div class="stat-experiments extendable narrow-info-container-wrapper" id="Experiments">
                         <% for(let game in enchanting.experiments){
                         const game_data = enchanting.experiments[game]; %>
                         <div class="narrow-info-container">
@@ -2267,7 +2267,7 @@ const getRarityUpgradeClass = item => {
                         </span>
                     </p>
 
-                    <div class="floor-containers">
+                    <div class="floor-containers narrow-info-container-wrapper">
                         <% for (let [id, floor] of Object.entries(calculated.dungeons.catacombs.floors)) { %>
                         <div class="narrow-info-container">
                             <div class="narrow-info-header">
@@ -2330,7 +2330,7 @@ const getRarityUpgradeClass = item => {
                         <span class="stat-name">Highest Floor Beaten: </span><span class="stat-value"><%= helper.titleCase(calculated.dungeons.master_catacombs.highest_floor.replace("_", " ")) %></span><br>
                     </p>
 
-                    <div class="floor-containers">
+                    <div class="floor-containers narrow-info-container-wrapper">
                         <% for (let [id, floor] of Object.entries(calculated.dungeons.master_catacombs.floors)) { %>
                         <div class="narrow-info-container">
                             <div class="narrow-info-header">
@@ -2440,7 +2440,7 @@ const getRarityUpgradeClass = item => {
                         <% } %>
                         "><span class="stat-name">Total Slayer XP: </span><span class="stat-value"><%= calculated.slayer_xp.toLocaleString() %></span></span>
                     </p>
-                    <div class="slayer-containers">
+                    <div class="slayer-containers narrow-info-container-wrapper">
                     <%
                     let maxSlayerLevel = 0;
                     let unclaimedRewards = false;
@@ -2722,7 +2722,7 @@ const getRarityUpgradeClass = item => {
                         <span class="stat-name">Total Kills: </span><span class="stat-value"><%= calculated.kills.map(a => a.amount).reduce((a, b) => a + b, 0).toLocaleString() %></span><br>
                         <span class="stat-name">Total Deaths: </span><span class="stat-value"><%= calculated.deaths.map(a => a.amount).reduce((a, b) => a + b, 0).toLocaleString() %></span><br>
 
-                        <div class="kills-deaths-container">
+                        <div class="kills-deaths-container narrow-info-container-wrapper">
                             <div class="narrow-info-container top-kills">
                                 <div class="narrow-info-header">Kills</div>
                                 <div class="narrow-info-content">
@@ -2779,7 +2779,7 @@ const getRarityUpgradeClass = item => {
                             <span class="stat-name"><%= raceName %>: </span><span class="stat-value"><%= raceDuration %></span><br>
                             <% } %>
                         </p>
-                        <div class="race-containers">
+                        <div class="race-containers narrow-info-container-wrapper">
                             <%
                             const races = [
                                 { id: "dungeon_hub_crystal_core", name: "Crystal Core", icon: '399_0' },

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1084,7 +1084,7 @@ const slayerEmojis = {
     zombie: "🧟",
     spider: "🕸️",
     wolf: "🐺",
-    enderman: "?"
+    enderman: "🔮"
 };
 
 if('levels' in calculated){

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -2457,10 +2457,6 @@ const getRarityUpgradeClass = item => {
 
                     for(const slayerName of Object.keys(calculated.slayers).sort((a, b) => slayerOrder.indexOf(a) - slayerOrder.indexOf(b))){
 
-                        // Disabled the Enderman slayer tab because Nate needs to look at this CSS.
-                        if(slayerName === "enderman")
-                            continue;
-
                         const slayer = calculated.slayers[slayerName];
 
                         if(slayer.xp === undefined || slayer.xp == 0)

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -189,7 +189,7 @@ const slayerInfo = {
     },
     enderman: {
         boss: 'Voidgloom Seraph',
-        head: '/head/908fc34531f652f5be7f27e4b27429986256ac422a8fb59f6d405b5c85c76f7',
+        head: '/head/1b09a3752510e914b0bdc9096b392bb359f7a8e8a9566a02e7f66faff8d6f89e',
         drops: []
     }
 };


### PR DESCRIPTION
this PR refactors how `.narrow-info-container` layout works and cleans up the enderman slayer a bit