### PR TITLE
remove slayer drops

### DIFF
--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -1675,8 +1675,7 @@ a.additional-player-stat:hover {
     color: var(--gold-hex) !important;
 }
 
-.stat-name.golden-text,
-.slayer-section-header.golden-text {
+.stat-name.golden-text {
     color: var(--maxed-hex) !important;
 }
 
@@ -2639,13 +2638,12 @@ a.additional-player-stat:hover {
 //     contain-intrinsic-size: ;
 // }
 
-.slayer-header {
-    text-align: center;
-    vertical-align: middle;
-    position: relative;
-    height: 32px;
-    font-weight: 600;
-    margin-bottom: 15px;
+.slayer {
+    display: flex;
+    flex-direction: column;
+    * {
+        flex: 0 0;
+    }
 }
 
 .slayer-icon {
@@ -2675,14 +2673,6 @@ a.additional-player-stat:hover {
     vertical-align: middle;
 }
 
-.slayer-section-header {
-    margin-top: 25px;
-    text-align: center;
-    font-weight: 600;
-    text-transform: capitalize;
-    color: rgba(var(--text-rgb), 0.8);
-}
-
 .narrow-info-section-header {
     font-weight: 700;
     text-transform: capitalize;
@@ -2693,6 +2683,7 @@ a.additional-player-stat:hover {
 
 .slayer-kills {
     display: flex;
+    margin-bottom: 1em;
 }
 
 .slayer-kill {
@@ -2710,6 +2701,12 @@ a.additional-player-stat:hover {
     margin-top: 5px;
     height: 20px;
     line-height: 20px;
+
+
+    margin-top: auto;
+    & + .slayer-level {
+        margin-top: 0;
+    }
 }
 
 .tier-name {
@@ -2721,6 +2718,11 @@ a.additional-player-stat:hover {
 
 .tier-kills {
     font-weight: 600;
+}
+
+.slayer-level {
+    align-self: center;
+    margin-top: auto;
 }
 
 .slayer-bar {

--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -2675,11 +2675,8 @@ a.additional-player-stat:hover {
     vertical-align: middle;
 }
 
-.slayer-section-header:not(:nth-child(2)) {
-    margin-top: 25px;
-}
-
 .slayer-section-header {
+    margin-top: 25px;
     text-align: center;
     font-weight: 600;
     text-transform: capitalize;
@@ -2724,37 +2721,6 @@ a.additional-player-stat:hover {
 
 .tier-kills {
     font-weight: 600;
-}
-
-.slayer-drops {
-    margin-top: 10px;
-    height: 160px;
-    display: flex;
-    flex-direction: column;
-}
-
-.slayer-drop {
-    position: relative;
-    padding-left: 36px;
-    box-sizing: border-box;
-    line-height: 2.5;
-    height: 40px;
-
-    .stat-value {
-        display: inline-block;
-        vertical-align: middle;
-        margin-left: 5px;
-    }
-}
-
-.slayer-drop-icon {
-    filter: drop-shadow(2px 2px 2px rgba(0, 0, 0, 0.4));
-    transform: scale(0.25) translateY(-50%);
-    transform-origin: top left;
-    display: inline-block;
-    position: absolute;
-    left: 0;
-    top: 50%;
 }
 
 .slayer-bar {
@@ -3481,16 +3447,6 @@ body {
 
     #skin_display_mobile {
         display: initial;
-    }
-
-    .slayer-drop .stat-name {
-        max-width: calc(100% - 95px);
-        display: inline-block;
-        overflow: hidden;
-        overflow: clip;
-        vertical-align: middle;
-        text-overflow: ellipsis;
-        white-space: nowrap;
     }
 }
 

--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -2682,14 +2682,13 @@ a.additional-player-stat:hover {
 }
 
 .slayer-kills {
-    display: flex;
+    display: grid;
+    grid-template-columns: repeat( auto-fit, 64px );
+    justify-content: center;
+    gap: 10px;
     margin-bottom: 1em;
-}
-
-.slayer-kill {
-    flex-grow: 1;
-    flex-basis: 0;
     text-align: center;
+
 }
 
 .slayer-unclaimed {

--- a/src/constants/misc.js
+++ b/src/constants/misc.js
@@ -252,6 +252,7 @@ module.exports = {
     },
 
     mob_names: {
+        pond_squid: "Squid",
         unburried_zombie: "Crypt Ghoul",
         zealot_enderman: "Zealot",
         invisible_creeper: "Sneaky Creeper",

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1746,15 +1746,12 @@ const getRarityUpgradeClass = item => {
                     <div class="slayer-containers narrow-info-container-wrapper">
                     <%
                     let maxSlayerLevel = 0;
-                    let unclaimedRewards = false;
 
                     for(const slayerName in calculated.slayers){
                         const slayer = calculated.slayers[slayerName];
 
                         if(slayer.level.progress >= 1 && slayer.level.currentLevel < slayer.level.maxLevel){
                             slayer.level.unclaimed = true;
-
-                            unclaimedRewards = true;
                         }
                     }
 
@@ -1776,23 +1773,21 @@ const getRarityUpgradeClass = item => {
                             totalKills += slayer.kills[tier];
 
                         %>
-                        <div class="narrow-info-container slayer-<%= slayerName %>">
-                            <div class="narrow-info-header"><%= slayerName %></div>
-                            <div class="slayer-section">
-                                <div class="slayer-header">
-                                    <div class="slayer-icon" style="background-image:url(<%= slayerInfo[slayerName].head %>)"></div>
-                                    <span><%= slayerInfo[slayerName].boss %> <span class="grey-text">x<%= totalKills %></span>
-                                </div>
-                                <div class="slayer-kills">
-                                    <% for(const [index, tier] of Object.keys(slayer.kills).entries()){ %>
-                                        <div class="slayer-kill"><div class="tier-name">Tier <%= romanize(tier) %></div><div class="tier-kills"><%= slayer.kills[tier].toLocaleString() %></div></div>
-                                    <% } %>
-                                </div>
+                        <div class="narrow-info-container slayer">
+                            <div class="narrow-info-header">
+                                <div class="floor-icon" style="background-image: url(<%= slayerInfo[slayerName].head %>)"></div>
+                                <span><%= slayerInfo[slayerName].boss %></span>
                             </div>
-                            <% max = slayer.level.currentLevel == slayer.level.maxLevel ? 'golden-text' : '' %><div class="slayer-section-header <%= max %>"><%= slayerName %> Level <span class="white-text <%= max %>"><%= slayer.level.currentLevel %></span></div>
-                            <% if(unclaimedRewards){ %>
-                                <div class="slayer-unclaimed"><%= slayer.level.unclaimed ? 'unclaimed slayer rewards!' : '' %></div>
+                            <div class="slayer-kills">
+                                <% for(const [index, tier] of Object.keys(slayer.kills).entries()){ %>
+                                    <div class="slayer-kill"><div class="tier-name">Tier <%= romanize(tier) %></div><div class="tier-kills"><%= slayer.kills[tier].toLocaleString() %></div></div>
+                                <% } %>
+                                <div class="slayer-kill"><div class="tier-name">Total</div><div class="tier-kills"><%= totalKills.toLocaleString() %></div></div>
+                            </div>
+                            <% if(slayer.level.unclaimed){ %>
+                                <div class="slayer-unclaimed">unclaimed slayer rewards!</div>
                             <% } %>
+                            <% max = slayer.level.currentLevel == slayer.level.maxLevel ? 'golden-text' : '' %><span class="<%= max %> stat-name slayer-level"><%= slayerName %> level <span class="stat-value <%= max %>"><%= slayer.level.currentLevel %></span></span>
                             <div class="slayer-bar <%= slayer.level.currentLevel == slayer.level.maxLevel ? 'maxed-slayer' : ''%>">
                                 <div class="skill-progress-bar slayer-progress-bar" style="--progress: <%= slayer.level.currentLevel == slayer.level.maxLevel ? 1 : slayer.level.progress %>"></div>
                                 <div class="skill-progress-text slayer-progress-text">

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -102,629 +102,84 @@ const seaCreatures = [
     {
         name: 'Squid',
         id: 'pond_squid',
-        rarity: 'common',
-        fishingLevel: 1,
-        level: 1,
-        hp: 120,
-        xp: 30,
-        drops: [
-            {
-                rarity: 'common',
-                name: 'Lily Pad'
-            }, {
-                rarity: 'common',
-                name: 'Ink Sac'
-            }
-        ]
     }, {
         name: 'Sea Walker',
         id: 'sea_walker',
-        rarity: 'common',
-        fishingLevel: 2,
-        level: 4,
-        hp: 750,
-        xp: 50,
-        drops: [
-            {
-                rarity: 'common',
-                name: 'Lily Pad'
-            }, {
-                rarity: 'common',
-                name: 'Raw Fish'
-            }, {
-                rarity: 'common',
-                name: 'Rotten Flesh'
-            }
-        ]
     }, {
         name: 'Night Squid',
         id: 'night_squid',
-        rarity: 'common',
-        fishingLevel: 3,
-        level: 6,
-        hp: 250,
-        xp: 200,
-        requirements: [
-            'Dark Bait',
-            'Night Time (6:00pm - 6:00am)'
-        ],
-        drops: [
-            {
-                rarity: 'common',
-                name: 'Lily Pad'
-            }, {
-                rarity: 'common',
-                name: 'Ink Sac'
-            }, {
-                rarity: 'uncommon',
-                name: 'Squid Boots'
-            }
-        ]
     }, {
         name: 'Frozen Steve',
         id: 'frozen_steve',
-        rarity: 'common',
-        fishingLevel: 4,
-        level: 7,
-        hp: 700,
-        xp: 80,
-        requirements: [
-            'Jerry Pond'
-        ],
-        drops: [
-            {
-                rarity: 'common',
-                name: 'Ice'
-            }, {
-                rarity: 'common',
-                name: 'Lily Pad'
-            }, {
-                rarity: 'common',
-                name: 'Pufferfish'
-            }, {
-                rarity: 'common',
-                name: 'Raw Fish'
-            }, {
-                rarity: 'common',
-                name: 'Raw Salmon'
-            }, {
-                rarity: 'common',
-                name: 'White Gift'
-            }, {
-                rarity: 'uncommon',
-                name: 'Hunk of Ice'
-            }, {
-                rarity: 'rare',
-                name: 'Ice Rod'
-            }
-        ]
     }, {
         name: 'Nurse Shark',
         id: 'nurse_shark',
-        rarity: 'special',
-        fishingLevel: 5,
-        level: 6,
-        drops: [
-            {
-                rarity: 'uncommon',
-                name: 'Nurse Shark Tooth'
-            }, {
-                rarity: 'rare',
-                name: 'Shark Fin'
-            }
-        ]
     }, {
         name: 'Sea Guardian',
         id: 'sea_guardian',
-        rarity: 'common',
-        fishingLevel: 5,
-        level: 10,
-        hp: 2500,
-        xp: 75,
-        drops: [
-            {
-                rarity: 'common',
-                name: 'Lily Pad'
-            }, {
-                rarity: 'common',
-                name: 'Prismarine Shard'
-            }, {
-                rarity: 'common',
-                name: 'Prismarine Crystals'
-            }, {
-                rarity: 'common',
-                name: 'Sea Lantern'
-            }
-        ]
     }, {
         name: 'Frosty the Snowman',
         id: 'frosty_the_snowman',
-        rarity: 'common',
-        fishingLevel: 6,
-        level: 13,
-        hp: 5000,
-        xp: 165,
-        requirements: [
-            'Jerry Pond'
-        ],
-        drops: [
-            {
-                rarity: 'common',
-                name: 'Ice'
-            }, {
-                rarity: 'common',
-                name: 'Lily Pad'
-            }, {
-                rarity: 'common',
-                name: 'Carrot'
-            }, {
-                rarity: 'common',
-                name: 'Raw Fish'
-            }, {
-                rarity: 'common',
-                name: 'Snow Block'
-            }, {
-                rarity: 'common',
-                name: 'Sponge'
-            }, {
-                rarity: 'common',
-                name: 'White Gift'
-            }, {
-                rarity: 'uncommon',
-                name: 'Hunk of Ice'
-            }
-        ]
     }, {
         name: 'Sea Witch',
         id: 'sea_witch',
-        rarity: 'uncommon',
-        fishingLevel: 7,
-        level: 15,
-        hp: 2700,
-        xp: 250,
-        requirements: [
-            'Light Bait',
-            'Day Time (6:00am - 6:00pm)'
-        ],
-        drops: [
-            {
-                rarity: 'common',
-                name: 'Lily Pad'
-            }, {
-                rarity: 'common',
-                name: 'Clownfish'
-            }, {
-                rarity: 'common',
-                name: 'Raw Salmon'
-            }, {
-                rarity: 'rare',
-                name: 'Fairy Armor'
-            }
-        ]
     }, {
         name: 'Scarecrow',
         id: 'scarecrow',
-        rarity: 'rare',
-        fishingLevel: 9,
-        level: 9,
-        requirements: [
-            'Spooky Festival'
-        ]
     }, {
         name: 'Sea Archer',
         id: 'sea_archer',
-        rarity: 'uncommon',
-        fishingLevel: 9,
-        level: 15,
-        hp: 3000,
-        xp: 125,
-        drops: [
-            {
-                rarity: 'common',
-                name: 'Lily Pad'
-            }, {
-                rarity: 'common',
-                name: 'Raw Fish'
-            }, {
-                rarity: 'common',
-                name: 'Bone'
-            }, {
-                rarity: 'uncommon',
-                name: 'Enchanted Bone'
-            }
-        ]
     }, {
         name: 'Blue Shark',
         id: 'blue_shark',
-        rarity: 'special',
-        fishingLevel: 10,
-        level: 20,
-        drops: [
-            {
-                rarity: 'rare',
-                name: 'Blue Shark Tooth'
-            }, {
-                rarity: 'rare',
-                name: 'Shark Fin'
-            }
-        ]
     }, {
         name: 'Monster of the Deep',
         id: 'monster_of_the_deep',
-        rarity: 'uncommon',
-        fishingLevel: 11,
-        level: 20,
-        hp: 5000,
-        xp: 200,
-        drops: [
-            {
-                rarity: 'common',
-                name: 'Lily Pad'
-            }, {
-                rarity: 'common',
-                name: 'Sponge'
-            }, {
-                rarity: 'common',
-                name: 'Dark Bait'
-            }, {
-                rarity: 'common',
-                name: 'Enchanted Book (Magnet 6)'
-            }, {
-                rarity: 'uncommon',
-                name: 'Enchanted Rotten Flesh'
-            }, {
-                rarity: 'common',
-                name: 'Enchanted Feather'
-            }
-        ]
     }, {
         name: 'Grinch',
         id: 'grinch',
-        rarity: 'uncommon',
-        fishingLevel: 13,
-        level: 21,
-        hp: 10,
-        xp: 300,
-        requirements: [
-            'Jerry Pond'
-        ],
-        drops: [
-            {
-                rarity: 'common',
-                name: 'White Gift'
-            }, {
-                rarity: 'uncommon',
-                name: 'Green Gift'
-            }
-        ]
     }, {
         name: 'Catfish',
         id: 'catfish',
-        rarity: 'rare',
-        fishingLevel: 13,
-        level: 23,
-        hp: 6000,
-        xp: 300,
-        drops: [
-            {
-                rarity: 'common',
-                name: 'Lily Pad'
-            }, {
-                rarity: 'common',
-                name: 'Sponge'
-            }, {
-                rarity: 'common',
-                name: 'Pufferfish'
-            }, {
-                rarity: 'common',
-                name: 'Raw Fish'
-            }, {
-                rarity: 'common',
-                name: 'Raw Salmon'
-            }, {
-                rarity: 'common',
-                name: 'Enchanted Book (Frail 6)'
-            }
-        ]
     }, {
         name: 'Nightmare',
         id: 'nightmare',
-        rarity: 'rare',
-        fishingLevel: 14,
-        level: 24,
-        requirements: [
-            'Spooky Festival'
-        ]
     }, {
         name: 'Carrot King',
         id: 'carrot_king',
-        rarity: 'rare',
-        fishingLevel: 15,
-        level: 25,
-        hp: 10000,
-        xp: 610,
-        requirements: [
-            'Carrot Bait'
-        ],
-        drops: [
-            {
-                rarity: 'common',
-                name: 'Lily Pad'
-            }, {
-                rarity: 'common',
-                name: 'Sponge'
-            }, {
-                rarity: 'common',
-                name: 'Enchanted Book (Caster 6)'
-            }, {
-                rarity: 'uncommon',
-                name: 'Rabbit Hat'
-            }, {
-                rarity: 'uncommon',
-                name: 'Enchanted Carrot'
-            }, {
-                rarity: 'rare',
-                name: 'Enchanted Rabbit Foot'
-            }
-        ]
     }, {
         name: 'Sea Leech',
         id: 'sea_leech',
-        rarity: 'rare',
-        fishingLevel: 16,
-        level: 30,
-        hp: 15000,
-        xp: 500,
-        drops: [
-            {
-                rarity: 'common',
-                name: 'Lily Pad'
-            }, {
-                rarity: 'common',
-                name: 'Sponge'
-            }, {
-                rarity: 'common',
-                name: 'Clownfish'
-            }, {
-                rarity: 'common',
-                name: 'Raw Fish'
-            }, {
-                rarity: 'common',
-                name: 'Enchanted Book (Spiked Hook 6)'
-            }
-        ]
     }, {
         name: 'Werewolf',
         id: 'werewolf',
-        rarity: 'epic',
-        fishingLevel: 17,
-        level: 50,
-        requirements: [
-            'Spooky Festival'
-        ]
     }, {
         name: 'Guardian Defender',
         id: 'guardian_defender',
-        rarity: 'epic',
-        fishingLevel: 17,
-        level: 45,
-        hp: 19000,
-        xp: 750,
-        drops: [
-            {
-                rarity: 'common',
-                name: 'Lily Pad'
-            }, {
-                rarity: 'common',
-                name: 'Sponge'
-            }, {
-                rarity: 'common',
-                name: 'Raw Fish'
-            }, {
-                rarity: 'common',
-                name: 'Enchanted Book (Lure 6)'
-            }, {
-                rarity: 'uncommon',
-                name: 'Enchanted Prismarine Shard'
-            }, {
-                rarity: 'uncommon',
-                name: 'Enchanted Prismarine Crystals'
-            }
-        ]
     }, {
         name: 'Deep Sea Protector',
         id: 'deep_sea_protector',
-        rarity: 'epic',
-        fishingLevel: 18,
-        level: 60,
-        hp: 20000,
-        xp: 1000,
-        drops: [
-            {
-                rarity: 'common',
-                name: 'Lily Pad'
-            }, {
-                rarity: 'common',
-                name: 'Sponge'
-            }, {
-                rarity: 'common',
-                name: 'Clownfish'
-            }, {
-                rarity: 'common',
-                name: 'Enchanted Book (Angler 6)'
-            }, {
-                rarity: 'uncommon',
-                name: 'Enchanted Iron'
-            }
-        ]
     }, {
         name: 'Tiger Shark',
         id: 'tiger_shark',
-        rarity: 'special',
-        fishingLevel: 18,
-        level: 50,
-        drops: [
-            {
-                rarity: 'epic',
-                name: 'Tiger Shark Tooth'
-            }, {
-                rarity: 'epic',
-                name: 'Megalodon Pet'
-            }, {
-                rarity: 'rare',
-                name: 'Shark Fin'
-            }
-        ]
     }, {
         name: 'Water Hydra',
         id: 'water_hydra',
-        rarity: 'legendary',
-        fishingLevel: 19,
-        level: 100,
-        hp: 30000,
-        xp: 3000,
-        drops: [
-            {
-                rarity: 'common',
-                name: 'Lily Pad'
-            }, {
-                rarity: 'common',
-                name: 'Sponge'
-            }, {
-                rarity: 'common',
-                name: 'Clownfish'
-            }, {
-                rarity: 'common',
-                name: 'Pufferfish'
-            }, {
-                rarity: 'common',
-                name: 'Raw Fish'
-            }, {
-                rarity: 'common',
-                name: 'Raw Salmon'
-            }, {
-                rarity: 'common',
-                name: 'Enchanted Book (Luck of the Sea 6)'
-            }, {
-                rarity: 'rare',
-                name: 'Fish Affinity Talisman'
-            }, {
-                rarity: 'epic',
-                name: 'Water Hydra Head'
-            }
-        ]
     }, {
         name: 'Sea Emperor',
         id: 'sea_emperor',
-        rarity: 'legendary',
-        fishingLevel: 20,
-        level: 150,
-        hp: 30000,
-        xp: 2500,
-        drops: [
-            {
-                rarity: 'common',
-                name: 'Lily Pad'
-            }, {
-                rarity: 'common',
-                name: 'Sponge'
-            }, {
-                rarity: 'common',
-                name: 'Raw Fish'
-            }, {
-                rarity: 'uncommon',
-                name: 'Enchanted Lily Pad'
-            }, {
-                rarity: 'uncommon',
-                name: 'Enchanted Prismarine Shard'
-            }, {
-                rarity: 'uncommon',
-                name: 'Enchanted Prismarine Crystals'
-            }, {
-                rarity: 'rare',
-                name: 'Emperor\'s Skull'
-            }, {
-                rarity: 'legendary',
-                name: 'Shredder'
-            }, {
-                rarity: 'special',
-                name: 'Flying Fish'
-            }
-        ]
     }, {
         name: 'Phantom Fisherman',
         id: 'phantom_fisherman',
-        rarity: 'legendary',
-        fishingLevel: 21,
-        level: 160,
-        requirements: [
-            'Spooky Festival'
-        ]
     }, {
         name: 'Great White Shark',
         id: 'great_white_shark',
-        rarity: 'special',
-        fishingLevel: 24,
-        level: 180,
-        drops: [
-            {
-                rarity: 'legendary',
-                name: 'Great White Shark Tooth'
-            }, {
-                rarity: 'legendary',
-                name: 'Megalodon Pet'
-            }, {
-                rarity: 'rare',
-                name: 'Shark Fin'
-            }
-        ]
     }, {
         name: 'Yeti',
         id: 'yeti',
-        rarity: 'legendary',
-        fishingLevel: 25,
-        level: 175,
-        hp: 300000,
-        xp: 3000,
-        drops: [
-            {
-                rarity: 'common',
-                name: 'Ice'
-            }, {
-                rarity: 'common',
-                name: 'Lily Pad'
-            }, {
-                rarity: 'common',
-                name: 'Sponge'
-            }, {
-                rarity: 'common',
-                name: 'Raw Fish'
-            }, {
-                rarity: 'uncommon',
-                name: 'Enchanted Lily Pad'
-            }, {
-                rarity: 'rare',
-                name: 'Hunk of Blue Ice'
-            }, {
-                rarity: 'rare',
-                name: 'Red Gift'
-            }, {
-                rarity: 'legendary',
-                name: 'Yeti Rod'
-            }, {
-                rarity: 'legendary',
-                name: 'Hilt of True Ice'
-            }
-        ]
     }, {
         name: 'Grim Reaper',
         id: 'grim_reaper',
-        rarity: 'legendary',
-        fishingLevel: 26,
-        level: 190,
-        requirements: [
-            'Spooky Festival'
-        ]
     }
 ];
 

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -99,88 +99,33 @@ const slayerInfo = {
 };
 
 const seaCreatures = [
-    {
-        name: 'Squid',
-        id: 'pond_squid',
-    }, {
-        name: 'Sea Walker',
-        id: 'sea_walker',
-    }, {
-        name: 'Night Squid',
-        id: 'night_squid',
-    }, {
-        name: 'Frozen Steve',
-        id: 'frozen_steve',
-    }, {
-        name: 'Nurse Shark',
-        id: 'nurse_shark',
-    }, {
-        name: 'Sea Guardian',
-        id: 'sea_guardian',
-    }, {
-        name: 'Frosty the Snowman',
-        id: 'frosty_the_snowman',
-    }, {
-        name: 'Sea Witch',
-        id: 'sea_witch',
-    }, {
-        name: 'Scarecrow',
-        id: 'scarecrow',
-    }, {
-        name: 'Sea Archer',
-        id: 'sea_archer',
-    }, {
-        name: 'Blue Shark',
-        id: 'blue_shark',
-    }, {
-        name: 'Monster of the Deep',
-        id: 'monster_of_the_deep',
-    }, {
-        name: 'Grinch',
-        id: 'grinch',
-    }, {
-        name: 'Catfish',
-        id: 'catfish',
-    }, {
-        name: 'Nightmare',
-        id: 'nightmare',
-    }, {
-        name: 'Carrot King',
-        id: 'carrot_king',
-    }, {
-        name: 'Sea Leech',
-        id: 'sea_leech',
-    }, {
-        name: 'Werewolf',
-        id: 'werewolf',
-    }, {
-        name: 'Guardian Defender',
-        id: 'guardian_defender',
-    }, {
-        name: 'Deep Sea Protector',
-        id: 'deep_sea_protector',
-    }, {
-        name: 'Tiger Shark',
-        id: 'tiger_shark',
-    }, {
-        name: 'Water Hydra',
-        id: 'water_hydra',
-    }, {
-        name: 'Sea Emperor',
-        id: 'sea_emperor',
-    }, {
-        name: 'Phantom Fisherman',
-        id: 'phantom_fisherman',
-    }, {
-        name: 'Great White Shark',
-        id: 'great_white_shark',
-    }, {
-        name: 'Yeti',
-        id: 'yeti',
-    }, {
-        name: 'Grim Reaper',
-        id: 'grim_reaper',
-    }
+    'pond_squid',
+    'sea_walker',
+    'night_squid',
+    'frozen_steve',
+    'nurse_shark',
+    'sea_guardian',
+    'frosty_the_snowman',
+    'sea_witch',
+    'scarecrow',
+    'sea_archer',
+    'blue_shark',
+    'monster_of_the_deep',
+    'grinch',
+    'catfish',
+    'nightmare',
+    'carrot_king',
+    'sea_leech',
+    'werewolf',
+    'guardian_defender',
+    'deep_sea_protector',
+    'tiger_shark',
+    'water_hydra',
+    'sea_emperor',
+    'phantom_fisherman',
+    'great_white_shark',
+    'yeti',
+    'grim_reaper',
 ];
 
 const milestone_rarities = ['common', 'uncommon', 'rare', 'epic', 'legendary'];
@@ -1437,10 +1382,10 @@ const getRarityUpgradeClass = item => {
                     <%
                     let totalSeaCreatureKills = 0;
 
-                    for(const creature of seaCreatures){
-                        let mobKills = calculated.kills.filter(a => a.entityId == creature.id);
-
-                        totalSeaCreatureKills += mobKills.length > 0 ? mobKills[0].amount : 0;
+                    for(const creature of calculated.kills){
+                        if(seaCreatures.includes(creature.entityId)) {
+                            totalSeaCreatureKills += creature.amount;
+                        }
                     }
                     %>
 
@@ -1504,20 +1449,19 @@ const getRarityUpgradeClass = item => {
                     <% if(totalSeaCreatureKills > 0){ %>
                         <button class="stat-sub-header extender" aria-controls="missing-seacreatures" aria-expanded="false">Sea Creatures</button>
                         <div class="sea-creatures extendable" id="missing-seacreatures">
-                            <% for(const creature of seaCreatures) {
-                                let mobKills = calculated.kills.filter(a => a.entityId == creature.id);
+                            <% for(const creatureId of seaCreatures) {
+                                const creature = calculated.kills.find(creature => creature.entityId == creatureId);
 
-                                mobKills = mobKills.length > 0 ? mobKills[0].amount : 0;
-
-                                if(mobKills == 0)
-                                    continue;
-                            %>
-                                <div class="sea-creature">
-                                    <div class="sea-creature-name"><span><%= creature.name %></span></div>
-                                    <div class="sea-creature-image" style="background-image: url(/resources/img/sea_creatures/<%= creature.id %>.webp)"></div>
-                                    <div class="sea-creature-kills"><span class="stat-value"><%= mobKills.toLocaleString() %></span><span class="stat-name"> Kill<%= mobKills != 1 ? 's' : '' %></span></div>
-                                </div>
-                            <% } %>
+                                if(creature?.amount > 0 ) {
+                                    %>
+                                    <div class="sea-creature">
+                                        <div class="sea-creature-name"><span><%= creature.entityName %></span></div>
+                                        <div class="sea-creature-image" style="background-image: url(/resources/img/sea_creatures/<%= creature.entityId %>.webp)"></div>
+                                        <div class="sea-creature-kills"><span class="stat-value"><%= creature.amount.toLocaleString() %></span><span class="stat-name"> Kill<%= creature.amount != 1 ? 's' : '' %></span></div>
+                                    </div>
+                                    <%
+                                }
+                            } %>
                         </div>
                     <% } %>
                 </div>

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -83,114 +83,18 @@ const slayerInfo = {
     zombie: {
         boss: 'Revenant Horror',
         head: '/head/1fc0184473fe882d2895ce7cbc8197bd40ff70bf10d3745de97b6c2a9c5fc78f',
-        drops: [
-            {
-                chance: {
-                    4: 42 / 13000
-                },
-                levelReq: 6,
-                name: 'Snake Rune',
-                icon: '/head/2c4a65c689b2d36409100a60c2ab8d3d0a67ce94eea3c1f7ac974fd893568b5d'
-            },
-            {
-                chance: {
-                    4: 21 / 13000
-                },
-                levelReq: 5,
-                name: 'Beheaded Horror',
-                icon: '/head/dbad99ed3c820b7978190ad08a934a68dfa90d9986825da1c97f6f21f49ad626'
-            },
-            {
-                chance: {
-                    4: 7 / 13000
-                },
-                levelReq: 7,
-                name: 'Scythe Blade',
-                id: 264,
-                damage: 0
-            }
-        ]
     },
     spider: {
         boss: 'Tarantula Broodfather',
         head: '/head/9d7e3b19ac4f3dee9c5677c135333b9d35a7f568b63d1ef4ada4b068b5a25',
-        drops: [
-            {
-                chance: {
-                    3: 42 / 130000,
-                    4: 42 / 13000
-                },
-                levelReq: 5,
-                name: 'Fly Swatter',
-                id: 284,
-                damage: 0
-            },
-            {
-                chance: {
-                    3: 21 / 130000,
-                    4: 21 / 13000
-                },
-                levelReq: 6,
-                name: 'Tarantula Talisman',
-                icon: '/head/442cf8ce487b78fa203d56cf01491434b4c33e5d236802c6d69146a51435b03d'
-            },
-            {
-                chance: {
-                    4: 7 / 13000
-                },
-                levelReq: 7,
-                name: 'Digested Mosquitoe',
-                id: 367,
-                damage: 0
-            }
-        ]
     },
     wolf: {
         boss: 'Sven Packmaster',
         head: '/head/f83a2aa9d3734b919ac24c9659e5e0f86ecafbf64d4788cfa433bbec189e8',
-        drops: [
-            {
-                chance: {
-                    4: 42 / 13000
-                },
-                levelReq: 6,
-                name: 'Couture Rune',
-                icon: '/head/734fb3203233efbae82628bd4fca7348cd071e5b7b52407f1d1d2794e31799ff'
-            },
-            {
-                chance: {
-                    3: 15 / 130000,
-                    4: 15 / 13000
-                },
-                levelReq: 5,
-                name: 'Red Claw Egg',
-                id: 383,
-                damage: "0_18"
-            },
-            {
-                chance: {
-                    4: 7 / 13000
-                },
-                levelReq: 7,
-                name: 'Grizzly Bait',
-                id: 349,
-                damage: 1
-            },
-            {
-                chance: {
-                    4: 5 / 13000
-                },
-                levelReq: 7,
-                name: 'Overflux Capacitor',
-                id: 406,
-                damage: 0
-            }
-        ]
     },
     enderman: {
         boss: 'Voidgloom Seraph',
         head: '/head/1b09a3752510e914b0bdc9096b392bb359f7a8e8a9566a02e7f66faff8d6f89e',
-        drops: []
     }
 };
 
@@ -2485,56 +2389,6 @@ const getRarityUpgradeClass = item => {
                                         <div class="slayer-kill"><div class="tier-name">Tier <%= romanize(tier) %></div><div class="tier-kills"><%= slayer.kills[tier].toLocaleString() %></div></div>
                                     <% } %>
                                 </div>
-                            </div>
-                            <div class="slayer-section-header"><span data-tippy-content="Average drops based on Slayer boss kills. The number ranges from 0% Magic Find to 100% Magic Find.">Average Drops</span></div>
-                            <div class="slayer-section slayer-drops">
-                                <%
-                                for(const drop of slayerInfo[slayerName].drops){
-                                    let dropsMin = 0;
-                                    let dropsMax = 0;
-
-                                    if(slayer.level.currentLevel >= drop.levelReq){
-                                        const slayerKills = Object.assign({}, slayer.kills);
-                                        let xpToLevel = constants.slayer_xp[slayerName][drop.levelReq];
-
-                                        for(const tier of Object.keys(slayer.kills).sort((a, b) => a - b)){
-                                            for(let i = slayer.kills[tier]; i > 0; i--){
-                                                xpToLevel -= constants.slayer_boss_xp[tier];
-                                                slayerKills[tier] -= 1;
-
-                                                if(xpToLevel <= 0)
-                                                    break;
-                                            }
-                                        }
-
-                                        for(const tier in drop.chance){
-                                            dropsMin += slayerKills[tier] * drop.chance[tier];
-                                            dropsMax += slayerKills[tier] * drop.chance[tier] * MAX_MAGIC_FIND
-                                        }
-                                    }
-
-                                    if(isNaN(dropsMin))
-                                        dropsMin = 0;
-
-                                    if(isNaN(dropsMax))
-                                        dropsMax = 0;
-
-                                    let dropsText = "";
-
-                                    if(dropsMin == 0)
-                                        dropsText = dropsMin
-                                    else
-                                        dropsText = `${dropsMin.toFixed(2)} - ${dropsMax.toFixed(2)}`;
-                                %>
-                                    <div class="slayer-drop">
-                                        <div class="slayer-drop-icon item-icon
-                                        <% if('icon' in drop){ %>custom-icon<% } %>
-                                        <% if('id' in drop){ %>icon-<%= drop.id %>_<%= drop.damage %><% } %>"
-                                        <% if('icon' in drop){ %> style="background-image: url(<%= drop.icon %>)"<% } %>>
-                                        </div>
-                                        <span class="stat-name"><%= drop.name %>s: </span><span class="stat-value"><%= dropsText %></span>
-                                    </div>
-                                <% } %>
                             </div>
                             <% max = slayer.level.currentLevel == slayer.level.maxLevel ? 'golden-text' : '' %><div class="slayer-section-header <%= max %>"><%= slayerName %> Level <span class="white-text <%= max %>"><%= slayer.level.currentLevel %></span></div>
                             <% if(unclaimedRewards){ %>


### PR DESCRIPTION
This PR does 3 things:
- remove average drops
- refactor slayer styles (using the grid for kills)
- remove unused constants from `stats.ejs`
## Before:
![image](https://user-images.githubusercontent.com/44071655/120874773-37540c80-c576-11eb-91c1-87266601ab7d.png)
## After:
![image](https://user-images.githubusercontent.com/44071655/120874778-40dd7480-c576-11eb-9a67-ce5b9e03636c.png)
