### PR TITLE
fix #501

### DIFF
--- a/src/constants/leaderboards.js
+++ b/src/constants/leaderboards.js
@@ -1,7 +1,6 @@
 const collections = require('./collections');
 const leveling = require('./leveling');
 const moment = require('moment');
-const { getLevelByXp } = require('../lib');
 require('moment-duration-format')(moment);
 
 const defaultOptions = {


### PR DESCRIPTION
this PR fixes #501 by removing a unsed import in leaderboards.js that was causeing `init.js` to require `ioredis`