### PR TITLE
change  name of CI workflow to "CI"

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,5 +1,5 @@
 # This CI Workflow was deployed and configured by WarpWing.
-name: SkyCrypt CI Workflow
+name: CI
 
 on:
   push:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,7 +29,7 @@ jobs:
       - name: es-lint
         run: npm run lint
 
-  pretier:
+  prettier:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,4 +1,4 @@
-# This CI Workflow was deployed and configured by WarpWing.
+# This CI Workflow was deployed and configured by WarpWing and Nate.
 name: CI
 
 on:


### PR DESCRIPTION
the name of the CI workflow is long and redundant this PR shortens it to "CI"

this PR also adds Nate's name to the workflow so you can blame him when it breaks

this PR also fixes the spelling of the prettier job id

before:
![image](https://user-images.githubusercontent.com/44071655/121824105-9c46eb00-cc77-11eb-90c5-0d1aca4fb13a.png)
after:
![image](https://user-images.githubusercontent.com/44071655/121960779-8e0ad480-cd34-11eb-8dc1-db134dd3d8cb.png)
