### PR TITLE
grammer and accesablity

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -25,7 +25,7 @@
         <figure class="banner error">
             <figcaption>Cache Only Mode!</figcaption>
             <p>
-              SkyCrypt is <strong>only</strong> showing the last known state of user's profiles which may be outdated due to an API maintenance.<br>
+              SkyCrypt is <strong>only</strong> showing the last known state of users' profiles which may be outdated due to API maintenance.<br>
               <%# <i>If a profile wasn't viewed/cached before, it can't be viewed.</i><br> %><br>
               For more info about Hypixel outages visit the official <a href="https://status.hypixel.net/" target="_blank" rel="noreferrer"> Hypixel Status</a>.
             </p>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -25,7 +25,7 @@
         <figure class="banner error">
             <figcaption>Cache Only Mode!</figcaption>
             <p>
-              SkyCrypt is <b>only</b> showing the last known state of user's profiles which may be outdated due to an API maintenance.<br>
+              SkyCrypt is <strong>only</strong> showing the last known state of user's profiles which may be outdated due to an API maintenance.<br>
               <%# <i>If a profile wasn't viewed/cached before, it can't be viewed.</i><br> %><br>
               For more info about Hypixel outages visit the official <a href="https://status.hypixel.net/" target="_blank" rel="noreferrer"> Hypixel Status</a>.
             </p>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -26,7 +26,8 @@
             <figcaption>Cache Only Mode!</figcaption>
             <p>
               SkyCrypt is <strong>only</strong> showing the last known state of users' profiles which may be outdated due to API maintenance.<br>
-              <%# <i>If a profile wasn't viewed/cached before, it can't be viewed.</i><br> %><br>
+              <%# <i>If a profile wasn't viewed/cached before, it can't be viewed.</i><br> %>
+              <br>
               For more info about Hypixel outages visit the official <a href="https://status.hypixel.net/" target="_blank" rel="noreferrer"> Hypixel Status</a>.
             </p>
         </figure>

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -549,7 +549,8 @@ const getRarityUpgradeClass = item => {
         <figcaption>Cache Only Mode!</figcaption>
         <p>
           SkyCrypt is <strong>only</strong> showing the last known state of user's profiles which may be outdated due to an API maintenance.<br>
-          <%# <i>If a profile wasn't viewed/cached before, it can't be viewed.</i><br> %><br>
+          <%# <i>If a profile wasn't viewed/cached before, it can't be viewed.</i><br> %>
+          <br>
           For more info about Hypixel outages visit the official <a href="https://status.hypixel.net/" target="_blank" rel="noreferrer"> Hypixel Status</a>.
         </p>
       </figure>

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -548,7 +548,7 @@ const getRarityUpgradeClass = item => {
       <figure class="banner error">
         <figcaption>Cache Only Mode!</figcaption>
         <p>
-          SkyCrypt is <strong>only</strong> showing the last known state of user's profiles which may be outdated due to an API maintenance.<br>
+          SkyCrypt is <strong>only</strong> showing the last known state of user's profiles which may be outdated due to API maintenance.<br>
           <%# <i>If a profile wasn't viewed/cached before, it can't be viewed.</i><br> %>
           <br>
           For more info about Hypixel outages visit the official <a href="https://status.hypixel.net/" target="_blank" rel="noreferrer"> Hypixel Status</a>.

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -548,7 +548,7 @@ const getRarityUpgradeClass = item => {
       <figure class="banner error">
         <figcaption>Cache Only Mode!</figcaption>
         <p>
-          SkyCrypt is <b>only</b> showing the last known state of user's profiles which may be outdated due to an API maintenance.<br>
+          SkyCrypt is <strong>only</strong> showing the last known state of user's profiles which may be outdated due to an API maintenance.<br>
           <%# <i>If a profile wasn't viewed/cached before, it can't be viewed.</i><br> %><br>
           For more info about Hypixel outages visit the official <a href="https://status.hypixel.net/" target="_blank" rel="noreferrer"> Hypixel Status</a>.
         </p>
@@ -1035,7 +1035,7 @@ const getRarityUpgradeClass = item => {
               <button class="stat-sub-header extender" aria-controls="missing-accessories" aria-expanded="false">Missing Accessories</button>
               <div class="pieces extendable" id="missing-accessories">
                 <br>
-                <p class="stat-sub-header">Missing Accessories<span data-tippy-content='Missing accessories that are <b>not</b> upgrades of another talisman.'></span></p>
+                <p class="stat-sub-header">Missing Accessories<span data-tippy-content='Missing accessories that are <strong>not</strong> upgrades of another talisman.'></span></p>
                 <% for(const [index, talisman] of calculated.missingTalismans.missing.entries()){ %>
                   <div tabindex="0" data-missing-talisman-index="<%= index %>" class="rich-item piece piece-<%= talisman.rarity %>-bg missing-talisman">
                     <div class="piece-hover-area"></div>


### PR DESCRIPTION
- removes "an" from "an API maintenance"
- change "user's" to "users'" because more than one user
- put only one `<br>` per line
- use `<strong>` instead of `<b>` for improved accesablity