### PR TITLE
set forceCacheOnly to false when status.hypixel.net doesn't say anything

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -69,18 +69,23 @@ async function main() {
   updateIsFoolsDay();
   setInterval(updateIsFoolsDay, 60_000);
 
-  let forceCacheOnly;
+  let forceCacheOnly = false;
   const badStatuses = ["under_maintenance"];
   async function updateCacheOnly() {
-    const response = await fetch("https://status.hypixel.net/api/v2/components.json");
-    const data = await response.json();
-    for (const component of data.components) {
-      if (component.name === "Public API") {
-        forceCacheOnly = badStatuses.includes(component.status);
-        if (forceCacheOnly) {
-          console.log("forcing cache only mode");
+    try {
+      const response = await fetch("https://status.hypixel.net/api/v2/components.json");
+      const data = await response.json();
+      forceCacheOnly = false;
+      for (const component of data.components) {
+        if (component.name === "Public API") {
+          if (badStatuses.includes(component.status)) {
+            forceCacheOnly = true;
+            console.log("forcing cache only mode");
+          }
         }
       }
+    } catch (error) {
+      forceCacheOnly = false;
     }
   }
   updateCacheOnly();


### PR DESCRIPTION
currently, if `https://status.hypixel.net/api/v2/components.json` does not return a value for `name === "Public API"` the value of `forceCacheOnly` is not defined and will take the previous state. This PR sets `forceCacheOnly` to false when `https://status.hypixel.net/api/v2/components.json` doesn't explicitly say it is under maintenance.

this will likely result in fewer false positives at the expense of more false negatives