### PR TITLE
Chip CSS refactor

### DIFF
--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -748,8 +748,7 @@ input[type="search"]::-webkit-search-cancel-button {
         content: none;
       }
 
-      .item-icon,
-      .head-icon {
+      .item-icon {
         position: absolute;
         top: 5px;
         left: 5px;
@@ -759,11 +758,6 @@ input[type="search"]::-webkit-search-cancel-button {
         transform: scale(0.2);
         transform-origin: top left;
         filter: drop-shadow(2px 2px 2px rgba(0, 0, 0, 0.4));
-      }
-
-      .head-icon {
-        top: 6px;
-        background-repeat: no-repeat;
       }
     }
 
@@ -2853,14 +2847,12 @@ a.additional-player-stat:hover {
 }
 
 .sea-creature {
-  display: inline-block;
-  width: 140px;
   position: relative;
-  margin-right: 15px;
-  margin-bottom: 15px;
   background-color: rgba(var(--background-rgb), 0.3);
   border-radius: 10px;
+  width: 140px;
   height: 230px;
+  flex-shrink: 0;
 }
 
 .sea-creature-name {
@@ -2900,7 +2892,6 @@ a.additional-player-stat:hover {
 .sea-creature-kills {
   position: absolute;
   top: 195px;
-  height: 40px;
   left: 0;
   right: 0;
   text-align: center;
@@ -2940,37 +2931,6 @@ a.additional-player-stat:hover {
   }
 }
 
-.minion,
-.collection {
-  position: relative;
-  display: inline-block;
-  margin-bottom: 8px;
-  margin-left: 5px;
-  background-color: rgba(var(--background-rgb), 0.3);
-  border-radius: 5px;
-}
-
-.minion {
-  padding: 10px;
-  padding-left: 60px;
-  line-height: 40px;
-
-  &:not(.skipped-minion)::after {
-    content: "";
-  }
-}
-
-.minion-icon {
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  width: 40px;
-  height: 40px;
-  background-size: auto 100%;
-  background-position: center;
-  background-repeat: no-repeat;
-}
-
 .max-stat .stat-name {
   color: var(--maxed-hex);
 }
@@ -2992,35 +2952,51 @@ a.additional-player-stat:hover {
   }
 }
 
-.collection {
-  padding: 7px;
-  padding-right: 15px;
+.collections,
+.minions,
+.stat-farming-crops,
+.sea-creatures {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+
+  &.sea-creatures {
+    gap: 15px;
+  }
+}
+
+.chip {
+  display: grid;
+  grid-template-columns: 48px max-content;
+  align-items: center;
+  padding: 8px;
+  background-color: rgba(var(--background-rgb), 0.3);
+  border-radius: 8px;
 
   &::after {
-    content: "";
+    content: none;
   }
-}
 
-.collection-icon {
-  width: 42px;
-  height: 42px;
-  display: inline-block;
-  position: relative;
-  vertical-align: middle;
+  .chip-icon-wrapper {
+    position: relative;
+    aspect-ratio: 1;
 
-  .item-icon {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%) scale(0.328125);
-    transform-origin: center center;
+    @supports not (aspect-ratio: 1) {
+      padding-bottom: 100%;
+    }
+
+    .item-icon {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%) scale(0.375);
+      transform-origin: center center;
+    }
   }
-}
 
-.collection-stats {
-  margin-left: 5px;
-  display: inline-block;
-  vertical-align: middle;
+  .chip-text {
+    padding: 0 8px;
+  }
 }
 
 .collection-name {
@@ -3029,33 +3005,6 @@ a.additional-player-stat:hover {
 
 .collection-amount {
   font-size: 14px;
-}
-
-.boss-collection {
-  position: relative;
-  display: inline-block;
-  padding: 7px;
-  padding-right: 15px;
-  margin-left: 5px;
-  margin-bottom: 8px;
-  background-color: rgba(var(--background-rgb), 0.3);
-  border-radius: 5px;
-
-  &::after {
-    content: "";
-  }
-}
-
-.boss-collection-icon {
-  position: relative;
-  display: inline-block;
-  vertical-align: middle;
-  width: 40px;
-  height: 40px;
-  margin-left: 5px;
-  background-size: auto 100%;
-  background-position: center;
-  background-repeat: no-repeat;
 }
 
 .narrow-info-header {
@@ -3808,16 +3757,17 @@ body {
 
   .collections,
   .minions,
+  .stat-farming-crops,
   .sea-creatures {
-    white-space: nowrap;
+    flex-wrap: nowrap;
     overflow-x: auto;
     margin-left: calc(-1 * var(--padding));
     margin-right: calc(-1 * var(--padding));
     content-visibility: auto;
-    contain-intrinsic-size: 200px 70px;
+    contain-intrinsic-size: 200px 64px;
 
-    &.sea-creature {
-      contain-intrinsic-size: 155px 245px;
+    &.sea-creatures {
+      contain-intrinsic-size: 140px 230px;
     }
 
     > :first-child {

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1366,11 +1366,11 @@ const getRarityUpgradeClass = item => {
             </div>
           <% } %>
 
-          <% if(farming.crops.length > 0){ %>
+          <% if(Object.keys(calculated.farming.crops).length > 0){ %>
             <button class="stat-sub-header extender" aria-controls="farming-crops" aria-expanded="false">Farming Crops</button>
             <div class="stat-farming-crops extendable" id="farming-crops">
               <%
-              const crops = Object.values(farming.crops).sort((a, b) => {
+              const crops = Object.values(calculated.farming.crops).sort((a, b) => {
                 return b.contests - a.contests;
               });
 

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -316,7 +316,7 @@ const skill_component = (skill, icon, level, extra = {}) => { %>
       data-tippy-content="<span class='stat-name'>Rank: </span><span class='stat-value'></span>#<%= level.rank %></span>"
     <% } %>>
       <% if(icon.startsWith('head-')){ %>
-        <div class="head-icon" style="background-image:url(/head/<%= icon.substring(5) %>)"></div>
+        <div class="item-icon custom-icon" style="background-image:url(/head/<%= icon.substring(5) %>)"></div>
       <% }else{ %>
         <div class="item-icon <%= icon %>"></div>
       <% } %>
@@ -1385,9 +1385,9 @@ const getRarityUpgradeClass = item => {
                     <span class="stat-value">${crop.badges[badge].toLocaleString()}</span><br>
                   `;
               %>
-              <div class="collection" data-tippy-content="<%= amountsTooltip %>">
-                <div class="collection-icon"><div class="item-icon icon-<%= crop.icon %>"></div></div>
-                <div class="collection-stats">
+              <div class="chip" data-tippy-content="<%= amountsTooltip %>">
+                <div class="chip-icon-wrapper"><div class="item-icon icon-<%= crop.icon %>"></div></div>
+                <div class="chip-text">
                   <div class="collection-name <%= crop.unique_gold ? 'max-minion' : '' %>"><span class="stat-name"><%= crop.name %></span></div>
                   <div class="collection-amount">
                     <small class="stat-name">Personal Best: </small><small class="stat-value"><%= helper.formatNumber(crop.personal_best, true) %></small><br>
@@ -1525,9 +1525,9 @@ const getRarityUpgradeClass = item => {
                   const tier_data = game_data.tiers[tier];
                 %>
                 <hr>
-                <div class="collection">
-                  <div class="collection-icon"><div class="item-icon icon-<%= tier_data.icon.replace(':', '_'); %>"></div></div>
-                  <div class="collection-stats">
+                <div class="chip">
+                  <div class="chip-icon-wrapper"><div class="item-icon icon-<%= tier_data.icon.replace(':', '_'); %>"></div></div>
+                  <div class="chip-text">
                     <div class="collection-name"><span class="stat-name"><%= tier_data.name %></span></div>
                     <div class="collection-amount">
                       <%
@@ -1720,7 +1720,7 @@ const getRarityUpgradeClass = item => {
         <% if (calculated.dungeons.unlocked_collections) { %>
           <p class="stat-sub-header">Boss Collections</p>
 
-          <div class="boss-collections">
+          <div class="collections">
           <%
           for(let boss in calculated.dungeons.boss_collections){
             let collection = calculated.dungeons.boss_collections[boss];
@@ -1737,9 +1737,9 @@ const getRarityUpgradeClass = item => {
             if (collection.unclaimed > 0)
               claimedTooltip += `<span class="stat-name">Unclaimed items: </span><span class="stat-value">${collection.unclaimed}</span>`;
           %>
-          <div class="boss-collection" <% if (claimedTooltip != "") { %>data-tippy-content="<%= claimedTooltip %>"<% } %>>
-            <div class="boss-collection-icon" style="background-image:url(/head/<%= collection.texture %>)"></div>
-            <div class="collection-stats">
+          <div class="chip" <% if (claimedTooltip != "") { %>data-tippy-content="<%= claimedTooltip %>"<% } %>>
+            <div class="chip-icon-wrapper"><div style="background-image:url(/head/<%= collection.texture %>)" class="item-icon custom-icon"></div></div>
+            <div class="chip-text">
               <div class="collection-name <%= collection.maxed ? 'max-stat' : '' %>"><span class="stat-name"><%= collection.name %> </span><% if (collection.tier > 0) { %><span class="stat-value"><%= collection.tier %></span><% } %></div>
               <div class="collection-amount"><span class="stat-name">Bosses killed: </span><span class="stat-value"><%= collection.killed.toLocaleString() %></span></div>
             </div>
@@ -1897,13 +1897,15 @@ const getRarityUpgradeClass = item => {
               <% for(let i = 1; i <= minion.tiers; i++){ %>
               <div class='minion-variant <% if(minion.levels.includes(i)){ %>minion-crafted<% } %>'><%= romanize(i) %></div>
               <% } %>
-              " class="minion
+              " class="chip
               <%= minion.maxLevel == 0 ? 'no-minion' : '' %>
               <%= minion.maxLevel == minion.tiers ? 'max-stat' : '' %>
               <%= minion.maxLevel != minion.levels.length ? 'skipped-minion' : '' %>
               ">
-                <div class="minion-icon" style="background-image: url(<%= minion.head %>)"></div>
-                <span class="stat-name"><%= minion.name %> </span><span class="stat-value"><%= minion.maxLevel %></span>
+                <div class="chip-icon-wrapper"><div style="background-image: url(<%= minion.head %>)" class="item-icon custom-icon"></div></div>
+                <div class="chip-text">
+                  <span class="stat-name"><%= minion.name %> </span><span class="stat-value"><%= minion.maxLevel %></span>
+                </div>
               </div>
             <% } %>
           </div>
@@ -1968,9 +1970,9 @@ const getRarityUpgradeClass = item => {
 
                 amountsTooltip += `<br><span class="stat-name">Total: </span><span class="stat-value">${collection.totalAmount.toLocaleString()}</span>`;
               %>
-                <div class="collection" data-tippy-content="<%= amountsTooltip %>">
-                  <div class="collection-icon"><div class="item-icon icon-<%= collection.id %>_<%= collection.damage %>"></div></div>
-                  <div class="collection-stats">
+                <div class="chip" data-tippy-content="<%= amountsTooltip %>">
+                  <div class="chip-icon-wrapper"><div class="item-icon icon-<%= collection.id %>_<%= collection.damage %>"></div></div>
+                  <div class="chip-text">
                     <div class="collection-name <%= collection.tier >= collection.maxTier ? 'max-stat' : '' %>"><span class="stat-name"><%= collection.name %> </span><span class="stat-value"><%= collection.tier %></span></div>
                     <div class="collection-amount"><span class="stat-name">Amount: </span><span class="stat-value"><%= collection.amount.toLocaleString() %></span></div>
                   </div>


### PR DESCRIPTION
this PR requires #575

This PR unifies collections, minions, boss collections, farming crops, and experiments all into one class called chip

this new class looks basically the same but uses CSS grid and flex for m modern flexible layout

additionally, the following things were changed about chips
- icons increased from 42px to 48px
- padding increased from 7px to 8px
- farming crops and boss collections now become horizontal scrollers on mobile

this PR also removes the white lines between experiments

before:
![image](https://user-images.githubusercontent.com/44071655/124354104-52975380-dbd8-11eb-8648-153dd7f137cb.png)

after:
![image](https://user-images.githubusercontent.com/44071655/124354112-5aef8e80-dbd8-11eb-96b0-b18c1cd09192.png)


before:
![image](https://user-images.githubusercontent.com/44071655/124354397-c9811c00-dbd9-11eb-9cd5-b1d1c4c68766.png)

after:
![image](https://user-images.githubusercontent.com/44071655/124354399-d30a8400-dbd9-11eb-8d90-d09d05acf974.png)

