### PR TITLE
remove .piece-hover-area

### DIFF
--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -2113,6 +2113,7 @@ a.additional-player-stat:hover {
       z-index: 20;
       transition: background-color 0.2s;
       border-radius: 5px;
+      pointer-events: none;
     }
     &.sticky-stats::after,
     &:hover::after {

--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -2100,20 +2100,25 @@ a.additional-player-stat:hover {
   }
 }
 
-.piece-hover-area {
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 0;
-  bottom: 0;
-  z-index: 20;
-  transition: background-color 0.2s;
-  border-radius: 5px;
-}
-
-.piece-hover-area:hover,
-.sticky-stats .piece-hover-area {
-  background-color: rgba(255, 255, 255, 0.2);
+.inventory-item,
+.piece {
+  @media (hover: hover) {
+    &::after {
+      content: "";
+      position: absolute;
+      left: 0;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      z-index: 20;
+      transition: background-color 0.2s;
+      border-radius: 5px;
+    }
+    &.sticky-stats::after,
+    &:hover::after {
+      background-color: rgba(255, 255, 255, 0.2);
+    }
+  }
 }
 
 .pieces {

--- a/public/resources/ts/stats-defer.ts
+++ b/public/resources/ts/stats-defer.ts
@@ -268,9 +268,6 @@ function renderInventory(inventory: ItemSlot[], type: string) {
 
       const inventoryItem = document.createElement("div");
 
-      const pieceHoverArea = document.createElement("div");
-      pieceHoverArea.className = "piece-hover-area";
-
       inventoryItem.className = "rich-item inventory-item";
 
       if (type === "backpack") {
@@ -280,7 +277,6 @@ function renderInventory(inventory: ItemSlot[], type: string) {
       }
 
       inventoryItem.appendChild(inventoryItemIcon);
-      inventoryItem.appendChild(pieceHoverArea);
 
       if (item.Count != 1) {
         inventoryItem.appendChild(inventoryItemCount);
@@ -288,7 +284,7 @@ function renderInventory(inventory: ItemSlot[], type: string) {
 
       inventorySlot.appendChild(inventoryItem);
 
-      bindLoreEvents(pieceHoverArea);
+      bindLoreEvents(inventoryItem);
     }
 
     if (index % pagesize === 0 && index !== 0) {
@@ -732,9 +728,8 @@ const itemLore = statsContent.querySelector(".item-lore") as HTMLElement;
 const backpackContents = statsContent.querySelector(".backpack-contents") as HTMLElement;
 
 function bindLoreEvents(element: HTMLElement) {
-  const parent = element.parentElement as HTMLElement;
   element.addEventListener("mouseenter", () => {
-    fillLore(parent);
+    fillLore(element);
 
     statsContent.classList.add("show-stats");
   });
@@ -767,11 +762,11 @@ function bindLoreEvents(element: HTMLElement) {
     statsContent.style.top = top + "px";
   });
 
-  const itemIndex = Number(parent.getAttribute("data-item-index"));
+  const itemIndex = Number(element.getAttribute("data-item-index"));
   const item = all_items.find((a) => a.item_index == itemIndex);
 
   if (item && "containsItems" in item) {
-    parent.addEventListener("contextmenu", (event) => {
+    element.addEventListener("contextmenu", (event) => {
       event.preventDefault();
 
       showBackpack(item);
@@ -787,17 +782,17 @@ function bindLoreEvents(element: HTMLElement) {
       if (statsContent.classList.contains("sticky-stats")) {
         closeLore();
       } else {
-        showLore(parent, false);
+        showLore(element, false);
 
         if (Number(statsContent.getAttribute("data-item-index")) != itemIndex) {
-          fillLore(parent);
+          fillLore(element);
         }
       }
     }
   });
 }
 
-for (const element of document.querySelectorAll<HTMLElement>(".rich-item .piece-hover-area")) {
+for (const element of document.querySelectorAll<HTMLElement>(".rich-item")) {
   bindLoreEvents(element);
 }
 

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -522,9 +522,9 @@ const getRarityUpgradeClass = item => {
 <body class="page-stats">
   <svg xmlns="http://www.w3.org/2000/svg" height="0" width="0" style="position: fixed;">
     <filter id="enchanted-glint">
-    <feImage href="/resources/img/enchanted-glint.png" />
-    <feComposite in2="SourceGraphic" operator="in" />
-    <feBlend in="SourceGraphic" mode="screen" />
+      <feImage href="/resources/img/enchanted-glint.png" />
+      <feComposite in2="SourceGraphic" operator="in" />
+      <feBlend in="SourceGraphic" mode="screen" />
     </filter>
   </svg>
   <%- include('../includes/header') %>

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -302,7 +302,6 @@ const inventorySlot = item => { %>
   <div class="inventory-slot">
     <% if(Object.keys(item).length > 2){ %>
     <div class="rich-item inventory-item" data-item-id="<%= item.itemId %>" data-item-index="<%= item.item_index %>">
-      <div class="piece-hover-area"></div>
       <% itemIcon(item, ['piece-icon']); %>
       <% if(item.Count != 1){ %><div class="item-count"><%= item.Count %></div><% } %>
     </div>
@@ -896,7 +895,6 @@ const getRarityUpgradeClass = item => {
                 <% if(rarityOrder.indexOf(item.rarity) < 3){ %>
                   <div class="piece-shine"></div>
                 <% } %>
-                <div class="piece-hover-area"></div>
                 <% itemIcon(item, ['piece-icon']); %>
               </div>
             <% } %>
@@ -916,7 +914,6 @@ const getRarityUpgradeClass = item => {
                     <% if(rarityOrder.indexOf(item.rarity) < 3){ %>
                       <div class="piece-shine"></div>
                     <% } %>
-                    <div class="piece-hover-area"></div>
                     <% itemIcon(item, ['piece-icon']); %>
                   </div>
                 <% } else { %>
@@ -962,7 +959,6 @@ const getRarityUpgradeClass = item => {
                     <% if(rarityOrder.indexOf(item.rarity) < 3){ %>
                       <div class="piece-shine"></div>
                     <% } %>
-                    <div class="piece-hover-area"></div>
                     <div class="select-weapon"></div>
                     <% itemIcon(item, ['piece-icon']); %>
                   </div>
@@ -1007,7 +1003,6 @@ const getRarityUpgradeClass = item => {
                     <% if(rarityOrder.indexOf(item.rarity) < 3){ %>
                       <div class="piece-shine"></div>
                     <% } %>
-                    <div class="piece-hover-area"></div>
                     <% itemIcon(item, ['piece-icon']); %>
                   </div>
                 <% }) %>
@@ -1027,7 +1022,6 @@ const getRarityUpgradeClass = item => {
                     <% if(rarityOrder.indexOf(item.rarity) < 3){ %>
                       <div class="piece-shine"></div>
                     <% } %>
-                    <div class="piece-hover-area"></div>
                     <% itemIcon(item, ['piece-icon']); %>
                   </div>
                 <% }) %>
@@ -1043,14 +1037,12 @@ const getRarityUpgradeClass = item => {
                 <p class="stat-sub-header">Missing Accessories<span data-tippy-content='Missing accessories that are <strong>not</strong> upgrades of another talisman.'></span></p>
                 <% for(const [index, talisman] of calculated.missingTalismans.missing.entries()){ %>
                   <div tabindex="0" data-missing-talisman-index="<%= index %>" class="rich-item piece piece-<%= talisman.rarity %>-bg missing-talisman">
-                    <div class="piece-hover-area"></div>
                     <div style='background-image: url("<%= talisman.texture_path %>")' class="piece-icon item-icon custom-icon"></div>
                   </div>
                 <% } %>
                 <p class="stat-sub-header">Missing Accessory Upgrades<span data-tippy-content='Missing accessories that are upgrades of a lower tier talisman.'></span></p>
                 <% for(const [index, talisman] of calculated.missingTalismans.upgrades.entries()){ %>
                   <div tabindex="0" data-upgrade-talisman-index="<%= index %>" class="rich-item piece piece-<%= talisman.rarity %>-bg missing-talisman">
-                    <div class="piece-hover-area"></div>
                     <div style='background-image: url("<%= talisman.texture_path %>")' class="piece-icon item-icon custom-icon"></div>
                   </div>
                 <% } %>
@@ -1128,7 +1120,6 @@ const getRarityUpgradeClass = item => {
                 <% if (rarityOrder.indexOf(activePet.rarity) < 3) { %>
                   <div class="piece-shine"></div>
                 <% } %>
-                <div class="piece-hover-area"></div>
                 <div style='background-image: url("<%= activePet.texture_path %>")' class="piece-icon item-icon custom-icon"></div>
               </div>
               <div class="active-pet-info">
@@ -1156,7 +1147,6 @@ const getRarityUpgradeClass = item => {
                   <% if(rarityOrder.indexOf(pet.rarity) < 3) { %>
                     <div class="piece-shine"></div>
                   <% } %>
-                  <div class="piece-hover-area"></div>
                   <div style='background-image: url("<%= pet.texture_path %>")' class="piece-icon item-icon custom-icon"></div>
                   <div class="other-pet-level"><abbr title="Level">Lvl</abbr> <%= pet.level.level %></div>
                 </div>
@@ -1171,7 +1161,6 @@ const getRarityUpgradeClass = item => {
             <div class="pieces extendable" id="missing-pets">
               <% for(const [index, pet] of calculated.missingPets.entries()) { %>
                 <div tabindex="0" data-missing-pet-index="<%= index %>" class="rich-item piece piece-<%= pet.rarity %>-bg missing-pet">
-                  <div class="piece-hover-area"></div>
                   <div style='background-image: url("<%= pet.texture_path %>")' class="piece-icon item-icon custom-icon"></div>
                 </div>
               <% } %>
@@ -1304,7 +1293,6 @@ const getRarityUpgradeClass = item => {
                     <% if(rarityOrder.indexOf(item.rarity) < 3){ %>
                       <div class="piece-shine"></div>
                     <% } %>
-                    <div class="piece-hover-area"></div>
                     <% itemIcon(item, ['piece-icon']); %>
                   </div>
               <% }); %>
@@ -1359,7 +1347,6 @@ const getRarityUpgradeClass = item => {
                     <% if(rarityOrder.indexOf(item.rarity) < 3){ %>
                       <div class="piece-shine"></div>
                     <% } %>
-                    <div class="piece-hover-area"></div>
                     <% itemIcon(item, ['piece-icon']); %>
                   </div>
               <% }); %>
@@ -1464,7 +1451,6 @@ const getRarityUpgradeClass = item => {
                     <% if(rarityOrder.indexOf(item.rarity) < 3){ %>
                       <div class="piece-shine"></div>
                     <% } %>
-                    <div class="piece-hover-area"></div>
                     <div class="select-rod"></div>
                     <% itemIcon(item, ['piece-icon']); %>
                   </div>


### PR DESCRIPTION
This PR removes the div with the `piece-hover-area` class

instead a ::after element is used

this PR also removes the hover effect from devices that cannot hover

this results in having fewer elements on mobile which should lead to a small performance improvement