### PR TITLE
add hover time to dungeon timestamp

### DIFF
--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1633,17 +1633,20 @@ const getRarityUpgradeClass = item => {
                   <% for (let [stat, value] of Object.entries(floor.best_runs[floor.best_runs.length - 1])) {
                     if(stat == "teammates") continue; %>
                     <span class="stat-name"><%= helper.capitalizeFirstLetter(stat.split("_").join(" ")) %>: </span>
-                    <span class="stat-value">
-                    <% switch (stat) { case "timestamp": %>
-                      <%= moment(value).fromNow() %>
-                    <% break; case "elapsed_time": %>
-                      <%= moment.duration(value, "milliseconds").format("m:ss.SSS") %>
-                    <% break; case "dungeon_class": %>
-                      <%= helper.titleCase(value) %>
-                    <% break; default: %>
-                      <%= helper.formatNumber(value) %>
-                    <% } %>
-                    </span><br>
+                    <span class="stat-value" <%- stat == "timestamp" ? `data-tippy-content='<local-time timestamp="${value}"></local-time>'` : ""%>><%=
+                      (() => {
+                        switch (stat) {
+                          case "timestamp":
+                            return moment(value).fromNow();
+                          case "elapsed_time":
+                            return moment.duration(value, "milliseconds").format("m:ss.SSS");
+                          case "dungeon_class":
+                            return helper.titleCase(value);
+                          default:
+                            return helper.formatNumber(value);
+                        }
+                      })()
+                    %></span><br>
                   <% } %>
                   </div>
                 <% } %>
@@ -1696,17 +1699,20 @@ const getRarityUpgradeClass = item => {
                   <% for (let [stat, value] of Object.entries(floor.best_runs[floor.best_runs.length - 1])) {
                     if(stat == "teammates") continue; %>
                     <span class="stat-name"><%= helper.capitalizeFirstLetter(stat.split("_").join(" ")) %>: </span>
-                    <span class="stat-value">
-                    <% switch (stat) { case "timestamp": %>
-                      <%= moment(value).fromNow() %>
-                    <% break; case "elapsed_time": %>
-                      <%= moment.duration(value, "milliseconds").format("m:ss.SSS") %>
-                    <% break; case "dungeon_class": %>
-                      <%= helper.titleCase(value) %>
-                    <% break; default: %>
-                      <%= helper.formatNumber(value) %>
-                    <% } %>
-                    </span><br>
+                    <span class="stat-value" <%- stat == "timestamp" ? `data-tippy-content='<local-time timestamp="${value}"></local-time>'` : ""%>><%=
+                      (() => {
+                        switch (stat) {
+                          case "timestamp":
+                            return moment(value).fromNow();
+                          case "elapsed_time":
+                            return moment.duration(value, "milliseconds").format("m:ss.SSS");
+                          case "dungeon_class":
+                            return helper.titleCase(value);
+                          default:
+                            return helper.formatNumber(value);
+                        }
+                      })()
+                    %></span><br>
                   <% } %>
                   </div>
                 <% } %>


### PR DESCRIPTION
This PR adds a timestamp tippy tip and refactors a few things to avoid extra spaces
![image](https://user-images.githubusercontent.com/44071655/124521525-c9da0c80-ddbd-11eb-884b-3586831c99f4.png)
