### PR TITLE
fix file does not exist error in dev

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -35,7 +35,9 @@ async function main() {
     });
 
     watch("public/resources/js/file-name-map.json", {}, async (evt, name) => {
-      fileNameMap = JSON.parse(fs.readFileSync("public/resources/js/file-name-map.json"));
+      if (evt != "remove") {
+        fileNameMap = JSON.parse(fs.readFileSync("public/resources/js/file-name-map.json"));
+      }
     });
   }
 


### PR DESCRIPTION
before rollup runs it deletes everything in the output directory this update was triggering nodewatch wich would try to read a nonexistent file.

this PR fixes the problem by ignoring nodewatch when the file is being removed