### PR TITLE
fix: make api page work when no theme is set

### DIFF
--- a/views/api.ejs
+++ b/views/api.ejs
@@ -18,7 +18,7 @@
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
     <script>
       function redocInit() {
-        const themeColors = extra.themes[localStorage.getItem("currentTheme")].colors;
+        const themeColors = extra.themes[localStorage.getItem("currentTheme")]?.colors;
         Redoc.init(
           'resources/api/api_docs.json',
           {


### PR DESCRIPTION
I can't run localhost to test this but it should work