### PR TITLE
fix dungeon weight calculation error

### DIFF
--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -4178,3 +4178,7 @@ body {
   font-size: 0.8em;
   letter-spacing: 3px;
 }
+
+.stat-error {
+  color: var(--§4);
+}

--- a/src/lib.js
+++ b/src/lib.js
@@ -3350,6 +3350,7 @@ module.exports = {
             : `floor_${highest_floor}`,
         floors: floors,
       };
+
       let dungeonLevelWithProgress = calcDungeonsClassLevelWithProgress(dungeon.experience);
       let dungeonsWeight = calcDungeonsWeight(type, dungeonLevelWithProgress, dungeon.experience);
       output.dungeonsWeight += dungeonsWeight.weight;
@@ -3363,6 +3364,11 @@ module.exports = {
     let current_class = dungeons.selected_dungeon_class || "none";
     for (const className of Object.keys(dungeons.player_classes)) {
       let data = dungeons.player_classes[className];
+
+      if (!data.experience) {
+        data.experience = 0;
+      }
+
       output.classes[className] = {
         experience: getLevelByXp(data.experience, { type: "dungeoneering" }),
         current: false,

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -816,13 +816,28 @@ const getRarityUpgradeClass = item => {
         </div>
         <div class="additional-stat">
           <span data-tippy-content="
-          <span class='stat-name'>Skill Weight: </span><span class='stat-value'><%= calculated.skillWeight >= 0 ? parseFloat(calculated.skillWeight.toFixed(2)).toLocaleString() : 'Error' %></span><br/>
-          <span class='stat-name'>Slayer Weight: </span><span class='stat-value'><%= calculated.slayerWeight >= 0 ? parseFloat(calculated.slayerWeight.toFixed(2)).toLocaleString() : 'Error'  %></span><br/>
-          <span class='stat-name'>Dungeon Weight: </span><span class='stat-value'><%= calculated.dungeonsWeight >= 0 ? parseFloat(calculated.dungeonsWeight.toFixed(2)).toLocaleString() : 'Error'  %></span><br/>
-          <br/>
-          <div class='tippy-explanation'>Weight calculations provided by Senither</div>
+            <span class='stat-name'>Skill Weight: </span>
+            <span class='stat-value'>
+              <%= calculated.skillWeight >= 0 ? parseFloat(calculated.skillWeight.toFixed(2)).toLocaleString() : 'Error' %>
+            </span><br/>
+            <span class='stat-name'>Slayer Weight: </span>
+            <span class='stat-value'>
+              <%= calculated.slayerWeight >= 0 ? parseFloat(calculated.slayerWeight.toFixed(2)).toLocaleString() : 'Error'  %>
+            </span><br/>
+            <span class='stat-name'>Dungeon Weight: </span>
+            <span class='stat-value'>
+              <%= calculated.dungeonsWeight >= 0 ? parseFloat(calculated.dungeonsWeight.toFixed(2)).toLocaleString() : 'Error'  %>
+            </span><br/>
+            <br/>
+            <div class='tippy-explanation'>Weight calculations provided by Senither</div>
           ">
-          <span class="stat-name">Weight: </span><span class="stat-value"><%= parseFloat(calculated.weight.toFixed(2)).toLocaleString() %></span></span>
+          <span class="stat-name">Weight: </span>
+          <span class="stat-value">
+            <%= parseFloat(calculated.weight.toFixed(2)).toLocaleString() %>
+          </span>
+          <span class="stat-value stat-error">
+            <%= (!calculated.skillWeight || !calculated.slayerWeight || !calculated.dungeonsWeight) ? '!' : '' %>
+          </span>
         </div>
       </div>
 


### PR DESCRIPTION
This PR:
- Adds a small red `!` next to weight if one of the 3 weights failed to calculate.
- Formatted the code that was printing the Weight stat and tooltip.... turns out there was an extra `</span>` there lol
- Fixes a bug where if a player never played a class, their entire dungeon weight will be Error.

The issue was caused by the player_classes looking like this:
![image](https://user-images.githubusercontent.com/2744227/128429920-ff945be0-3ff8-4613-8e53-d54adaa248b1.png)

I first tried to skip calculation for classes never played, but all the code after it and in frontend expects the resulting object to have all the classes so I ended up manually setting experience=0 for the never played classes.

Ref
![image](https://user-images.githubusercontent.com/2744227/128430185-4e702e47-9280-4710-9bf5-f64536b99242.png)
