### PR TITLE
change/fix Cache-Control max-age

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -580,6 +580,7 @@ async function main() {
       background = color;
       foreground = "ffffff";
     }
+    res.setHeader("Cache-Control", `public, max-age=${cacheMaxAge}`);
     res.type("svg").send(/*xml*/ `
       <svg width="120" height="120" xmlns="http://www.w3.org/2000/svg">
         <title>SkyCrypt Logo</title>


### PR DESCRIPTION
## The Change
this PR makes 3 cache settings and groups all cached assets into one of these

### maxMaxAge: 1 year (max allowed by HTTP)
used for hashed assets as recommended by google and others

### cacheMaxAge: 30 days
used for things that will probably not change and if they did change it would be ok if the user gets an old version

### volatileCacheMaxAge: 12 hours
used by capes because they could change any time but it's ok if they are a little outdated

## The Fix
before this PR some `max-age` was set to 100 times more than it should have been because of confusion between seconds and milliseconds