### PR TITLE
label weight as senither weight

### DIFF
--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -839,7 +839,7 @@ const getRarityUpgradeClass = item => {
             <br/>
             <div class='tippy-explanation'>Weight calculations provided by Senither</div>
           ">
-          <span class="stat-name">Weight: </span>
+          <span class="stat-name">Senither Weight: </span>
           <span class="stat-value">
             <%= parseFloat(calculated.weight.toFixed(2)).toLocaleString() %>
           </span>


### PR DESCRIPTION
rename Weight to Senither Weight so that when we add Lily Weight it will be clear to users which was the old one. This also avoids confusion with the lily weight used on skylea

this is a ejs only change so a server restart is optional

![image](https://user-images.githubusercontent.com/44071655/130316952-466f85f9-0050-49ce-a7bc-dd3831a4cce9.png)
