### PR TITLE
add fallback for item-name background

### DIFF
--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -1173,6 +1173,7 @@ input[type="search"]::-webkit-search-cancel-button {
     text-transform: uppercase;
     font-weight: 600;
     color: white;
+    background-color: var(--header-hex); // fallback for rarity color
     text-shadow: 0px 0px 7px rgba(0, 0, 0, 0.3);
     box-sizing: border-box;
   }


### PR DESCRIPTION
this PR adds grey background to items with no valid rarity

Before:
![image](https://user-images.githubusercontent.com/44071655/130339910-29cc6807-a0c4-4508-a546-e245cc7e6f9b.png)
![image](https://user-images.githubusercontent.com/44071655/130339913-a7467306-97d4-4025-90ed-c1ab69dc0cfb.png)

After:
![image](https://user-images.githubusercontent.com/44071655/130339894-111fbe23-c554-4c65-b719-582104f1e354.png)
![image](https://user-images.githubusercontent.com/44071655/130339888-178e85f6-ad90-4672-890e-17cbda13113f.png)
