### PR TITLE
respond with offline url based on navigation type not url

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -28,8 +28,7 @@ self.addEventListener("fetch", (event) => {
     fetch(event.request).catch(() => {
       return caches.match(event.request).then((response) => {
         if (!response) {
-          const url = new URL(event.request.url);
-          if (url.pathname === "/" || url.pathname.substring(0, 7) === "/stats/") {
+          if (event.request.mode === "navigate") {
             return caches.match("/resources/html/offline.html");
           }
         }


### PR DESCRIPTION
currently, the service worker replaces index and stats pages with the offline page when offline

this PR makes it respond to any navigation requests, not just index and stats