### PR TITLE
cachebusting stats icons

### DIFF
--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -1799,8 +1799,8 @@ a.additional-player-stat:hover {
 }
 
 .stat-health::before {
-  -webkit-mask-image: url(../img/icons/heart.svg);
-  mask-image: url(../img/icons/heart.svg);
+  -webkit-mask-image: url(../img/icons/heart.svg?v2);
+  mask-image: url(../img/icons/heart.svg?v2);
 }
 
 .stat-health,
@@ -1815,8 +1815,8 @@ a.additional-player-stat:hover {
 }
 
 .stat-defense::before {
-  -webkit-mask-image: url(../img/icons/shield.svg);
-  mask-image: url(../img/icons/shield.svg);
+  -webkit-mask-image: url(../img/icons/shield.svg?v2);
+  mask-image: url(../img/icons/shield.svg?v2);
 }
 
 .stat-defense,
@@ -1825,13 +1825,13 @@ a.additional-player-stat:hover {
 }
 
 .stat-strength::before {
-  -webkit-mask-image: url(../img/icons/flower-poppy.svg);
-  mask-image: url(../img/icons/flower-poppy.svg);
+  -webkit-mask-image: url(../img/icons/flower-poppy.svg?v2);
+  mask-image: url(../img/icons/flower-poppy.svg?v2);
 }
 
 .stat-speed::before {
-  -webkit-mask-image: url(../img/icons/star-four-points.svg);
-  mask-image: url(../img/icons/star-four-points.svg);
+  -webkit-mask-image: url(../img/icons/star-four-points.svg?v2);
+  mask-image: url(../img/icons/star-four-points.svg?v2);
 }
 
 .stat-speed,
@@ -1840,13 +1840,13 @@ a.additional-player-stat:hover {
 }
 
 .stat-crit-chance::before {
-  -webkit-mask-image: url(../img/icons/atom.svg);
-  mask-image: url(../img/icons/atom.svg);
+  -webkit-mask-image: url(../img/icons/atom.svg?v2);
+  mask-image: url(../img/icons/atom.svg?v2);
 }
 
 .stat-crit-damage::before {
-  -webkit-mask-image: url(../img/icons/skull-crossbones.svg);
-  mask-image: url(../img/icons/skull-crossbones.svg);
+  -webkit-mask-image: url(../img/icons/skull-crossbones.svg?v2);
+  mask-image: url(../img/icons/skull-crossbones.svg?v2);
 }
 
 .stat-crit-chance,
@@ -1857,8 +1857,8 @@ a.additional-player-stat:hover {
 }
 
 .stat-bonus-attack-speed::before {
-  -webkit-mask-image: url(../img/icons/sword-cross.svg);
-  mask-image: url(../img/icons/sword-cross.svg);
+  -webkit-mask-image: url(../img/icons/sword-cross.svg?v2);
+  mask-image: url(../img/icons/sword-cross.svg?v2);
 }
 
 .stat-bonus-attack-speed,
@@ -1867,8 +1867,8 @@ a.additional-player-stat:hover {
 }
 
 .stat-intelligence::before {
-  -webkit-mask-image: url(../img/icons/lead-pencil.svg);
-  mask-image: url(../img/icons/lead-pencil.svg);
+  -webkit-mask-image: url(../img/icons/lead-pencil.svg?v2);
+  mask-image: url(../img/icons/lead-pencil.svg?v2);
 }
 
 .stat-intelligence,
@@ -1877,8 +1877,8 @@ a.additional-player-stat:hover {
 }
 
 .stat-sea-creature-chance::before {
-  -webkit-mask-image: url(../img/icons/fish.svg);
-  mask-image: url(../img/icons/fish.svg);
+  -webkit-mask-image: url(../img/icons/fish.svg?v2);
+  mask-image: url(../img/icons/fish.svg?v2);
 }
 
 .stat-sea-creature-chance,
@@ -1887,8 +1887,8 @@ a.additional-player-stat:hover {
 }
 
 .stat-magic-find::before {
-  -webkit-mask-image: url(../img/icons/star.svg);
-  mask-image: url(../img/icons/star.svg);
+  -webkit-mask-image: url(../img/icons/star.svg?v2);
+  mask-image: url(../img/icons/star.svg?v2);
 }
 
 .stat-magic-find,
@@ -1897,8 +1897,8 @@ a.additional-player-stat:hover {
 }
 
 .stat-pet-luck::before {
-  -webkit-mask-image: url(../img/icons/cards-club.svg);
-  mask-image: url(../img/icons/cards-club.svg);
+  -webkit-mask-image: url(../img/icons/cards-club.svg?v2);
+  mask-image: url(../img/icons/cards-club.svg?v2);
 }
 
 .stat-pet-luck,
@@ -1907,13 +1907,13 @@ a.additional-player-stat:hover {
 }
 
 .stat-ferocity::before {
-  -webkit-mask-image: url(../img/icons/ferocity.svg);
-  mask-image: url(../img/icons/ferocity.svg);
+  -webkit-mask-image: url(../img/icons/ferocity.svg?v2);
+  mask-image: url(../img/icons/ferocity.svg?v2);
 }
 
 .stat-ability-damage::before {
-  -webkit-mask-image: url(../img/icons/ability_damage.svg);
-  mask-image: url(../img/icons/ability_damage.svg);
+  -webkit-mask-image: url(../img/icons/ability_damage.svg?v2);
+  mask-image: url(../img/icons/ability_damage.svg?v2);
 }
 
 .stat-ability-damage,
@@ -1922,8 +1922,8 @@ a.additional-player-stat:hover {
 }
 
 .stat-mining-speed::before {
-  -webkit-mask-image: url(../img/icons/mining_speed.svg);
-  mask-image: url(../img/icons/mining_speed.svg);
+  -webkit-mask-image: url(../img/icons/mining_speed.svg?v2);
+  mask-image: url(../img/icons/mining_speed.svg?v2);
 }
 
 .stat-mining-speed,
@@ -1932,8 +1932,8 @@ a.additional-player-stat:hover {
 }
 
 .stat-mining-fortune::before {
-  -webkit-mask-image: url(../img/icons/fortune.svg);
-  mask-image: url(../img/icons/fortune.svg);
+  -webkit-mask-image: url(../img/icons/fortune.svg?v2);
+  mask-image: url(../img/icons/fortune.svg?v2);
 }
 
 .stat-mining-fortune,
@@ -1942,8 +1942,8 @@ a.additional-player-stat:hover {
 }
 
 .stat-farming-fortune::before {
-  -webkit-mask-image: url(../img/icons/fortune.svg);
-  mask-image: url(../img/icons/fortune.svg);
+  -webkit-mask-image: url(../img/icons/fortune.svg?v2);
+  mask-image: url(../img/icons/fortune.svg?v2);
 }
 
 .stat-farming-fortune,
@@ -1952,8 +1952,8 @@ a.additional-player-stat:hover {
 }
 
 .stat-foraging-fortune::before {
-  -webkit-mask-image: url(../img/icons/fortune.svg);
-  mask-image: url(../img/icons/fortune.svg);
+  -webkit-mask-image: url(../img/icons/fortune.svg?v2);
+  mask-image: url(../img/icons/fortune.svg?v2);
 }
 
 .stat-foraging-fortune,
@@ -1962,8 +1962,8 @@ a.additional-player-stat:hover {
 }
 
 .stat-pristine::before {
-  -webkit-mask-image: url(../img/icons/pristine.svg);
-  mask-image: url(../img/icons/pristine.svg);
+  -webkit-mask-image: url(../img/icons/pristine.svg?v2);
+  mask-image: url(../img/icons/pristine.svg?v2);
 }
 
 .stat-pristine,


### PR DESCRIPTION
Just adding `?v2` to all stats icons for cache busting

Didn't test... I can't test, I don't have the old images in cache