### PR TITLE
Import Tippy 6 directly

### DIFF
--- a/includes/footer.ejs
+++ b/includes/footer.ejs
@@ -1,5 +1,3 @@
-<script src="https://unpkg.com/popper.js@1"></script>
-<script src="https://unpkg.com/tippy.js@5"></script>
 <script src="https://twemoji.maxcdn.com/v/latest/twemoji.min.js" crossorigin="anonymous"></script>
 
 <script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -129,6 +129,11 @@
         "fastq": "^1.6.0"
       }
     },
+    "@popperjs/core": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.3.tgz",
+      "integrity": "sha512-xDu17cEfh7Kid/d95kB6tZsLOmSWKCZKtprnhVepjsSaCij+lM3mItSJDuuHDMbCWTh8Ejmebwb+KONcCJ0eXQ=="
+    },
     "@rollup/plugin-commonjs": {
       "version": "20.0.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-20.0.0.tgz",
@@ -3907,11 +3912,6 @@
         "find-up": "^2.1.0"
       }
     },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
-    },
     "prebuild-install": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.4.tgz",
@@ -4952,11 +4952,11 @@
       "integrity": "sha512-VkZAv8ZTJqiE/fyEmoWLxcNHImpVcjqW7RO0GzMu3tRpwO0KUvK9pjTmJzJcAbc51BOeB2G38zh80yjHTbP8gQ=="
     },
     "tippy.js": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-5.2.1.tgz",
-      "integrity": "sha512-66UT6JRVn3dXNCORE+0UvUK3JZqV/VhLlU6HTDm3FmrweUUFUxUGvT8tUQ7ycMp+uhuLAwQw6dBabyC+iKf/MA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.1.tgz",
+      "integrity": "sha512-JnFncCq+rF1dTURupoJ4yPie5Cof978inW6/4S6kmWV7LL9YOSEVMifED3KdrVPEG+Z/TFH2CDNJcQEfaeuQww==",
       "requires": {
-        "popper.js": "^1.16.0"
+        "@popperjs/core": "^2.8.3"
       }
     },
     "to-readable-stream": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -166,6 +166,16 @@
         "resolve": "^1.19.0"
       }
     },
+    "@rollup/plugin-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-3.0.0.tgz",
+      "integrity": "sha512-3c7JCbMuYXM4PbPWT4+m/4Y6U60SgsnDT/cCyAyUKwFHg7pTSfsSQzIpETha3a3ig6OdOKzZz87D9ZXIK3qsDg==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "magic-string": "^0.25.7"
+      }
+    },
     "@rollup/plugin-typescript": {
       "version": "8.2.5",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.2.5.tgz",
@@ -3897,6 +3907,11 @@
         "find-up": "^2.1.0"
       }
     },
+    "popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
+    },
     "prebuild-install": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.4.tgz",
@@ -4935,6 +4950,14 @@
       "version": "0.131.3",
       "resolved": "https://registry.npmjs.org/three/-/three-0.131.3.tgz",
       "integrity": "sha512-VkZAv8ZTJqiE/fyEmoWLxcNHImpVcjqW7RO0GzMu3tRpwO0KUvK9pjTmJzJcAbc51BOeB2G38zh80yjHTbP8gQ=="
+    },
+    "tippy.js": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-5.2.1.tgz",
+      "integrity": "sha512-66UT6JRVn3dXNCORE+0UvUK3JZqV/VhLlU6HTDm3FmrweUUFUxUGvT8tUQ7ycMp+uhuLAwQw6dBabyC+iKf/MA==",
+      "requires": {
+        "popper.js": "^1.16.0"
+      }
     },
     "to-readable-stream": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "sharp": "^0.29.0",
     "sitemap": "^7.0.0",
     "skinview3d": "^2.0.2",
+    "tippy.js": "5",
     "twemoji": "^13.1.0",
     "upng-js": "^2.1.0",
     "uuid": "^8.3.1"
@@ -81,6 +82,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^20.0.0",
     "@rollup/plugin-node-resolve": "^13.0.4",
+    "@rollup/plugin-replace": "^3.0.0",
     "@rollup/plugin-typescript": "^8.2.5",
     "@typescript-eslint/eslint-plugin": "^4.30.0",
     "@typescript-eslint/parser": "^4.29.3",
@@ -88,8 +90,8 @@
     "ejs-lint": "^1.2.1",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-import": "^2.24.1",
     "eslint-plugin-deprecation": "^1.2.1",
+    "eslint-plugin-import": "^2.24.1",
     "node-watch": "^0.7.1",
     "nodemon": "^2.0.12",
     "prettier": "2.3.2",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "sharp": "^0.29.0",
     "sitemap": "^7.0.0",
     "skinview3d": "^2.0.2",
-    "tippy.js": "5",
+    "tippy.js": "^6.3.1",
     "twemoji": "^13.1.0",
     "upng-js": "^2.1.0",
     "uuid": "^8.3.1"

--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -1,5 +1,6 @@
 @use "./stripes";
 @use "./fonts";
+@use "../../../node_modules/tippy.js/dist/tippy.css";
 
 :root {
   /* Icon Green (used for Skill Icons, Underlines etc.) */

--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -226,16 +226,14 @@ a.no-underline {
   text-decoration: none;
 }
 
-.tippy-tooltip {
+.tippy-box {
   font-weight: 500;
-  background-color: transparent;
-  border-radius: 0;
+  background-color: var(--grey_background-hex);
+  border-radius: 5px;
   user-select: text;
   color: var(--text-hex);
 
-  .tippy-content {
-    border-radius: 5px;
-    background-color: var(--grey_background-hex);
+  > .tippy-content {
     padding: 15px;
 
     .stat-name {
@@ -244,11 +242,11 @@ a.no-underline {
     }
   }
 
-  &[data-placement^="top"] > .tippy-arrow {
+  &[data-placement^="top"] > .tippy-arrow::before {
     border-top-color: var(--icon-hex);
   }
 
-  &[data-placement^="bottom"] > .tippy-arrow {
+  &[data-placement^="bottom"] > .tippy-arrow::before {
     border-bottom-color: var(--icon-hex);
   }
 }

--- a/public/resources/ts/common-defer.ts
+++ b/public/resources/ts/common-defer.ts
@@ -41,7 +41,7 @@ document.querySelectorAll<HTMLFormElement>(".lookup-player").forEach((form) => {
     } catch (error) {
       const errorTip = tippy(form.querySelector("input") as HTMLInputElement, {
         trigger: "manual",
-        content: error || "please enter a valid Minecraft username or UUID",
+        content: (error as string | undefined) ?? "please enter a valid Minecraft username or UUID",
       });
       errorTip.show();
       setTimeout(() => {

--- a/public/resources/ts/common-defer.ts
+++ b/public/resources/ts/common-defer.ts
@@ -1,8 +1,5 @@
 import { loadTheme } from "./themes";
-
-declare global {
-  function tippy(targets: string | Element | Element[], optionalProps: Record<string, unknown>): any;
-}
+import tippy from "tippy.js";
 
 function validateURL(url: string) {
   const urlSegments = url.trim().split("/");

--- a/public/resources/ts/common-defer.ts
+++ b/public/resources/ts/common-defer.ts
@@ -1,6 +1,8 @@
 import { loadTheme } from "./themes";
 import tippy from "tippy.js";
 
+tippy.setDefaultProps({ allowHTML: true });
+
 function validateURL(url: string) {
   const urlSegments = url.trim().split("/");
   if (urlSegments.length < 1) {
@@ -140,9 +142,7 @@ function setCheckedTheme(theme: string) {
 
 setCheckedTheme(localStorage.getItem("currentTheme") ?? "default");
 
-tippy("*[data-tippy-content]", {
-  boundary: "window",
-});
+tippy("*[data-tippy-content]");
 
 const prideFlag = document.querySelector(".pride-flag") as HTMLElement;
 const prideFlags = ["rainbow", "trans", "lesbian", "bi", "pan", "nb", "ace", "genderfluid", "logo"];

--- a/public/resources/ts/stats-defer.ts
+++ b/public/resources/ts/stats-defer.ts
@@ -1,9 +1,6 @@
 import { setCookie } from "./common-defer";
 import { SkinViewer, createOrbitControls } from "skinview3d";
-
-declare global {
-  function tippy(targets: string | Element | Element[], optionalProps?: Record<string, unknown>): any;
-}
+import tippy from "tippy.js";
 
 const favoriteElement = document.querySelector(".favorite") as HTMLButtonElement;
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,7 @@ import commonjs from "@rollup/plugin-commonjs";
 import { terser } from "rollup-plugin-terser";
 import nameMap from "./lib/rollup-plugin-name-map.js";
 import del from "rollup-plugin-delete";
+import replace from "@rollup/plugin-replace";
 
 // `npm run start` -> `production` is true
 // `npm run dev` -> `production` is false
@@ -30,6 +31,7 @@ const config = {
   },
   plugins: [
     del({ targets: "public/resources/js/*" }),
+    replace({ "process.env.NODE_ENV": JSON.stringify(production ? "production" : "development") }), // makes process.env.NODE_ENV work on client side
     typescript({ tsconfig: "public/resources/ts/tsconfig.json" }), // converts TypeScript modules to JavaScript
     resolve(), // tells Rollup how to stuff in node_modules
     commonjs(), // converts Node modules to ES modules


### PR DESCRIPTION
This PR makes tippy an npm dependency instead of using the CDN. this allows us to tree shake and also means that the browser doesn't have to open an extra connection. it also means that dependabot can update tippy now.

This PR also updates from tippy 5 to tippy 6