### PR TITLE
fix: :lipstick: Prevent skill icons from clipping

### DIFF
--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -691,9 +691,7 @@ input[type="search"]::-webkit-search-cancel-button {
     font-size: 14px;
   }
   .basic-stat::before {
-    // transform: scale(0.85);
-    width: 20px;
-    height: 20px;
+    transform: scale(0.95);
   }
 }
 


### PR DESCRIPTION
Before, skill icons were clipping the outside and it didn't look very good. The `transform: scale()` is optional, it just was there before.