### PR TITLE
Fixed API caching in /apiv2

### DIFF
--- a/src/apiv2.js
+++ b/src/apiv2.js
@@ -64,7 +64,7 @@ export default (app, db) => {
       }
     }
 
-    req.cacheOnly = req.apiKey;
+    req.cacheOnly = !req.apiKey;
     next();
   });
 


### PR DESCRIPTION
Our API should've been cache-only all along, so this fixes the issue of API requests using external resources.

This bug was created by a commit from me from April 19th, _sorry for that one_.