### PR TITLE
Remove hardcoded minion count

### DIFF
--- a/src/constants/minions.js
+++ b/src/constants/minions.js
@@ -274,7 +274,6 @@ export const minions = {
     name: "Voidling",
     type: "combat",
     head: "/head/3a851ed2ce5c2c0523af772d206d9555e2e1383ec87946e6ff4c51186e29ef7f",
-    tiers: 12,
   },
   HARD_STONE: {
     name: "Hard Stone",

--- a/src/constants/minions.js
+++ b/src/constants/minions.js
@@ -25,7 +25,7 @@ export const minion_slots = {
   650: 26,
 };
 
-export const minions_max_uniques = 631;
+export let minions_max_uniques = 0;
 export const minions_max_slots = 25; // From unique tiers (excludes community shop upgrades)
 
 export const minions = {
@@ -274,6 +274,7 @@ export const minions = {
     name: "Voidling",
     type: "combat",
     head: "/head/3a851ed2ce5c2c0523af772d206d9555e2e1383ec87946e6ff4c51186e29ef7f",
+    tiers: 12,
   },
   HARD_STONE: {
     name: "Hard Stone",
@@ -282,3 +283,7 @@ export const minions = {
     tiers: 12,
   },
 };
+
+for(const minion in minions){
+  minions_max_uniques += minions[minion].tiers || 11;
+}

--- a/src/constants/minions.js
+++ b/src/constants/minions.js
@@ -284,6 +284,6 @@ export const minions = {
   },
 };
 
-for(const minion in minions){
+for (const minion in minions) {
   minions_max_uniques += minions[minion].tiers || 11;
 }

--- a/src/lib.js
+++ b/src/lib.js
@@ -1923,7 +1923,7 @@ export const getStats = async (
     output.slayer_xp = 0;
 
     for (const slayer in slayers) {
-      if (!slayers[slayer]?.level?.currentLevel) {
+      if (slayers[slayer]?.level?.currentLevel == undefined) {
         continue;
       }
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -1920,10 +1920,28 @@ export const getStats = async (
       output.slayer_coins_spent.total = output.slayer_coins_spent.total || 0;
     }
 
+    if(profile.uuid == "b44d2d5272dc49c28185b2d6a158d80a"){
+      slayers.slime = {
+        level: {
+          currentLevel: -3,
+          xp: 69420,
+          progress: 0.83,
+          xpForNext: 1_400_000_000
+        },
+        kills: {
+          '1': 39283
+        },
+        xp: 69420
+      }
+    }
+
     output.slayer_xp = 0;
 
     for (const slayer in slayers) {
-      if (slayers[slayer]?.level?.currentLevel == undefined) {
+      if(slayer == "slime"){
+        continue;
+      }
+      if (!helper.hasPath(slayers[slayer], "level", "currentLevel")) {
         continue;
       }
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -1920,25 +1920,25 @@ export const getStats = async (
       output.slayer_coins_spent.total = output.slayer_coins_spent.total || 0;
     }
 
-    if(profile.uuid == "b44d2d5272dc49c28185b2d6a158d80a"){
+    if (profile.uuid == "b44d2d5272dc49c28185b2d6a158d80a") {
       slayers.slime = {
         level: {
           currentLevel: -3,
           xp: 69420,
           progress: 0.83,
-          xpForNext: 1_400_000_000
+          xpForNext: 1_400_000_000,
         },
         kills: {
-          '1': 39283
+          1: 39283,
         },
-        xp: 69420
-      }
+        xp: 69420,
+      };
     }
 
     output.slayer_xp = 0;
 
     for (const slayer in slayers) {
-      if(slayer == "slime"){
+      if (slayer == "slime") {
         continue;
       }
       if (!slayers[slayer]?.level?.currentLevel) {

--- a/src/lib.js
+++ b/src/lib.js
@@ -1920,27 +1920,9 @@ export const getStats = async (
       output.slayer_coins_spent.total = output.slayer_coins_spent.total || 0;
     }
 
-    if (profile.uuid == "b44d2d5272dc49c28185b2d6a158d80a") {
-      slayers.slime = {
-        level: {
-          currentLevel: -3,
-          xp: 69420,
-          progress: 0.83,
-          xpForNext: 1_400_000_000,
-        },
-        kills: {
-          1: 39283,
-        },
-        xp: 69420,
-      };
-    }
-
     output.slayer_xp = 0;
 
     for (const slayer in slayers) {
-      if (slayer == "slime") {
-        continue;
-      }
       if (!slayers[slayer]?.level?.currentLevel) {
         continue;
       }

--- a/src/lib.js
+++ b/src/lib.js
@@ -1941,7 +1941,7 @@ export const getStats = async (
       if(slayer == "slime"){
         continue;
       }
-      if (!helper.hasPath(slayers[slayer], "level", "currentLevel")) {
+      if (!slayers[slayer]?.level?.currentLevel) {
         continue;
       }
 

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1,6 +1,6 @@
 <%
 const rarityOrder = ['special', 'supreme', 'mythic', 'legendary', 'epic', 'rare', 'uncommon', 'common'];
-const slayerOrder = ['zombie', 'spider', 'wolf', 'enderman', 'slime'];
+const slayerOrder = ['zombie', 'spider', 'wolf', 'enderman'];
 const badgeOrder = ['gold', 'silver', 'bronze'];
 
 const allItems = items.armor.concat(items.inventory, items.enderchest, items.talisman_bag, items.fishing_bag, items.quiver, items.potion_bag, items.wardrobe_inventory, items.storage);
@@ -111,10 +111,6 @@ const slayerInfo = {
     boss: 'Voidgloom Seraph',
     head: '/head/1b09a3752510e914b0bdc9096b392bb359f7a8e8a9566a02e7f66faff8d6f89e',
   },
-  slime: {
-    boss: 'Congealed Monstrosity',
-    head: '/head/bb13133a8fb4ef00b71ef9bab639a66fbc7d5cffcc190c1df74bf2161dfd3ec7'
-  }
 };
 
 const seaCreatures = [

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1,6 +1,6 @@
 <%
 const rarityOrder = ['special', 'supreme', 'mythic', 'legendary', 'epic', 'rare', 'uncommon', 'common'];
-const slayerOrder = ['zombie', 'spider', 'wolf', 'enderman'];
+const slayerOrder = ['zombie', 'spider', 'wolf', 'enderman', 'slime'];
 const badgeOrder = ['gold', 'silver', 'bronze'];
 
 const allItems = items.armor.concat(items.inventory, items.enderchest, items.talisman_bag, items.fishing_bag, items.quiver, items.potion_bag, items.wardrobe_inventory, items.storage);
@@ -110,6 +110,10 @@ const slayerInfo = {
   enderman: {
     boss: 'Voidgloom Seraph',
     head: '/head/1b09a3752510e914b0bdc9096b392bb359f7a8e8a9566a02e7f66faff8d6f89e',
+  },
+  slime: {
+    boss: 'Congealed Monstrosity',
+    head: '/head/bb13133a8fb4ef00b71ef9bab639a66fbc7d5cffcc190c1df74bf2161dfd3ec7'
   }
 };
 
@@ -1864,25 +1868,6 @@ const getRarityUpgradeClass = item => {
                 <div class="skill-progress-bar slayer-progress-bar" style="--progress: <%= slayer.level.currentLevel == slayer.level.maxLevel ? 1 : slayer.level.progress %>"></div>
                 <div class="skill-progress-text slayer-progress-text">
                   <%= slayer.level.xp.toLocaleString() %><% if(slayer.level.xpForNext != 0){ %> / <%= slayer.level.xpForNext.toLocaleString() %><% } %> XP
-                </div>
-              </div>
-            </div>
-          <% } %>
-          <% if(calculated.display_name == "metalcupcake5"){ %>
-            <div class="narrow-info-container slayer">
-              <div class="narrow-info-header">
-                <div class="floor-icon" style="background-image: url(/head/bb13133a8fb4ef00b71ef9bab639a66fbc7d5cffcc190c1df74bf2161dfd3ec7)"></div>
-                <span>Congealed Monstrosity</span>
-              </div>
-              <div class="slayer-kills">
-                  <div class="slayer-kill"><div class="tier-name">Tier I</div><div class="tier-kills">39283</div></div>
-                <div class="slayer-kill"><div class="tier-name">Total</div><div class="tier-kills">39283</div></div>
-              </div>
-              <span class="stat-name slayer-level">Slime level <span class="stat-value">-3</span></span>
-              <div class="slayer-bar ">
-                <div class="skill-progress-bar slayer-progress-bar" style="--progress: 1.3"></div>
-                <div class="skill-progress-text slayer-progress-text">
-                  69420 / 1.4b XP
                 </div>
               </div>
             </div>


### PR DESCRIPTION
wowo metal actually contributing

this pr edits the `minions_max_uniques` constant to automatically calculate how many unique minions a user can craft
it also has a fix for #730 