### PR TITLE
New gemstone slots support (defensive, combat, mining)

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -823,6 +823,36 @@ export function parseItemGems(gems, rarity) {
         gem_type: gems[`${key}_gem`],
         gem_tier: value,
       });
+    } else if (key.startsWith("DEFENSIVE_")) {
+      if (key.endsWith("_gem")) {
+        continue;
+      }
+      parsed.push({
+        slot_type: "DEFENSIVE",
+        slot_number: +key.split("_")[1],
+        gem_type: gems[`${key}_gem`],
+        gem_tier: value,
+      });
+    } else if (key.startsWith("COMBAT_")) {
+      if (key.endsWith("_gem")) {
+        continue;
+      }
+      parsed.push({
+        slot_type: "COMBAT",
+        slot_number: +key.split("_")[1],
+        gem_type: gems[`${key}_gem`],
+        gem_tier: value,
+      });
+    } else if (key.startsWith("MINING_")) {
+      if (key.endsWith("_gem")) {
+        continue;
+      }
+      parsed.push({
+        slot_type: "MINING",
+        slot_number: +key.split("_")[1],
+        gem_type: gems[`${key}_gem`],
+        gem_tier: value,
+      });
     } else {
       parsed.push({
         slot_type: key.split("_")[0],


### PR DESCRIPTION
Closes #790 

Adds support for Mining, Combat and Defensive gemstone slots types on top of Universal and gem specific ones

Fixes https://sky.shiiyu.moe/stats/snapdoomy `TypeError: Cannot read property 'color' of undefined`

⚠️ I could not find any profile with a MINING slot being used, so that's not tested (and I do not own a X655 or Divan Drill)