### PR TITLE
(fix) Some gemstone stats for divine

### DIFF
--- a/src/constants/gemstones.js
+++ b/src/constants/gemstones.js
@@ -1,7 +1,7 @@
 /*
  * gemstone stats values:
  * - int: exact value
- * - null: value doesn't exist, gem can't be applied to any item of that rarity
+ * - null: unknown value
  */
 export const gemstones = {
   JADE: {
@@ -9,19 +9,19 @@ export const gemstones = {
     color: "a",
     stats: {
       ROUGH: {
-        mining_fortune: [null, 4, 6, 8, 10, 12],
+        mining_fortune: [null, 4, 6, 8, 10, 12, null],
       },
       FLAWED: {
-        mining_fortune: [null, 5, 7, 10, 14, 18],
+        mining_fortune: [null, 5, 7, 10, 14, 18, null],
       },
       FINE: {
-        mining_fortune: [null, 7, 10, 15, 20, 25],
+        mining_fortune: [null, 7, 10, 15, 20, 25, null],
       },
       FLAWLESS: {
-        mining_fortune: [null, 10, 15, 20, 27, 35],
+        mining_fortune: [null, 10, 15, 20, 27, 35, null],
       },
       PERFECT: {
-        mining_fortune: [null, 14, 20, 30, 40, 50],
+        mining_fortune: [null, 14, 20, 30, 40, 50, 60],
       },
     },
   },
@@ -30,19 +30,19 @@ export const gemstones = {
     color: "6",
     stats: {
       ROUGH: {
-        mining_speed: [4, 8, 12, 16, 20, 24],
+        mining_speed: [4, 8, 12, 16, 20, 24, null],
       },
       FLAWED: {
-        mining_speed: [6, 10, 14, 18, 24, 30],
+        mining_speed: [6, 10, 14, 18, 24, 30, null],
       },
       FINE: {
-        mining_speed: [10, 14, 20, 28, 36, 45],
+        mining_speed: [10, 14, 20, 28, 36, 45, null],
       },
       FLAWLESS: {
-        mining_speed: [14, 20, 30, 44, 58, 75],
+        mining_speed: [14, 20, 30, 44, 58, 75, null],
       },
       PERFECT: {
-        mining_speed: [20, 28, 40, 60, 80, 100],
+        mining_speed: [20, 28, 40, 60, 80, 100, 120],
       },
     },
   },
@@ -51,19 +51,19 @@ export const gemstones = {
     color: "e",
     stats: {
       ROUGH: {
-        pristine: [null, null, 0.4, 0.4, 0.4, 0.4],
+        pristine: [null, null, 0.4, 0.4, 0.4, 0.4, null],
       },
       FLAWED: {
-        pristine: [null, null, 0.8, 0.8, 0.8, 0.8],
+        pristine: [null, null, 0.8, 0.8, 0.8, 0.8, null],
       },
       FINE: {
-        pristine: [null, null, 1.2, 1.2, 1.2, 1.2],
+        pristine: [null, null, 1.2, 1.2, 1.2, 1.2, null],
       },
       FLAWLESS: {
-        pristine: [null, null, 1.6, 1.6, 1.6, 1.6],
+        pristine: [null, null, 1.6, 1.6, 1.6, 1.6, null],
       },
       PERFECT: {
-        pristine: [null, null, 2, 2, 2, 2],
+        pristine: [null, null, 2, 2, 2, 2, 2.2],
       },
     },
   },
@@ -72,19 +72,19 @@ export const gemstones = {
     color: "b",
     stats: {
       ROUGH: {
-        intelligence: [2, 2, 3, 4, 5, 6],
+        intelligence: [2, 2, 3, 4, 5, 6, null],
       },
       FLAWED: {
-        intelligence: [4, 4, 5, 6, 7, 8],
+        intelligence: [4, 4, 5, 6, 7, 8, null],
       },
       FINE: {
-        intelligence: [6, 6, 7, 8, 9, 10],
+        intelligence: [6, 6, 7, 8, 9, 10, null],
       },
       FLAWLESS: {
-        intelligence: [8, 9, 10, 12, 14, 16],
+        intelligence: [8, 9, 10, 12, 14, 16, null],
       },
       PERFECT: {
-        intelligence: [10, 12, 14, 17, 20, 25],
+        intelligence: [10, 12, 14, 17, 20, 25, null],
       },
     },
   },
@@ -93,19 +93,19 @@ export const gemstones = {
     color: "5",
     stats: {
       ROUGH: {
-        defense: [1, 2, 3, 4, 5, 7],
+        defense: [1, 2, 3, 4, 5, 7, null],
       },
       FLAWED: {
-        defense: [3, 4, 5, 6, 8, 10],
+        defense: [3, 4, 5, 6, 8, 10, null],
       },
       FINE: {
-        defense: [4, 5, 6, 8, 10, 14],
+        defense: [4, 5, 6, 8, 10, 14, null],
       },
       FLAWLESS: {
-        defense: [5, 7, 10, 14, 18, 22],
+        defense: [5, 7, 10, 14, 18, 22, null],
       },
       PERFECT: {
-        defense: [6, 9, 13, 18, 24, 30],
+        defense: [6, 9, 13, 18, 24, 30, null],
       },
     },
   },
@@ -114,19 +114,19 @@ export const gemstones = {
     color: "d",
     stats: {
       ROUGH: {
-        strength: [null, null, 1, 2, 2, 3],
+        strength: [null, null, 1, 2, 2, 3, null],
       },
       FLAWED: {
-        strength: [null, null, 2, 3, 3, 4],
+        strength: [null, null, 2, 3, 3, 4, null],
       },
       FINE: {
-        strength: [null, null, 3, 4, 4, 5],
+        strength: [null, null, 3, 4, 4, 5, null],
       },
       FLAWLESS: {
-        strength: [null, null, 5, 6, 7, 8],
+        strength: [null, null, 5, 6, 7, 8, null],
       },
       PERFECT: {
-        strength: [null, null, 7, 9, 10, 12],
+        strength: [null, null, 7, 9, 10, 12, null],
       },
     },
   },
@@ -135,19 +135,19 @@ export const gemstones = {
     color: "c",
     stats: {
       ROUGH: {
-        health: [1, 2, 3, 4, 5, 7],
+        health: [1, 2, 3, 4, 5, 7, null],
       },
       FLAWED: {
-        health: [3, 4, 5, 6, 8, 10],
+        health: [3, 4, 5, 6, 8, 10, null],
       },
       FINE: {
-        health: [4, 5, 6, 8, 10, 14],
+        health: [4, 5, 6, 8, 10, 14, null],
       },
       FLAWLESS: {
-        health: [5, 7, 10, 14, 18, 22],
+        health: [5, 7, 10, 14, 18, 22, null],
       },
       PERFECT: {
-        health: [6, 9, 13, 18, 24, 30],
+        health: [6, 9, 13, 18, 24, 30, null],
       },
     },
   },


### PR DESCRIPTION
This fix requires #808 to be merged (since that PR adds support for Divine rarity)

Basically added the few known stats of gemstones on divine rarity (based on DeathStreeks Divan's Drill), also changed the main comment again so that `null` values are to be considering "unknown value" which is honestly more correct.

Added `null` on everything unknown, I could've left it empty but this way is easier to spot missing values for future updates.