### PR TITLE
Quick claw

### DIFF
--- a/src/constants/pet-stats.js
+++ b/src/constants/pet-stats.js
@@ -78,6 +78,9 @@ class Pet {
         case "mining_speed":
           list.push(`§7Mining Speed: ${formatStat(newStats[stat])}`);
           break;
+        case "mining_fortune":
+          list.push(`§7Mining Fortune: ${formatStat(newStats[stat])}`);
+          break;
         default:
           list.push(`§cUNKNOWN: ${stat}`);
           break;

--- a/src/constants/pets.js
+++ b/src/constants/pets.js
@@ -1,18 +1,4 @@
-const symbols = {
-  health: "❤",
-  defense: "❈",
-  strength: "❁",
-  crit_chance: "☣",
-  crit_damage: "☠",
-  intelligence: "✎",
-  speed: "✦",
-  sea_creature_chance: "α",
-  magic_find: "✯",
-  pet_luck: "♣",
-  attack_speed: "⚔️",
-  true_defense: "❂",
-  ferocity: "⫽",
-};
+import { stats_symbols as symbols } from "./stats.js";
 
 export const pet_rarity_offset = {
   common: 0,
@@ -842,6 +828,17 @@ export const pet_rewards = {
   },
 };
 
+/*
+  PET_ITEM_ID = {
+    name: string,
+    tier: string (uppercase),
+    description: string,
+    stats?: {stat: value},
+    statsPerLevel?: {stat: value},
+    multStats?: {stat: value},
+    multAllStats?: {stat: value},
+  }
+*/
 export const pet_items = {
   PET_ITEM_ALL_SKILLS_BOOST_COMMON: {
     name: "All Skills Exp Boost",
@@ -1018,7 +1015,6 @@ export const pet_items = {
     tier: "EPIC",
     description: "§7Gives +§a50% §7pet exp for Farming",
   },
-  // new pet items from 0.9 update yay
   REINFORCED_SCALES: {
     name: "Reinforced Scales",
     tier: "RARE",
@@ -1120,5 +1116,14 @@ export const pet_items = {
     name: "Flying Pig",
     tier: "UNCOMMON",
     description: `§7Grants your pig pet the ability to fly while on your private island! You also don't need to hold a carrot on a stick to control your pig.`,
+  },
+  PET_ITEM_QUICK_CLAW: {
+    name: "Quick Claw",
+    tier: "RARE",
+    description: `§7Every 2 pet level you gain §6+1 ${symbols.mining_speed} Mining Speed §7and §6+1 §6${symbols.mining_fortune} Mining Fortune§7.`,
+    statsPerLevel: {
+      mining_speed: 1,
+      mining_fortune: 1,
+    },
   },
 };

--- a/src/lib.js
+++ b/src/lib.js
@@ -2897,22 +2897,16 @@ export async function getPets(profile) {
       let heldItemObj = await db.collection("items").findOne({ id: heldItem });
 
       if (heldItem in constants.pet_items) {
-        if ("stats" in constants.pet_items[heldItem]) {
-          for (const stat in constants.pet_items[heldItem].stats) {
-            pet.stats[stat] = (pet.stats[stat] || 0) + constants.pet_items[heldItem].stats[stat];
-          }
+        for (const stat in constants.pet_items[heldItem]?.stats) {
+          pet.stats[stat] = (pet.stats[stat] || 0) + constants.pet_items[heldItem].stats[stat];
         }
-        if ("statsPerLevel" in constants.pet_items[heldItem]) {
-          for (const stat in constants.pet_items[heldItem].statsPerLevel) {
-            pet.stats[stat] =
-              (pet.stats[stat] || 0) + constants.pet_items[heldItem].statsPerLevel[stat] * pet.level.level;
-          }
+        for (const stat in constants.pet_items[heldItem]?.statsPerLevel) {
+          pet.stats[stat] =
+            (pet.stats[stat] || 0) + constants.pet_items[heldItem].statsPerLevel[stat] * pet.level.level;
         }
-        if ("multStats" in constants.pet_items[heldItem]) {
-          for (const stat in constants.pet_items[heldItem].multStats) {
-            if (pet.stats[stat]) {
-              pet.stats[stat] = (pet.stats[stat] || 0) * constants.pet_items[heldItem].multStats[stat];
-            }
+        for (const stat in constants.pet_items[heldItem]?.multStats) {
+          if (pet.stats[stat]) {
+            pet.stats[stat] = (pet.stats[stat] || 0) * constants.pet_items[heldItem].multStats[stat];
           }
         }
         if ("multAllStats" in constants.pet_items[heldItem]) {

--- a/src/lib.js
+++ b/src/lib.js
@@ -2902,6 +2902,12 @@ export async function getPets(profile) {
             pet.stats[stat] = (pet.stats[stat] || 0) + constants.pet_items[heldItem].stats[stat];
           }
         }
+        if ("statsPerLevel" in constants.pet_items[heldItem]) {
+          for (const stat in constants.pet_items[heldItem].statsPerLevel) {
+            pet.stats[stat] =
+              (pet.stats[stat] || 0) + constants.pet_items[heldItem].statsPerLevel[stat] * pet.level.level;
+          }
+        }
         if ("multStats" in constants.pet_items[heldItem]) {
           for (const stat in constants.pet_items[heldItem].multStats) {
             if (pet.stats[stat]) {


### PR DESCRIPTION
Support for new Quick Claw pet item:
![image](https://user-images.githubusercontent.com/2744227/133256411-00f7395c-ea7b-4f39-92ff-7ff91d025f36.png)

pet items now can have a new property `statsPerLevel` to make this new pet item work

![image](https://user-images.githubusercontent.com/2744227/133256477-c2f29ad7-7457-417b-a476-b82f2112e638.png)

Closes #792 