### PR TITLE
fix: parseItemGems refactor

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -811,55 +811,37 @@ export function generateUUID() {
  */
 export function parseItemGems(gems, rarity) {
   /** @type {Gem[]} */
+
+  const slots = {
+    normal: Object.keys(constants.gemstones),
+    special: ["UNIVERSAL", "COMBAT", "OFFENSIVE", "DEFENSIVE", "MINING"],
+    ignore: ["unlocked_slots"],
+  };
+
   const parsed = [];
   for (const [key, value] of Object.entries(gems)) {
-    if (key.startsWith("UNIVERSAL_")) {
-      if (key.endsWith("_gem")) {
-        continue;
-      }
+    const slot_type = key.split("_")[0];
+
+    if (slots.ignore.includes(key) || (slots.special.includes(slot_type) && key.endsWith("_gem"))) {
+      continue;
+    }
+
+    if (slots.special.includes(slot_type)) {
       parsed.push({
-        slot_type: "UNIVERSAL",
+        slot_type,
         slot_number: +key.split("_")[1],
         gem_type: gems[`${key}_gem`],
         gem_tier: value,
       });
-    } else if (key.startsWith("DEFENSIVE_")) {
-      if (key.endsWith("_gem")) {
-        continue;
-      }
-      parsed.push({
-        slot_type: "DEFENSIVE",
-        slot_number: +key.split("_")[1],
-        gem_type: gems[`${key}_gem`],
-        gem_tier: value,
-      });
-    } else if (key.startsWith("COMBAT_")) {
-      if (key.endsWith("_gem")) {
-        continue;
-      }
-      parsed.push({
-        slot_type: "COMBAT",
-        slot_number: +key.split("_")[1],
-        gem_type: gems[`${key}_gem`],
-        gem_tier: value,
-      });
-    } else if (key.startsWith("MINING_")) {
-      if (key.endsWith("_gem")) {
-        continue;
-      }
-      parsed.push({
-        slot_type: "MINING",
-        slot_number: +key.split("_")[1],
-        gem_type: gems[`${key}_gem`],
-        gem_tier: value,
-      });
-    } else {
+    } else if (slots.normal.includes(slot_type)) {
       parsed.push({
         slot_type: key.split("_")[0],
         slot_number: +key.split("_")[1],
         gem_type: key.split("_")[0],
         gem_tier: value,
       });
+    } else {
+      throw `Error! Unknwon gemstone slot key: ${key}`;
     }
   }
 

--- a/src/helper.js
+++ b/src/helper.js
@@ -835,7 +835,7 @@ export function parseItemGems(gems, rarity) {
       });
     } else if (slots.normal.includes(slot_type)) {
       parsed.push({
-        slot_type: key.split("_")[0],
+        slot_type,
         slot_number: +key.split("_")[1],
         gem_type: key.split("_")[0],
         gem_tier: value,


### PR DESCRIPTION
Fixes `TypeError: Cannot read property 'color' of undefined` for:
- https://sky.shiiyu.moe/stats/TheDarkKillerGR
- https://sky.shiiyu.moe/stats/15h

Basically yesterday I didn't knew `OFFENSIVE` was another type of special slot, but I also noticed there's a new key for only the new items in `ExtraAttributes.gemstones.slots_unlocked` that needs to be ignored while parsing the gems.

So I just went ahead and refactored the function a bit, now it's much more cleaner and should also give a straightforward error message in case new unknown keys appear.