### PR TITLE
Fallback divine gemstone stats (feedback?)

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -875,7 +875,13 @@ export function generateGemLore(type, tier, rarity) {
     const gemstone_stats = constants.gemstones[type.toUpperCase()]?.stats?.[tier.toUpperCase()];
     if (gemstone_stats) {
       Object.keys(gemstone_stats).forEach((stat) => {
-        const stat_value = gemstone_stats[stat][rarityNameToInt(rarity)];
+        let stat_value = gemstone_stats[stat][rarityNameToInt(rarity)];
+
+        // Fallback since skyblock devs didn't code all gemstone stats for divine rarity yet
+        // ...they didn't expect people to own divine tier items other than divan's drill
+        if (rarity.toUpperCase() === "DIVINE" && stat_value === null) {
+          stat_value = gemstone_stats[stat][rarityNameToInt("MYTHIC")];
+        }
 
         if (stat_value) {
           stats.push(["§", constants.stats_colors[stat], "+", stat_value, constants.stats_symbols[stat]].join(""));


### PR DESCRIPTION
This temporarily solves the issue, but I would like some feedback.

Basically in game there's some DIVINE rarity items that aren't supposed to exist, mostly dungeon armor like Necron or Shadow Assassin, example:

https://sky.shiiyu.moe/stats/Bucklez/Coconut#Armor
![image](https://user-images.githubusercontent.com/2744227/133478959-398b5f4f-2540-486c-a5d0-0b8994ce2830.png)

What I think happened is that admins didn't expect/know this items existed so they didn't code in the values for DIVINE stats in gemstone that can't be applied to Divan's Drill (the only item that should have DIVINE rarity as of right now).
In game that item gems use the value as if the item was a a mythic rarity, so as a temporarily solution I coded that if the item is DIVINE and we are missing the gemstone stat value it tries to fallback to MYTHIC.

What do you think?

Instead of doing this we could just hardcode the "fake/temp" values where they are missing, so like Flawless Sapphire will give the same stats in both mythic and divine. But doing this will probably mean that in the future we might not be sure which values were added temporarily and which are the definitive ones... with the risk of forgetting to update some.
