### PR TITLE
armor_set refactor with some bug fixes

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,4 @@
+export * from "./constants/armor.js";
 export * from "./constants/bonuses.js";
 export * from "./constants/collections.js";
 export * from "./constants/dungeons.js";

--- a/src/constants/armor.js
+++ b/src/constants/armor.js
@@ -1,0 +1,15 @@
+// Object with skill, slayer bonuses and enchantment bonuses
+export const special_sets = [
+  {
+    pieces: ["SKELETON_HELMET", "GUARDIAN_CHESTPLATE", "CREEPER_LEGGINGS", "SPIDER_BOOTS"],
+    name: "Monster Hunter Armor",
+  },
+  {
+    pieces: ["SKELETON_HELMET", "GUARDIAN_CHESTPLATE", "CREEPER_LEGGINGS", "TARANTULA_BOOTS"],
+    name: "Monster Raider Armor",
+  },
+  {
+    pieces: ["SPONGE_HELMET", "SPONGE_CHESTPLATE", "SPONGE_LEGGINGS", "SPONGE_BOOTS"],
+    name: "Sponge Armor",
+  },
+];

--- a/src/constants/armor.js
+++ b/src/constants/armor.js
@@ -12,4 +12,24 @@ export const special_sets = [
     pieces: ["SPONGE_HELMET", "SPONGE_CHESTPLATE", "SPONGE_LEGGINGS", "SPONGE_BOOTS"],
     name: "Sponge Armor",
   },
+  {
+    pieces: ["FAIRY_HELMET", "FAIRY_CHESTPLATE", "FAIRY_LEGGINGS", "FAIRY_BOOTS"],
+    name: "Fairy Armor",
+  },
+  {
+    pieces: ["DIVER_HELMET", "DIVER_CHESTPLATE", "DIVER_LEGGINGS", "DIVER_BOOTS"],
+    name: "Diver Armor",
+  },
+  {
+    pieces: ["LEAFLET_HELMET", "LEAFLET_CHESTPLATE", "LEAFLET_LEGGINGS", "LEAFLET_BOOTS"],
+    name: "Leaflet Armor",
+  },
+  {
+    pieces: ["MASTIFF_HELMET", "MASTIFF_CHESTPLATE", "MASTIFF_LEGGINGS", "MASTIFF_BOOTS"],
+    name: "Mastiff Armor",
+  },
+  {
+    pieces: ["ADAPTIVE_HELMET", "ADAPTIVE_CHESTPLATE", "ADAPTIVE_LEGGINGS", "ADAPTIVE_BOOTS"],
+    name: "Adaptive Armor",
+  },
 ];

--- a/src/lib.js
+++ b/src/lib.js
@@ -1618,10 +1618,16 @@ export const getItems = async (
         name = name.split(" ").slice(1).join(" ");
       }
 
-      // Replacing piece name with 'Armor' and removing potential 'Armor Armor'
-      // (Ex: Emerald Armor Boots -> Emerald Armor Armor)
-      name = name.replace("Armor", "").replace("  ", " ").trim();
-      name = name.replace(/(Helmet|Chestplate|Leggings|Boots)/g, "Armor");
+      // Converting armor_name to generic name
+      // Ex: Superior Dragon Helmet -> Superior Dragon Armor
+      if (/^Armor .*? (Helmet|Chestplate|Leggings|Boots)$/g.test(name)) {
+        // name starts with Armor and ends with piece name, remove piece name
+        name = name.replace(/(Helmet|Chestplate|Leggings|Boots)/g, "").trim();
+      } else {
+        // removing old 'Armor' and replacing the piece name with 'Armor'
+        name = name.replace("Armor", "").replace("  ", " ").trim();
+        name = name.replace(/(Helmet|Chestplate|Leggings|Boots)/g, "Armor").trim();
+      }
 
       armorPiece.armor_name = name;
     });


### PR DESCRIPTION
Ok so basically someone reported this:
![image](https://user-images.githubusercontent.com/2744227/134667761-dd48d9e3-7ef3-41fc-87eb-545732eaba61.png)

one thing got to another and... well refactored half the code of armor_set.

Now:
- it should be much easier to understand
- the bug has been fixed
- armor_name ignores master stars ⍟ and skin ✦
- armor_name converts directly *piece name* to Armor
- special sets of armor have been moved to constants/armor.js
- armor_set_rarity now calculates the highest rarity of the armor set instead of just using the boots rarity
- support for all armor sets added in the past 2 years... yeah this code was quite outdated

Only feature lost is if you are wearing different tiers of Perfect Armor, before it would display "Perfect Armor" while now it doesn't display anything. I prefer it this way so I don't have to hard-code anything specific in lib.js.


I tested this changes with plenty of armor sets in different scenarios:
- Yog Armor (no reforge)
- Perfect Armor - Tier XII
- Perfect Armor (different tiers)
- Tarantula Armor (different reforges and rarity on the pieces)
- Renowned Superior Dragon Armor
- Mixed armor sets

Hopefully I didn't miss anything!