### PR TITLE
forge css fix

### DIFF
--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -4212,9 +4212,13 @@ body {
 .forge-item {
   display: flex;
   gap: 8px;
-  align-items: center;
+  align-items: flex-start;
+  & + & {
+    margin-top: 4px;
+  }
 }
 
 .forge-slot {
   margin: 0;
+  white-space: nowrap;
 }


### PR DESCRIPTION
Quick css fixes for mobile.

The forge-slot name ("Slot 1:") doesn't split in 2 lines on mobile.
The forge-item have a 4px space between them (mostly useful in mobile, but nice on desktop too) and aligned on top to not look weird on mobile.