### PR TITLE
fix: remove smooth scrolling on the API page

### DIFF
--- a/public/resources/scss/api.scss
+++ b/public/resources/scss/api.scss
@@ -6,6 +6,8 @@
 html {
   background: white;
 
+  scroll-behavior: initial;
+
   &:before {
     content: none;
   }


### PR DESCRIPTION
remove smooth scrolling, which was breaking the API page, as mentioned in #880

Closes #880