### PR TITLE
fix mining-forge-processes optional chaining

### DIFF
--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1325,12 +1325,12 @@ const getRarityUpgradeClass = item => {
             </div>
           <% } %>
           <p class="stat-sub-header">Forge</p>
-          <% if(mining.forge.processes.length > 0){
+          <% if(mining.forge?.processes?.length > 0){
           mining.forge.processes.forEach(process => { %>
             <div class="forge-item">
               <p class="stat-name forge-slot">Slot <%= process.slot %>:</p>
               <span data-tippy-content='<local-time timestamp="<%= process.timeFinished %>"></local-time>'><span class="stat-raw-values"><%= process.name %> - <%= process.timeFinished < Date.now() ? "ended" : `ending ${process.timeFinishedText}`%></span></span>
-            </div>    
+            </div>
           <% });
         } else { %>
             <p class="stat-raw-values">No items currently forging!</p>


### PR DESCRIPTION
player who never went to forge can't see their profile anymore, examples:
- https://sky.shiiyu.moe/stats/femboynate
- https://sky.shiiyu.moe/stats/dynamicex