### PR TITLE
minify HTML literals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -246,6 +246,16 @@
       "resolved": "https://registry.npmjs.org/@tillhub/tableify/-/tableify-1.1.1.tgz",
       "integrity": "sha512-RPqzG9eP0eeGLYBABK6YKzr+s/0YmPDRjiio75CVQzCbjXcSmcZtT8t345DLYVpqmFPdyMin94BDd1a1ZGEDGw=="
     },
+    "@types/clean-css": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@types/clean-css/-/clean-css-4.2.5.tgz",
+      "integrity": "sha512-NEzjkGGpbs9S9fgC4abuBvTpVwE3i+Acu9BBod3PUyjDVZcNsGx61b8r2PphR61QGPnn0JHVs5ey6/I4eTrkxw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "source-map": "^0.6.0"
+      }
+    },
     "@types/debug": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
@@ -268,6 +278,17 @@
       "requires": {
         "@types/minimatch": "*",
         "@types/node": "*"
+      }
+    },
+    "@types/html-minifier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@types/html-minifier/-/html-minifier-3.5.3.tgz",
+      "integrity": "sha512-j1P/4PcWVVCPEy5lofcHnQ6BtXz9tHGiFPWzqm7TtGuWZEfCHEP446HlkSNc9fQgNJaJZ6ewPtp2aaFla/Uerg==",
+      "dev": true,
+      "requires": {
+        "@types/clean-css": "*",
+        "@types/relateurl": "*",
+        "@types/uglify-js": "*"
       }
     },
     "@types/json-schema": {
@@ -303,6 +324,12 @@
       "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.6.4.tgz",
       "integrity": "sha512-u8SAgdZ8ROtkTF+mfZGOscl0or6BSj9A4g37e6nvxDc+YB/oDut0wHkK2PBBiC2bNR8TS0CPV+1gAk4fNisr1Q=="
     },
+    "@types/relateurl": {
+      "version": "0.2.29",
+      "resolved": "https://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.29.tgz",
+      "integrity": "sha512-QSvevZ+IRww2ldtfv1QskYsqVVVwCKQf1XbwtcyyoRvLIQzfyPhj/C+3+PKzSDRdiyejaiLgnq//XTkleorpLg==",
+      "dev": true
+    },
     "@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -329,6 +356,15 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+    },
+    "@types/uglify-js": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.13.1.tgz",
+      "integrity": "sha512-O3MmRAk6ZuAKa9CHgg0Pr0+lUOqoMLpc9AS4R8ano2auvsg7IE8syF3Xh/NPr26TWklxYcqoEEFdzLLs1fV9PQ==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      }
     },
     "@types/webidl-conversions": {
       "version": "6.1.1",
@@ -1102,6 +1138,16 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
+    "camel-case": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
+      }
+    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -1189,6 +1235,15 @@
             "is-descriptor": "^0.1.0"
           }
         }
+      }
+    },
+    "clean-css": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz",
+      "integrity": "sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==",
+      "dev": true,
+      "requires": {
+        "source-map": "~0.6.0"
       }
     },
     "clean-stack": {
@@ -3133,6 +3188,27 @@
         "traverse": ">=0.2.4"
       }
     },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "html-minifier": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-4.0.0.tgz",
+      "integrity": "sha512-aoGxanpFPLg7MkIl/DDFYtb0iWz7jMFGqFhvEDZga6/4QTjneiD8I/NXL1x5aaoCp7FSIT6h/OhykDdPsbtMig==",
+      "dev": true,
+      "requires": {
+        "camel-case": "^3.0.0",
+        "clean-css": "^4.2.1",
+        "commander": "^2.19.0",
+        "he": "^1.2.0",
+        "param-case": "^2.1.1",
+        "relateurl": "^0.2.7",
+        "uglify-js": "^3.5.1"
+      }
+    },
     "http-cache-semantics": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
@@ -4017,6 +4093,12 @@
       "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
       "dev": true
     },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+      "dev": true
+    },
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -4149,6 +4231,19 @@
       "version": "2.95.0",
       "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-2.95.0.tgz",
       "integrity": "sha512-e/WgRMU86diPtuqYJncmiAszpy8LmNjMb+raEwGFY0+eFi84WcinXyts7Lcuvj/lTYvX5tuQ1wFMjOpLwdTk+w=="
+    },
+    "minify-html-literals": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/minify-html-literals/-/minify-html-literals-1.3.5.tgz",
+      "integrity": "sha512-p8T8ryePRR8FVfJZLVFmM53WY25FL0moCCTycUDuAu6rf9GMLwy0gNjXBGNin3Yun7Y+tIWd28axOf0t2EpAlQ==",
+      "dev": true,
+      "requires": {
+        "@types/html-minifier": "^3.5.3",
+        "clean-css": "^4.2.1",
+        "html-minifier": "^4.0.0",
+        "magic-string": "^0.25.0",
+        "parse-literals": "^1.2.1"
+      }
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -4310,6 +4405,15 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+    },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "dev": true,
+      "requires": {
+        "lower-case": "^1.1.1"
+      }
     },
     "node-abi": {
       "version": "2.30.1",
@@ -4597,6 +4701,15 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
+    "param-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0"
+      }
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4604,6 +4717,15 @@
       "dev": true,
       "requires": {
         "callsites": "^3.0.0"
+      }
+    },
+    "parse-literals": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/parse-literals/-/parse-literals-1.2.1.tgz",
+      "integrity": "sha512-Ml0w104Ph2wwzuRdxrg9booVWsngXbB4bZ5T2z6WyF8b5oaNkUmBiDtahi34yUIpXD8Y13JjAK6UyIyApJ73RQ==",
+      "dev": true,
+      "requires": {
+        "typescript": "^2.9.2 || ^3.0.0 || ^4.0.0"
       }
     },
     "parse5": {
@@ -4956,6 +5078,12 @@
         "rc": "^1.2.8"
       }
     },
+    "relateurl": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+      "dev": true
+    },
     "relaxed-json": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/relaxed-json/-/relaxed-json-1.0.3.tgz",
@@ -5077,6 +5205,16 @@
         "del": "^5.1.0"
       }
     },
+    "rollup-plugin-minify-html-literals": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-minify-html-literals/-/rollup-plugin-minify-html-literals-1.2.6.tgz",
+      "integrity": "sha512-JRq2fjlCTiw0zu+1Sy3ClHGCxA79dWGr4HLHWSQgd060StVW9fBVksuj8Xw/suPkNSGClJf/4xNQ1MF6JeXPaw==",
+      "dev": true,
+      "requires": {
+        "minify-html-literals": "^1.3.5",
+        "rollup-pluginutils": "^2.8.2"
+      }
+    },
     "rollup-plugin-terser": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
@@ -5087,6 +5225,23 @@
         "jest-worker": "^26.2.1",
         "serialize-javascript": "^4.0.0",
         "terser": "^5.0.0"
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^0.6.1"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+          "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+          "dev": true
+        }
       }
     },
     "run-parallel": {
@@ -6127,6 +6282,12 @@
       "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
       "dev": true
     },
+    "uglify-js": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.2.tgz",
+      "integrity": "sha512-rtPMlmcO4agTUfz10CbgJ1k6UAoXM2gWb3GoMPPZB/+/Ackf8lNWk11K4rYi2D0apgoFRLtQOZhb+/iGNJq26A==",
+      "dev": true
+    },
     "uid-safe": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
@@ -6304,6 +6465,12 @@
       "requires": {
         "pako": "^1.0.5"
       }
+    },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
+      "dev": true
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "prettier": "2.4.1",
     "rollup": "^2.58.0",
     "rollup-plugin-delete": "^2.0.0",
+    "rollup-plugin-minify-html-literals": "^1.2.6",
     "rollup-plugin-terser": "^7.0.2",
     "sass": "^1.43.2",
     "ts-lit-plugin": "^1.2.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,7 @@ import typescript from "@rollup/plugin-typescript";
 import resolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 import { terser } from "rollup-plugin-terser";
+import minifyHTML from "rollup-plugin-minify-html-literals";
 import nameMap from "./lib/rollup-plugin-name-map.js";
 import del from "rollup-plugin-delete";
 import replace from "@rollup/plugin-replace";
@@ -37,6 +38,14 @@ const config = {
     resolve(), // tells Rollup how to stuff in node_modules
     commonjs(), // converts Node modules to ES modules
     production && terser(), // minify, but only in production
+    production && // minify html strings inside javascript (aka lit-html)
+      minifyHTML({
+        options: {
+          minifyOptions: {
+            conservativeCollapse: true,
+          },
+        },
+      }),
     nameMap("public/resources/js/file-name-map.json"),
   ],
 };


### PR DESCRIPTION
this PR adds a rollup plugin to remove extra whitespace in HTML string literals

before:
```js
`<div class="view-backpack" @click="${() => showBackpack(backpack)}">
            <span>View Backpack</span>
            <small>(Right click backpack to immediately open)</small>
          </div>`
```
after:
```js
`<div class="view-backpack" @click="${() => showBackpack(backpack)}"> <span>View Backpack</span> <small>(Right click backpack to immediately open)</small> </div>`
```