### PR TITLE
Hotm fixes

### DIFF
--- a/src/constants/hotm.js
+++ b/src/constants/hotm.js
@@ -1280,10 +1280,15 @@ class HotmReset extends HotmItem {
       `§8- §d${this.resources.gemstone_powder.toLocaleString()} Gemstone Powder`,
       "",
       "§7You will §akeep §7any Tiers and §cPeak of the Mountain §7that you have unlocked.",
-      "",
-      "§7Cost",
-      "§6100,000 Coins",
     ];
+
+    // cost
+    output.push("", "§7Cost");
+    if (this.last_reset === 0) {
+      output.push("§aFREE §7for your first reset.");
+    } else {
+      output.push("§6100,000 Coins");
+    }
 
     // cooldown or warning
     if (Date.now() - this.last_reset > 24 * 60 * 60 * 1000) {

--- a/src/constants/hotm.js
+++ b/src/constants/hotm.js
@@ -1072,7 +1072,10 @@ class QuickForge extends Node {
   }
 
   perk(level) {
-    const val = round(10 + 0.5 * level, 1);
+    let val = round(10 + 0.5 * level, 1);
+    if (level === this.max_level) {
+      val = 30;
+    }
     return [`§7Decreases the time it takes to forge by §a${val}%§7.`];
   }
 }

--- a/src/constants/hotm.js
+++ b/src/constants/hotm.js
@@ -302,7 +302,9 @@ class Node {
       output.push(
         "",
         "§7Cost",
-        `§${upgrade_types[this.upgrade_type].color}${this.upgradeCost} ${upgrade_types[this.upgrade_type].name}`
+        `§${upgrade_types[this.upgrade_type].color}${this.upgradeCost.toLocaleString()} ${
+          upgrade_types[this.upgrade_type].name
+        }`
       );
     }
 


### PR DESCRIPTION
Fixes a couple issues with HotM:
- Quick forge at level 20 goes up by 10.5% instead of the normal 0.5% (so level 18 is 19%, 19 is 19.5%, 20 is 30%)
- Change the lore of the reset when user hasn't used the free reset yet
- Upgrade costs are now formatted (before: `123456`, after: `123.456`)