### PR TITLE
Social skill

### DIFF
--- a/src/constants/bonuses.js
+++ b/src/constants/bonuses.js
@@ -87,6 +87,9 @@ export const bonus_stats = {
   runecrafting_skill: {
     1: {},
   },
+  social_skill: {
+    1: {},
+  },
   zombie_slayer: {
     1: {
       health: 2,

--- a/src/constants/leveling.js
+++ b/src/constants/leveling.js
@@ -73,6 +73,7 @@ export const default_skill_caps = {
   taming: 50,
   carpentry: 50,
   runecrafting: 25,
+  social: 25,
 };
 
 export const maxed_skill_caps = {
@@ -106,6 +107,34 @@ export const runecrafting_xp = {
   23: 12200,
   24: 15300,
   25: 19050,
+};
+
+export const social_xp = {
+  1: 50,
+  2: 100,
+  3: 150,
+  4: 250,
+  5: 500,
+  6: 750,
+  7: 1000,
+  8: 1250,
+  9: 1500,
+  10: 2000,
+  11: 2500,
+  12: 3000,
+  13: 3750,
+  14: 4500,
+  15: 6000,
+  16: 8000,
+  17: 10000,
+  18: 12500,
+  19: 15000,
+  20: 20000,
+  21: 25000,
+  22: 30000,
+  23: 35000,
+  24: 40000,
+  25: 50000,
 };
 
 export const dungeoneering_xp = {

--- a/src/constants/weight.js
+++ b/src/constants/weight.js
@@ -59,6 +59,9 @@ export const skillWeight = {
   runecrafting: {
     maxLevel: 25,
   },
+  social: {
+    maxLevel: 25,
+  },
 };
 
 export const dungeonsWeight = {

--- a/src/lib.js
+++ b/src/lib.js
@@ -143,6 +143,9 @@ export function getLevelByXp(xp, extra = {}) {
     case "runecrafting":
       xp_table = constants.runecrafting_xp;
       break;
+    case "social":
+      xp_table = constants.social_xp;
+      break;
     case "dungeoneering":
       xp_table = constants.dungeoneering_xp;
       break;
@@ -1710,7 +1713,8 @@ export async function getLevels(userProfile, hypixelProfile, levelCaps) {
     "experience_skill_enchanting" in userProfile ||
     "experience_skill_alchemy" in userProfile ||
     "experience_skill_carpentry" in userProfile ||
-    "experience_skill_runecrafting" in userProfile
+    "experience_skill_runecrafting" in userProfile ||
+    "experience_skill_social" in userProfile
   ) {
     let average_level_no_progress = 0;
 
@@ -1731,10 +1735,14 @@ export async function getLevels(userProfile, hypixelProfile, levelCaps) {
         skill: "runecrafting",
         type: "runecrafting",
       }),
+      social: getLevelByXp(userProfile.experience_skill_social || 0, {
+        skill: "social",
+        type: "social",
+      }),
     };
 
     for (let skill in skillLevels) {
-      if (skill != "runecrafting" && skill != "carpentry" && skill != "social") {
+      if (!["runecrafting", "carpentry", "social"].includes(skill)) {
         average_level += skillLevels[skill].level + skillLevels[skill].progress;
         average_level_no_progress += skillLevels[skill].level;
 

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -74,15 +74,17 @@ const statShort = {
 };
 
 const skillItems = {
-  farming: "icon-294_0",
-  mining: "icon-274_0",
-  combat: "icon-272_0",
-  foraging: "icon-6_3",
-  fishing: "icon-346_0",
-  enchanting: "icon-116_0",
   alchemy: "icon-379_0",
   carpentry: "icon-58_0",
+  combat: "icon-272_0",
+  enchanting: "icon-116_0",
+  farming: "icon-294_0",
+  fishing: "icon-346_0",
+  foraging: "icon-6_3",
+  mining: "icon-274_0",
   runecrafting: "icon-378_0",
+  social: "icon-388_0",
+  taming: "icon-383_0",
 };
 
 const slayerInfo = {
@@ -151,6 +153,7 @@ const skillEmojis = {
   foraging: "🌳",
   mining: "⛏️",
   runecrafting: "✨",
+  social: "💬",
   taming: "🦴",
 };
 
@@ -1010,26 +1013,25 @@ const metaDescription = getMetaDescription()
       </div>
 
       <div id="skill_levels_container">
-        <%
-          if('levels' in calculated){
-        %>
+        <% if ('levels' in calculated) { %>
           <div class="skill-bars" data-api-enabled="<%= 'runecrafting' in calculated.levels %>">
-            <%= skill_component('Taming', 'icon-383_0', calculated.levels.taming) %>
-            <%= skill_component('Farming', 'icon-294_0', calculated.levels.farming) %>
-            <%= skill_component('Mining', 'icon-274_0', calculated.levels.mining) %>
-            <%= skill_component('Combat', 'icon-272_0', calculated.levels.combat) %>
-            <%= skill_component('Foraging', 'icon-6_3', calculated.levels.foraging) %>
-            <%= skill_component('Fishing', 'icon-346_0', calculated.levels.fishing) %>
-            <%= skill_component('Enchanting', 'icon-116_0', calculated.levels.enchanting) %>
-            <%= skill_component('Alchemy', 'icon-379_0', calculated.levels.alchemy) %>
-            <% if('runecrafting' in calculated.levels){ %>
-              <%= skill_component('Carpentry', 'icon-58_0', calculated.levels.carpentry) %>
-              <%= skill_component('Runecrafting', 'icon-378_0', calculated.levels.runecrafting) %>
-            <% }else{ %>
+            <%= skill_component('Taming', skillItems.taming, calculated.levels.taming) %>
+            <%= skill_component('Farming', skillItems.farming, calculated.levels.farming) %>
+            <%= skill_component('Mining', skillItems.mining, calculated.levels.mining) %>
+            <%= skill_component('Combat', skillItems.combat, calculated.levels.combat) %>
+            <%= skill_component('Foraging', skillItems.foraging, calculated.levels.foraging) %>
+            <%= skill_component('Fishing', skillItems.fishing, calculated.levels.fishing) %>
+            <%= skill_component('Enchanting', skillItems.enchanting, calculated.levels.enchanting) %>
+            <%= skill_component('Alchemy', skillItems.alchemy, calculated.levels.alchemy) %>
+            <% if ('runecrafting' in calculated.levels) { %>
+              <%= skill_component('Carpentry', skillItems.carpentry, calculated.levels.carpentry) %>
+              <%= skill_component('Runecrafting', skillItems.runecrafting, calculated.levels.runecrafting) %>
+              <%= skill_component('Social', skillItems.social, calculated.levels.social) %>
+            <% } else { %>
               <div class="no-access">Skills from achievements across profiles. <a target="_blank" class="enable-api" href="/resources/video/enable-api.mp4">Enable Skills API</a> for more accurate data.</div>
             <% } %>
           </div>
-        <% }else{ %>
+        <% } else { %>
           <div class="no-access"><%= calculated.display_name %> doesn't have skills access via API enabled. <a target="_blank" class="enable-api" href="/resources/video/enable-api.mp4">See here</a> how to enable full API access.</div>
         <% } %>
       </div>

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1026,7 +1026,7 @@ const metaDescription = getMetaDescription()
             <% if ('runecrafting' in calculated.levels) { %>
               <%= skill_component('Carpentry', skillItems.carpentry, calculated.levels.carpentry) %>
               <%= skill_component('Runecrafting', skillItems.runecrafting, calculated.levels.runecrafting) %>
-              <%= skill_component('Social', skillItems.social, calculated.levels.social) %>
+              <!--<%= skill_component('Social', skillItems.social, calculated.levels.social) %>-->
             <% } else { %>
               <div class="no-access">Skills from achievements across profiles. <a target="_blank" class="enable-api" href="/resources/video/enable-api.mp4">Enable Skills API</a> for more accurate data.</div>
             <% } %>


### PR DESCRIPTION
Adds support for social skill, but it's not being displayed (`skill_component()` commented out) since the API seems to be returning wrong values.

For my profile it doesn't even return the `experience_skill_social` key, even though I'm level 12. Same for Nate and Lea profiles.
For metalcupcake it returns a value, but it's far from the real value in game (returned value is level 2, in game he's level 11)


Merge anyway in case it will be fixed in the future?