### PR TITLE
forge processes unknown and scrolls

### DIFF
--- a/src/constants/forge.js
+++ b/src/constants/forge.js
@@ -63,6 +63,8 @@ export const forge_times = {
   BOOTS_OF_DIVAN: 23 * 60,
   DIVAN_DRILL: 2 * 24 * 60 + 12 * 60,
   PET: 12 * 24 * 60,
+  FORGE_TRAVEL_SCROLL: 5 * 60,
+  CRYSTAL_HOLLOWS_TRAVEL_SCROLL: 10 * 60,
 };
 
 export const quick_forge_multiplier = {

--- a/src/lib.js
+++ b/src/lib.js
@@ -3724,6 +3724,8 @@ export async function getForge(userProfile) {
         const timeFinished = item.startTime + forgeTime;
         forgeItem.timeFinished = timeFinished;
         forgeItem.timeFinishedText = moment(timeFinished).fromNow();
+      } else {
+        forgeItem.id = "UNKNOWN";
       }
       processes.push(forgeItem);
     }

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1607,7 +1607,11 @@ const metaDescription = getMetaDescription()
           %>
             <div class="forge-item">
               <p class="stat-name forge-slot">Slot <%= process.slot %>:</p>
-              <span data-tippy-content='<local-time timestamp="<%= process.timeFinished %>"></local-time>'><span class="stat-raw-values"><%= process.name %> - <%= process.timeFinished < Date.now() ? "ended" : `ending ${process.timeFinishedText}`%></span></span>
+              <% if (process.id !== "UNKNOWN") { %>
+                <span data-tippy-content='<local-time timestamp="<%= process.timeFinished %>"></local-time>' class="stat-value"><%= process.name %> - <%= process.timeFinished < Date.now() ? "ended" : `ending ${process.timeFinishedText}`%></span>
+              <% } else { %>
+                <span data-tippy-content='Unknown end time' class="stat-value">Unknown item</span>
+              <% } %>
             </div>
           <%
               });

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1608,9 +1608,9 @@ const metaDescription = getMetaDescription()
             <div class="forge-item">
               <p class="stat-name forge-slot">Slot <%= process.slot %>:</p>
               <% if (process.id !== "UNKNOWN") { %>
-                <span data-tippy-content='<local-time timestamp="<%= process.timeFinished %>"></local-time>' class="stat-value"><%= process.name %> - <%= process.timeFinished < Date.now() ? "ended" : `ending ${process.timeFinishedText}`%></span>
+                <span data-tippy-content="<local-time timestamp='<%= process.timeFinished %>'></local-time>" class="stat-value"><%= process.name %> - <%= process.timeFinished < Date.now() ? "ended" : `ending ${process.timeFinishedText}`%></span>
               <% } else { %>
-                <span data-tippy-content='Unknown end time' class="stat-value">Unknown item</span>
+                <span data-tippy-content="Unknown end time" class="stat-value">Unknown item</span>
               <% } %>
             </div>
           <%


### PR DESCRIPTION
This PR does 2 things:
1. Closes #942 by adding the times for the new recipes
2. Changes the HTML so that it only uses 1 `<span>` instead of 2 and also uses the correct `stat-value` class instead of `stat-raw-values` which is correctly vertically aligned (and it's what we usually use everywhere else)
3. Adds a fallback in case of future new items, so the forge processes won't look like this:

old:
![image](https://user-images.githubusercontent.com/2744227/140836731-6f838f52-206a-44c1-8b11-a25755223dce.png)


new:
![image](https://user-images.githubusercontent.com/2744227/140836589-ef4609ad-1763-49cd-bd6e-2fe977d9b187.png)

---
![image](https://user-images.githubusercontent.com/2744227/140836891-4165914c-e861-43c4-9783-df5b8abb7554.png)

PS: The name is parsed by items collection so it will get fixed soon, whenever builder's API updates
```js
const dbObject = await db.collection("items").findOne({ id: item.id });
forgeItem.name = item.id == "PET" ? "[Lvl 1] Ammonite" : dbObject ? dbObject.name : item.id;
```

next day edit:
![image](https://user-images.githubusercontent.com/2744227/140964594-7279776b-f77c-403d-8af4-84ff408ad7d6.png)

there they are