### PR TITLE
fix makeLore to show correct stats for Health

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -2025,6 +2025,8 @@ export const getStats = async (
       items.armor.find((a) => a.type === "boots" || a.type === "dungeon boots"),
       getId(items.armor.find((a) => a.type === "boots" || a.type === "dungeon boots"))
     );
+
+    // Updates items lore after modifyArmor() changed their stats/extra (hpb)
     makeLore(items.armor.find((a) => a.type === "helmet" || a.type === "dungeon helmet"));
     makeLore(items.armor.find((a) => a.type === "chestplate" || a.type === "dungeon chestplate"));
     makeLore(items.armor.find((a) => a.type === "leggings" || a.type === "dungeon leggings"));

--- a/src/lore-generator.js
+++ b/src/lore-generator.js
@@ -15,6 +15,8 @@ function addSign(num) {
 
 /**
  * update item Lore to match item stats
+ * item stats get changed or updated after Pet modifyArmor() function runs
+ * this function tries to update the Lore of the item to match the new stats
  * @param {{tag?:{display?:{Lore?:string}},stats:{[key:string]:number},extra?:{hpbs?:number}}} item
  * @returns {void}
  */
@@ -44,8 +46,8 @@ export function makeLore(item) {
       const statValue = split[1].substring(0, 2) + addSign(item.stats[statNames[statName]]);
 
       if (statName === "Health" && item.equipmentType == "armor" && item.extra?.hpbs > 0) {
-        const hpbString = `HP §e(+${item.extra.hpbs * 4} HP)`;
-        lore_raw[i] = statType + ": " + statValue + " " + hpbString + " " + split.slice(5).join(" ");
+        const hpbString = `§e(+${item.extra.hpbs * 4})`;
+        lore_raw[i] = statType + ": " + statValue + " " + hpbString + " " + split.slice(3).join(" ");
       } else if (statName === "Defense" && item.equipmentType == "armor" && item.extra?.hpbs > 0) {
         const hpbString = `§e(+${item.extra.hpbs * 2})`;
         lore_raw[i] = statType + ": " + statValue + " " + hpbString + " " + split.slice(3).join(" ");


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2744227/141016717-b69b274a-f3f9-45f5-87a0-2c0857909d81.png)

basically the function `makeLore()` that updates the item Lore when an active pet modifies the armor `activePet.ref.modifyArmor()` had a `.slice(5)` that should be a `.slice(3)` instead.

Also added a few comments to hopefully help in case someone in the future has to go through these functions again... and removed the outdated "HP" in the generated lore

I honestly have no clue why it was 5, if it was correct before but wrong now or what... but with 3 it seems to be working fine now

Edit: I know why it was 5:
![image](https://user-images.githubusercontent.com/2744227/141016975-782251b9-728b-498d-91ac-82356cfbc31d.png)

Health with HPB used to contain the words HP on the health value and in the parenthesis... now it doesn't anymore so the split contains less items... so it's correct that it is 3 now and before it was correct that it was 5
![image](https://user-images.githubusercontent.com/2744227/141017092-442bb595-29a8-48b0-aa70-70d2f49d842d.png)
