### PR TITLE
use passive scroll listeners

### DIFF
--- a/public/resources/ts/stats-defer.ts
+++ b/public/resources/ts/stats-defer.ts
@@ -806,7 +806,7 @@ class ScrollMemory {
     if (this._isSmoothScrolling !== value) {
       this._isSmoothScrolling = value;
       if (value) {
-        window.addEventListener("scroll", this._onScroll);
+        window.addEventListener("scroll", this._onScroll, { passive: true });
         this._onScroll();
       } else {
         window.removeEventListener("scroll", this._onScroll);
@@ -985,6 +985,6 @@ function onScroll() {
   }
 }
 onScroll();
-window.addEventListener("scroll", onScroll);
+window.addEventListener("scroll", onScroll, { passive: true });
 
 setTimeout(resize, 1000);


### PR DESCRIPTION
by using passive listeners we promise the browser we will never use `.preventDefault()` on the scroll event so the browser can scroll for the user before it is done calling our code. this should result in smoother scrolling for users with slow CPUs.