### PR TITLE
crystal hollows pass 5h

### DIFF
--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1499,7 +1499,7 @@ const metaDescription = getMetaDescription()
               <span class="stat-value <%= max %>"><%= mining.commissions.milestone.toLocaleString() %></span>
               <br>
               <!-- Crystal Hollows Pass -->
-              <% const chpass = mining.core.crystal_hollows_last_access > Date.now() - 2*60*60*1000 %>
+              <% const chpass = mining.core.crystal_hollows_last_access > Date.now() - 5*60*60*1000 %>
               <% max = chpass ? 'golden-text' : '' %>
               <span class="stat-name <%= max %>">Crystal Hollows Pass:</span>
               <span class="stat-value <%= max %>" data-tippy-content="


### PR DESCRIPTION
Crystal Hollows Pass now lasts 5h, instead of 2h... the tooltip while buying it is still outdated in game though.

![image](https://user-images.githubusercontent.com/2744227/141805684-5a465b62-609e-4ec8-8ae9-60e870bf592b.png)
![image](https://user-images.githubusercontent.com/2744227/141805688-f13f9a36-4384-4812-8dbd-c56c2a4fa852.png)
