### PR TITLE
Weight systems fixes

### DIFF
--- a/includes/header.ejs
+++ b/includes/header.ejs
@@ -61,7 +61,7 @@
         <li>Weight Calculations:
           <ul>
             <li><a rel="noreferrer" href="https://github.com/Senither/hypixel-skyblock-facade" target="_blank">Hypixel SkyBlock Facade</a> by <span class="name">Senither</span></li>
-            <li><a rel="noreferrer" href="https://www.npmjs.com/package/lilyweight" target="_blank">lilyweight</a> by <span class="name">LappySheep</span> and <span class="name">Antonio32A</span></li>
+            <li><a rel="noreferrer" href="https://github.com/Antonio32A/lilyweight" target="_blank">lilyweight</a> by <span class="name">LappySheep</span> and <span class="name">Antonio32A</span></li>
           </ul>
         </li>
         <li>Player Heads: <a rel="noreferrer" href="https://hypixel.net/forums/skyblock.157/" target="_blank">SkyBlock</a> by <span class="name">Hypixel</span></li>

--- a/public/resources/scss/shared.scss
+++ b/public/resources/scss/shared.scss
@@ -240,6 +240,11 @@ a.no-underline {
       color: rgba(var(--text-rgb), 0.85);
       text-transform: none;
     }
+    .stat-info {
+      color: rgba(var(--text-rgb), 0.5);
+      text-transform: none;
+      font-style: italic;
+    }
   }
 
   &[data-placement^="top"] > .tippy-arrow::before {

--- a/src/weight/lily-weight.js
+++ b/src/weight/lily-weight.js
@@ -16,11 +16,11 @@ export function calculateLilyWeight(profile) {
   const skillLevels = skillOrder.map((key) => profile.levels[key].level);
   const skillXP = skillOrder.map((key) => profile.levels[key].xp);
 
-  const cataCompletions = getTierCompletions(profile.dungeons.catacombs.floors);
-  const masterCataCompletions = getTierCompletions(profile.dungeons.master_catacombs.floors);
-  const cataXP = profile.dungeons?.catacombs?.level.xp ?? 0;
+  const cataCompletions = getTierCompletions(profile.dungeons?.catacombs?.floors ?? {});
+  const masterCataCompletions = getTierCompletions(profile.dungeons?.master_catacombs?.floors ?? {});
+  const cataXP = profile.dungeons?.catacombs?.level?.xp ?? 0;
 
-  const slayerXP = slayerOrder.map((key) => profile.slayers?.[key]?.level.xp ?? 0);
+  const slayerXP = slayerOrder.map((key) => profile.slayers?.[key]?.level?.xp ?? 0);
 
   return LilyWeight.getWeightRaw(skillLevels, skillXP, cataCompletions, masterCataCompletions, cataXP, slayerXP);
 }

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -538,7 +538,11 @@ function getDescription() {
 			: calculated.stats
 
 		description.push(
-			`❤️ ${stats.health} 🛡️ ${stats.defense} 💪 ${stats.strength} 🌀 ${stats.crit_chance}% ☠️ ${stats.crit_damage}%`,
+			`❤️ ${stats.health} `,
+			`🛡️ ${stats.defense} `,
+			`💪 ${stats.strength} `,
+			`🌀 ${stats.crit_chance}% `,
+			`☠️ ${stats.crit_damage}%`,
 			'\n',
 			'\n'
 		)
@@ -622,33 +626,36 @@ function getDescription() {
 		description.push('\n', '\n')
 	}
 
-	// Avg. skill, weight, purse
+	// Avg. skill
 	if (calculated.average_level) {
 		description.push(
-			`⚒ Avg Skill Level: ${
+			`📚 Avg Skill Level: ${
 				Math.floor(calculated.average_level * 10) / 10
 			} `
 		)
+		description.push('\n')
 	}
+
+	// Weights
 	if (calculated.weight) {
 		description.push(
-			`💪 Weight: ${Math.floor(calculated.weight * 10) / 10} `
+			`💪 Senither Weight: ${Math.floor(
+				calculated.weight.senither.overall
+			).toLocaleString()} `,
+			`💪 Lily Weight: ${Math.floor(
+				calculated.weight.lily.total
+			).toLocaleString()}`
 		)
+		description.push('\n')
 	}
-	description.push(
-		`💰 Purse: ${helper.formatNumber(calculated.purse, true)} Coins `
-	)
-	description.push('\n')
 
-	// Bank
+	// Bank & purse
 	if (calculated.bank) {
 		description.push(
-			`🏦 Bank Account: ${helper.formatNumber(
-				calculated.bank,
-				true
-			)} Coin${Math.floor(calculated.bank) == 1 ? '' : 's'}`
+			`🏦 Bank: ${helper.formatNumber(calculated.bank, true)} `
 		)
 	}
+	description.push(`💰 Purse: ${helper.formatNumber(calculated.purse, true)}`)
 
 	// Done!
 	return description.join('')
@@ -993,28 +1000,29 @@ const metaDescription = getMetaDescription()
           const senitherSlayerWeight = weight.senither.slayer.total;
           const senitherTotalWeight = weight.senither.overall; %>
           <span data-tippy-content="
-            <span class='stat-name'>Skill Weight: </span>
+            <span class='stat-name'>Senither Weight</span><br>
+            <span class='stat-info'>Weight calculations provided by Senither</span>
+            <br/><br/>
+            <span class='stat-name'>Skill: </span>
             <span class='stat-value'>
               <%= senitherSkillWeight >= 0 ? parseFloat(senitherSkillWeight.toFixed(2)).toLocaleString() : 'Error' %>
             </span><br/>
-            <span class='stat-name'>Slayer Weight: </span>
+            <span class='stat-name'>Slayer: </span>
             <span class='stat-value'>
               <%= senitherSlayerWeight >= 0 ? parseFloat(senitherSlayerWeight.toFixed(2)).toLocaleString() : 'Error'  %>
             </span><br/>
-            <span class='stat-name'>Dungeon Weight: </span>
+            <span class='stat-name'>Dungeon: </span>
             <span class='stat-value'>
               <%= senitherDungeonWeight >= 0 ? parseFloat(senitherDungeonWeight.toFixed(2)).toLocaleString() : 'Error'  %>
-            </span><br/>
-            <br/>
-            <div class='tippy-explanation'>Weight calculations provided by Senither</div>
+            </span><br/><br/>
+            <span class='stat-name'>Total: </span>
+            <span class='stat-value'>
+              <%= parseFloat(senitherTotalWeight.toFixed(2)).toLocaleString()  %>
+            </span>
           ">
           <span class="stat-name">Senither Weight: </span>
-          <span class="stat-value">
-            <%= parseFloat(senitherTotalWeight.toFixed(2)).toLocaleString() %>
-          </span>
-          <span class="stat-value stat-error">
-            <%= (!senitherSkillWeight || !senitherSlayerWeight || !senitherDungeonWeight) ? '!' : '' %>
-          </span>
+          <span class="stat-value"><%= parseFloat(Math.floor(senitherTotalWeight)).toLocaleString() %></span>
+          <span class="stat-value stat-error"><%= (!senitherSkillWeight || !senitherSlayerWeight || !senitherDungeonWeight) ? '!' : '' %></span>
         </div>
         <div class="additional-stat">
           <%
@@ -1023,28 +1031,29 @@ const metaDescription = getMetaDescription()
           const lilySlayerWeight = weight.lily.slayer;
           const lilyWeight = weight.lily.total; %>
           <span data-tippy-content="
-            <span class='stat-name'>Skill Weight: </span>
+            <span class='stat-name'>Lily Weight</span><br>
+            <span class='stat-info'>Weight calculations provided by LappySheep</span>
+            <br/><br/>
+            <span class='stat-name'>Skill: </span>
             <span class='stat-value'>
               <%= lilySkillWeight >= 0 ? parseFloat(lilySkillWeight.toFixed(2)).toLocaleString() : 'Error' %>
             </span><br/>
-            <span class='stat-name'>Slayer Weight: </span>
+            <span class='stat-name'>Slayer: </span>
             <span class='stat-value'>
               <%= lilySlayerWeight >= 0 ? parseFloat(lilySlayerWeight.toFixed(2)).toLocaleString() : 'Error'  %>
             </span><br/>
-            <span class='stat-name'>Dungeon Weight: </span>
+            <span class='stat-name'>Dungeon: </span>
             <span class='stat-value'>
               <%= lilyDungeonWeight >= 0 ? parseFloat(lilyDungeonWeight.toFixed(2)).toLocaleString() : 'Error'  %>
-            </span><br/>
-            <br/>
-            <div class='tippy-explanation'>Weight calculations provided by LappySheep</div>
+            </span><br/><br/>
+            <span class='stat-name'>Total: </span>
+            <span class='stat-value'>
+              <%= parseFloat(lilyWeight.toFixed(2)).toLocaleString()  %>
+            </span>
           ">
           <span class="stat-name">Lily Weight: </span>
-          <span class="stat-value">
-            <%= parseFloat(lilyWeight.toFixed(2)).toLocaleString() %>
-          </span>
-          <span class="stat-value stat-error">
-            <%= (!lilySkillWeight || !lilySlayerWeight || !lilyDungeonWeight) ? '!' : '' %>
-          </span>
+          <span class="stat-value"><%= parseFloat(Math.floor(lilyWeight)).toLocaleString() %></span>
+          <span class="stat-value stat-error"><%= (!lilySkillWeight || !lilySlayerWeight || !lilyDungeonWeight) ? '!' : '' %></span>
         </div>
       </div>
 


### PR DESCRIPTION
Changes:
- Uses github repo link instead of npm package for lilyweight attribution
- Updates the meta description to include lily weight (preview below)
- Changes the emoji used for `Avg Skill Level` in meta description so discord doesn't see it as a character but rather an emoji like the others (maybe it's just a windows thing, idk)... we are still discussing in discord which emoji to use so it might change later
- Changes the tooltips for weights and rounds the value to 0 decimals (the 2 decimals value can be now seen in the tooltip)
- Fixes an issue that caused profiles that never entered dungeons to return a TypeError (see changes in `lily-weight.js`)

![image](https://user-images.githubusercontent.com/2744227/142267002-38a898a2-3625-44cc-92c0-2d090e5962b5.png)
![image](https://user-images.githubusercontent.com/2744227/142267023-3e056846-d73b-437a-bc57-d5198fdf9bc0.png)

Meta description:

```text
❤️ 2980 🛡️ 1088 💪 1054 🌀 121% ☠️ 840%

🧚 227/227 Fairy Souls
🗡️ Fabled Atomsplit Katana
🌾 Farming 60
🔥 Legendary Blaze (Lvl 82)

🤺 Slayer: 🧟 9  🕸️ 9  🐺 9  🔮 8  

📚 Avg Skill Level: 48.3 
💪 Senither Weight: 16.859 💪 Lily Weight: 11.878
🏦 Bank: 998.0M 💰 Purse: 1.81B
```

@metalcupcake5 @MartinNemi03 