### PR TITLE
fix furfsky reborn 1.4.2 reaper scythe

### DIFF
--- a/public/resourcepacks/FurfSky_Reborn_1_4_2/assets/minecraft/mcpatcher/cit/item/weapons/normal/melee/reaper_scythe/reaper_scythe_revenant.properties
+++ b/public/resourcepacks/FurfSky_Reborn_1_4_2/assets/minecraft/mcpatcher/cit/item/weapons/normal/melee/reaper_scythe/reaper_scythe_revenant.properties
@@ -1,5 +1,0 @@
-items=minecraft:diamond_hoe
-texture=reaper_scythe
-enchantmentIDs=34
-enchantmentLevels=1
-nbt.ExtraAttributes.id=REAPER_SCYTHE

--- a/public/resourcepacks/FurfSky_Reborn_1_4_2/assets/minecraft/mcpatcher/cit/item/weapons/normal/melee/reaper_scythe/reaper_scythe_revenant.properties
+++ b/public/resourcepacks/FurfSky_Reborn_1_4_2/assets/minecraft/mcpatcher/cit/item/weapons/normal/melee/reaper_scythe/reaper_scythe_revenant.properties
@@ -2,3 +2,4 @@ items=minecraft:diamond_hoe
 texture=reaper_scythe
 enchantmentIDs=34
 enchantmentLevels=1
+nbt.ExtraAttributes.id=REAPER_SCYTHE


### PR DESCRIPTION
Closes #981 

Fixes the issue caused by a generic .properties file of FurfSky Reborn 1.4.2 matching all diamond hoes as Reaper Scythes.

Thanks Erymanthus | u/RayDeeUx for the help!

Discord thread: https://discord.com/channels/738971489411399761/911036781661679656/911643519813320725