### PR TITLE
Fix "Couldn't find config for resource pack README.md"

### DIFF
--- a/src/custom-resources.js
+++ b/src/custom-resources.js
@@ -58,7 +58,12 @@ async function init() {
   console.log(`Custom Resources loading started on ${getClusterId(true)}.`);
   console.time(`custom_resources_${getClusterId()}`);
 
-  for (const pack of await fs.readdir(RESOURCE_PACK_FOLDER)) {
+  for (const packOrFile of await fs.readdir(RESOURCE_PACK_FOLDER, { withFileTypes: true })) {
+    if (!packOrFile.isDirectory()) {
+      continue;
+    }
+
+    const pack = packOrFile.name;
     const basePath = path.resolve(RESOURCE_PACK_FOLDER, pack);
 
     try {


### PR DESCRIPTION
didn't realize my PR that added a `README.md` in the resourcepack folder with instructions on how to add new/update resourcepacks added this warning.... this fixes it by ignoring files in the `/public/resourcepacks/` folder