### PR TITLE
SkyCrypt Dev Mode - Alt+click .rich-item to console.log the js item object

### DIFF
--- a/includes/resources.ejs
+++ b/includes/resources.ejs
@@ -42,7 +42,7 @@
     <link rel="preload" href="/resources/js/<%- fileNameMap['inventory-view'] %>" as="script">
   <% } %>
 
-  <% if (process.env.NODE_ENV == "development") { %>
+  <% if (process.env.NODE_ENV === "development") { %>
     <script defer type="module" src="/resources/js/<%- fileNameMap['development-defer'] %>"></script>
   <% } %>
 

--- a/includes/resources.ejs
+++ b/includes/resources.ejs
@@ -34,12 +34,16 @@
   </script>
   <script data-ad-client="ca-pub-7573886460664405" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 
-  <% if(page == 'stats'){ %>
+  <% if (page === "stats") { %>
     <link rel="preload" href="/resources/css/inventory.css?<%- fileHashes.css['inventory.css'] %>" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <script async type="module" src="/resources/js/<%- fileNameMap['local-time'] %>"></script>
     <script defer type="module" src="/resources/js/<%- fileNameMap['stats-defer'] %>"></script>
     <script defer type="module" src="/resources/js/<%- fileNameMap['rich-item'] %>"></script>
     <link rel="preload" href="/resources/js/<%- fileNameMap['inventory-view'] %>" as="script">
+  <% } %>
+
+  <% if (process.env.NODE_ENV == "development") { %>
+    <script defer type="module" src="/resources/js/<%- fileNameMap['development-defer'] %>"></script>
   <% } %>
 
   <script defer type="module" src="/resources/js/<%- fileNameMap['common-defer'] %>"></script>

--- a/public/resources/ts/development-defer.ts
+++ b/public/resources/ts/development-defer.ts
@@ -15,29 +15,28 @@ console.log(
 );
 
 // Alt+Click on any .rich-item to console.log the item object
-for (const element of document.querySelectorAll<HTMLElement>(".rich-item")) {
-  element.addEventListener("click", (e) => {
-    if (!e.altKey) {
-      return;
-    }
+document.addEventListener("click", (e) => {
+  const element = e.target as HTMLElement;
 
-    let item: DisplayItem | Item | Pet | undefined = undefined;
+  if (!e.altKey || !element.classList.contains("rich-item")) {
+    return;
+  }
 
-    if (element.hasAttribute("data-item-id")) {
-      const itemId = element.getAttribute("data-item-id") as string;
-      item = allItems.get(itemId) as Item;
-    } else if (element.hasAttribute("data-pet-index")) {
-      item = calculated.pets[parseInt(element.getAttribute("data-pet-index") as string)];
-    } else if (element.hasAttribute("data-missing-pet-index")) {
-      item = calculated.missingPets[parseInt(element.getAttribute("data-missing-pet-index") as string)];
-    } else if (element.hasAttribute("data-missing-talisman-index")) {
-      item =
-        calculated.missingTalismans.missing[parseInt(element.getAttribute("data-missing-talisman-index") as string)];
-    } else if (element.hasAttribute("data-upgrade-talisman-index")) {
-      item =
-        calculated.missingTalismans.upgrades[parseInt(element.getAttribute("data-upgrade-talisman-index") as string)];
-    }
+  let item: DisplayItem | Item | Pet | undefined = undefined;
 
-    console.log(item);
-  });
-}
+  if (element.hasAttribute("data-item-id")) {
+    const itemId = element.getAttribute("data-item-id") as string;
+    item = allItems.get(itemId) as Item;
+  } else if (element.hasAttribute("data-pet-index")) {
+    item = calculated.pets[parseInt(element.getAttribute("data-pet-index") as string)];
+  } else if (element.hasAttribute("data-missing-pet-index")) {
+    item = calculated.missingPets[parseInt(element.getAttribute("data-missing-pet-index") as string)];
+  } else if (element.hasAttribute("data-missing-talisman-index")) {
+    item = calculated.missingTalismans.missing[parseInt(element.getAttribute("data-missing-talisman-index") as string)];
+  } else if (element.hasAttribute("data-upgrade-talisman-index")) {
+    item =
+      calculated.missingTalismans.upgrades[parseInt(element.getAttribute("data-upgrade-talisman-index") as string)];
+  }
+
+  console.log(item);
+});

--- a/public/resources/ts/development-defer.ts
+++ b/public/resources/ts/development-defer.ts
@@ -1,0 +1,43 @@
+import { allItems } from "./stats-defer";
+
+// Announce dev mode in console
+console.log(
+  "%cSKYCRYPT ⌨ DEV MODE",
+  [
+    "background: #0bca51",
+    "color: #fff",
+    "padding: 8px 16px",
+    'font-family: "Fira Code", "Montserrat", sans-serif',
+    "font-size: 16px",
+    "font-weight: 700",
+    "line-height: 1",
+  ].join(";")
+);
+
+// Alt+Click on any .rich-item to console.log the item object
+for (const element of document.querySelectorAll<HTMLElement>(".rich-item")) {
+  element.addEventListener("click", (e) => {
+    if (!e.altKey) {
+      return;
+    }
+
+    let item: DisplayItem | Item | Pet | undefined = undefined;
+
+    if (element.hasAttribute("data-item-id")) {
+      const itemId = element.getAttribute("data-item-id") as string;
+      item = allItems.get(itemId) as Item;
+    } else if (element.hasAttribute("data-pet-index")) {
+      item = calculated.pets[parseInt(element.getAttribute("data-pet-index") as string)];
+    } else if (element.hasAttribute("data-missing-pet-index")) {
+      item = calculated.missingPets[parseInt(element.getAttribute("data-missing-pet-index") as string)];
+    } else if (element.hasAttribute("data-missing-talisman-index")) {
+      item =
+        calculated.missingTalismans.missing[parseInt(element.getAttribute("data-missing-talisman-index") as string)];
+    } else if (element.hasAttribute("data-upgrade-talisman-index")) {
+      item =
+        calculated.missingTalismans.upgrades[parseInt(element.getAttribute("data-upgrade-talisman-index") as string)];
+    }
+
+    console.log(item);
+  });
+}

--- a/public/resources/ts/stats-defer.ts
+++ b/public/resources/ts/stats-defer.ts
@@ -988,31 +988,3 @@ onScroll();
 window.addEventListener("scroll", onScroll, { passive: true });
 
 setTimeout(resize, 1000);
-
-// Alt+Click on any rich-item to console.log the item object
-for (const element of document.querySelectorAll<HTMLElement>(".rich-item")) {
-  element.addEventListener("click", (e) => {
-    if (!e.altKey) {
-      return;
-    }
-
-    let item: DisplayItem | Item | Pet | undefined = undefined;
-
-    if (element.hasAttribute("data-item-id")) {
-      const itemId = element.getAttribute("data-item-id") as string;
-      item = allItems.get(itemId) as Item;
-    } else if (element.hasAttribute("data-pet-index")) {
-      item = calculated.pets[parseInt(element.getAttribute("data-pet-index") as string)];
-    } else if (element.hasAttribute("data-missing-pet-index")) {
-      item = calculated.missingPets[parseInt(element.getAttribute("data-missing-pet-index") as string)];
-    } else if (element.hasAttribute("data-missing-talisman-index")) {
-      item =
-        calculated.missingTalismans.missing[parseInt(element.getAttribute("data-missing-talisman-index") as string)];
-    } else if (element.hasAttribute("data-upgrade-talisman-index")) {
-      item =
-        calculated.missingTalismans.upgrades[parseInt(element.getAttribute("data-upgrade-talisman-index") as string)];
-    }
-
-    console.log(item);
-  });
-}

--- a/public/resources/ts/stats-defer.ts
+++ b/public/resources/ts/stats-defer.ts
@@ -988,3 +988,31 @@ onScroll();
 window.addEventListener("scroll", onScroll, { passive: true });
 
 setTimeout(resize, 1000);
+
+// Alt+Click on any rich-item to console.log the item object
+for (const element of document.querySelectorAll<HTMLElement>(".rich-item")) {
+  element.addEventListener("click", (e) => {
+    if (!e.altKey) {
+      return;
+    }
+
+    let item: DisplayItem | Item | Pet | undefined = undefined;
+
+    if (element.hasAttribute("data-item-id")) {
+      const itemId = element.getAttribute("data-item-id") as string;
+      item = allItems.get(itemId) as Item;
+    } else if (element.hasAttribute("data-pet-index")) {
+      item = calculated.pets[parseInt(element.getAttribute("data-pet-index") as string)];
+    } else if (element.hasAttribute("data-missing-pet-index")) {
+      item = calculated.missingPets[parseInt(element.getAttribute("data-missing-pet-index") as string)];
+    } else if (element.hasAttribute("data-missing-talisman-index")) {
+      item =
+        calculated.missingTalismans.missing[parseInt(element.getAttribute("data-missing-talisman-index") as string)];
+    } else if (element.hasAttribute("data-upgrade-talisman-index")) {
+      item =
+        calculated.missingTalismans.upgrades[parseInt(element.getAttribute("data-upgrade-talisman-index") as string)];
+    }
+
+    console.log(item);
+  });
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,6 +20,7 @@ const config = {
     "public/resources/ts/common-defer.ts",
     "public/resources/ts/common.ts",
     "public/resources/ts/stats-defer.ts",
+    "public/resources/ts/development-defer.ts",
     "public/resources/ts/themes.ts",
     "public/resources/ts/elements/local-time.ts",
     "public/resources/ts/elements/rich-item.ts",


### PR DESCRIPTION
This PR adds `development-defer.ts`.

In `development-defer.ts` we can add various things useful for developers, this file is only loaded when the website is launched in development (`npm run dev`).

Currently it adds 2 things:
- A `console.log()` message to let the developer know they are in development mode
- The ability to `alt+click` on any `.rich-item` on the page to `console.log()` the item object (very useful for debugging resource packs!)