### PR TITLE
fix furfsky reborn fortunate perk

### DIFF
--- a/public/resourcepacks/FurfSky_Reborn_1_4_2/assets/minecraft/mcpatcher/cit/uielements/skyblock_menu/hotm/complete/fortunate.properties
+++ b/public/resourcepacks/FurfSky_Reborn_1_4_2/assets/minecraft/mcpatcher/cit/uielements/skyblock_menu/hotm/complete/fortunate.properties
@@ -1,4 +1,4 @@
 type=item
 items=minecraft:diamond
-nbt.display.Name=ipattern:*\u00A7aFortunate*
-nbt.display.Lore=ipattern:*\u00A76Fortune\u00A77 when mining Gemstone.*
+nbt.display.Name=ipattern:*Fortunate*
+# nbt.display.Lore=ipattern:*\u00A76Fortune\u00A77 when mining Gemstone.*

--- a/public/resourcepacks/README.md
+++ b/public/resourcepacks/README.md
@@ -11,7 +11,14 @@
    - Any other file outside the `cit` folder
 6. Run `npm run start` once, it will generate all the animated textures (gifs) and normalize the other textures sizes
 
----
+# Things that require manual update or changes
+
+Some resource packs require some files to be changed in order to resolve some bugs.
+
+- FurfSky Reborn
+  - `cit/uielements/skyblock_menu/hotm/complete/fortunate.properties` remove color formatting from "nbt.display.Name" and comment "nbt.display.Lore" line.
+
+# Examples
 
 Example folder structure:
 


### PR DESCRIPTION
The HotM perk "Fortunate", when maxed, was missing the texture due to how the `.properties` file matches the GUI item:

![image](https://user-images.githubusercontent.com/2744227/142781237-3187dac9-bb42-4f95-8a72-58bd0629546f.png)

asked in discord and there's a good reason to why they do this ([link](https://discord.com/channels/738971489411399761/911990892347416646/911994728109703239)) ... but this means we need to manually update this every time we update FSR pack.

This PR:
- Fixes the issue by manually updating the `.properties` file
- Adds a section to the `public/resourcepacks/README.md` to keep track of the files that need manual changes when updating the resource packs.


I thought if there's a way to automatically detect and fix this but I couldn't think of any (even ignoring the color codes in the name wouldn't be enough)