### PR TITLE
fix custom resources non-breaking loop

### DIFF
--- a/src/custom-resources.js
+++ b/src/custom-resources.js
@@ -474,11 +474,7 @@ export async function getTexture(item, ignoreId = false, packIds) {
           matchValues = [matchValues];
         }
 
-        for (const matchValue of matchValues) {
-          if (!regex.test(matchValue.toString().replace(removeFormatting, ""))) {
-            continue;
-          }
-
+        if (matchValues.some((matchValue) => regex.test(matchValue.toString().replace(removeFormatting, "")))) {
           matches++;
         }
       }


### PR DESCRIPTION
Fixes #978 

---

Ok so, `custom-resources.js` was bugged. I'll try to explain the bug...

For each texture the JS was checking if the value was matching the regex pattern specified in the .properties file... 

Example (`value`=ipattern:`regex`):
`nbt.display.Name=ipattern:*Mole*`
`nbt.display.Lore.*=ipattern:*Level 1*`

if it was matching it would increase the total number of matches by 1... at the end if the total number of matches was === to the number of values:regex to check, then the texture was a match for the item.

So where's the issue? in the Lore.
The code was checking if the regex was matching for **each line** of the Lore, so if the Lore matched 2 times, it would increase the total matches by 2... meaning that if we had 2 values, 1 failed but the Lore matched 2 times, the total number of matches would still be 2 (cause 0+2), equal to the number of values to check... even though it's not.

Basically the old `for()` loop was missing a `break;` after finding the first match in the Lore array.

I refactored that part of code using `Array.prototype.some()` which makes the code much cleaner and easier to read in my opinion.