### PR TITLE
fix fix lilyweight

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -137,7 +137,7 @@ function getXpByLevel(level, extra = {}) {
   return output;
 }
 
-export function getLevelByXp(xp, extra = {}) {
+export function getLevelByXp(xp, extra = {}, forceMaxLevel = false) {
   let xp_table;
   switch (extra.type) {
     case "runecrafting":
@@ -200,7 +200,11 @@ export function getLevelByXp(xp, extra = {}) {
     maxLevel = levelCap;
   }
 
-  for (let x = 1; x <= Object.keys(xp_table).length; x++) {
+  if (forceMaxLevel) {
+    maxLevel = forceMaxLevel;
+  }
+
+  for (let x = 1; x <= maxLevel; x++) {
     xpTotal += xp_table[x];
 
     if (xpTotal > xp) {

--- a/src/weight/lily-weight.js
+++ b/src/weight/lily-weight.js
@@ -1,4 +1,5 @@
 import LilyWeight from "lilyweight";
+import { getLevelByXp } from "../lib.js";
 
 const skillOrder = ["enchanting", "taming", "alchemy", "mining", "farming", "foraging", "combat", "fishing"];
 const slayerOrder = ["zombie", "spider", "wolf", "enderman"];
@@ -13,7 +14,7 @@ function getTierCompletions(floors = {}) {
 }
 
 export function calculateLilyWeight(profile) {
-  const skillLevels = skillOrder.map((key) => profile.levels[key].uncappedLevel);
+  const skillLevels = skillOrder.map((key) => getLevelByXp(profile.levels[key].xp, {}, 60).uncappedLevel);
   const skillXP = skillOrder.map((key) => profile.levels[key].xp);
 
   const cataCompletions = getTierCompletions(profile.dungeons?.catacombs?.floors ?? {});


### PR DESCRIPTION
basically lilyweights considers all skills already at level 60 so we need to calculate the level faking a maxLevel of 60 for everything... this PR does that

what Nate did in his first fix PR did pretty much the same, but for the entire site... so players were missing a lot of overflow xp on max skills

honestly idk if this is the best way to fix the issue... I never really liked how we handle the parsing the xp to level, overflow xp etc... 