### PR TITLE
Fix Eslint warnings

### DIFF
--- a/public/resources/ts/common-defer.ts
+++ b/public/resources/ts/common-defer.ts
@@ -12,7 +12,7 @@ function validateURL(url: string) {
   } else {
     if (urlSegments.length === 2) {
       if (urlSegments[1].match(/^[A-Za-z]+/)) {
-        urlSegments[1] = urlSegments[1].charAt(0).toUpperCase() + urlSegments[1].substr(1).toLowerCase();
+        urlSegments[1] = urlSegments[1].charAt(0).toUpperCase() + urlSegments[1].substring(1).toLowerCase();
       } else if (!urlSegments[1].match(/^([0-9a-fA-F]{32})$/)) {
         throw `"${urlSegments[1]}" is not a valid profile name or ID`;
       }

--- a/public/resources/ts/stats-defer.ts
+++ b/public/resources/ts/stats-defer.ts
@@ -40,7 +40,7 @@ function getCookie(c_name: string) {
       if (c_end == -1) {
         c_end = document.cookie.length;
       }
-      return unescape(document.cookie.substring(c_start, c_end));
+      return decodeURIComponent(document.cookie.substring(c_start, c_end));
     }
   }
   return "";


### PR DESCRIPTION
fixes 2 eslint warnings

`substr()` -> `substring()`
`unescape()` -> `decodeURIComponent()`