### PR TITLE
added the speed tiers reached in the races

### DIFF
--- a/public/resources/scss/shared.scss
+++ b/public/resources/scss/shared.scss
@@ -2861,8 +2861,11 @@ inventory-view {
   padding-bottom: 30px;
 }
 
-.tier-completion {
-  float: right;
+.narrow-info-container .narrow-info-flexsb {
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: flex-start;
+  justify-content: space-between;
 }
 
 .slayer {

--- a/public/resources/scss/shared.scss
+++ b/public/resources/scss/shared.scss
@@ -2861,6 +2861,10 @@ inventory-view {
   padding-bottom: 30px;
 }
 
+.tier-completion {
+  float: right;
+}
+
 .slayer {
   display: flex;
   flex-direction: column;

--- a/src/constants/misc.js
+++ b/src/constants/misc.js
@@ -303,7 +303,7 @@ export const raceObjectiveToStatName = {
   complete_the_giant_mushroom_no_pearls_with_return_race: "dungeon_hub_giant_mushroom_no_pearls_with_return_best_time",
   complete_the_giant_mushroom_no_abilities_with_return_race:
     "dungeon_hub_giant_mushroom_no_abilities_with_return_best_time",
-  complete_the_giant_mushroom_nothing_with_return_race_: "dungeon_hub_giant_mushroom_nothing_with_return_best_time",
+  complete_the_giant_mushroom_nothing_with_return_race: "dungeon_hub_giant_mushroom_nothing_with_return_best_time",
   complete_the_precursor_ruins_anything_with_return_race: "dungeon_hub_precursor_ruins_anything_with_return_best_time",
   complete_the_precursor_ruins_no_pearls_with_return_race:
     "dungeon_hub_precursor_ruins_no_pearls_with_return_best_time",

--- a/src/constants/misc.js
+++ b/src/constants/misc.js
@@ -295,6 +295,42 @@ export const mob_names = {
   maxor: "Necron",
 };
 
+export const raceObjectiveToStatName = {
+  complete_the_end_race: "end_race_best_time",
+  complete_the_woods_race: "foraging_race_best_time",
+  complete_the_chicken_race: "chicken_race_best_time_2",
+  complete_the_giant_mushroom_anything_with_return_race: "dungeon_hub_giant_mushroom_anything_with_return_best_time",
+  complete_the_giant_mushroom_no_pearls_with_return_race: "dungeon_hub_giant_mushroom_no_pearls_with_return_best_time",
+  complete_the_giant_mushroom_no_abilities_with_return_race:
+    "dungeon_hub_giant_mushroom_no_abilities_with_return_best_time",
+  complete_the_giant_mushroom_nothing_with_return_race_: "dungeon_hub_giant_mushroom_nothing_with_return_best_time",
+  complete_the_precursor_ruins_anything_with_return_race: "dungeon_hub_precursor_ruins_anything_with_return_best_time",
+  complete_the_precursor_ruins_no_pearls_with_return_race:
+    "dungeon_hub_precursor_ruins_no_pearls_with_return_best_time",
+  complete_the_precursor_ruins_no_abilities_with_return_race:
+    "dungeon_hub_precursor_ruins_no_abilities_with_return_best_time",
+  complete_the_precursor_ruins_nothing_with_return_race: "dungeon_hub_precursor_ruins_nothing_with_return_best_time",
+  complete_the_crystal_core_anything_with_return_race: "dungeon_hub_crystal_core_anything_with_return_best_time",
+  complete_the_crystal_core_no_pearls_with_return_race: "dungeon_hub_crystal_core_no_pearls_with_return_best_time",
+  complete_the_crystal_core_no_abilities_with_return_race:
+    "dungeon_hub_crystal_core_no_abilities_with_return_best_time",
+  complete_the_crystal_core_nothing_with_return_race: "dungeon_hub_crystal_core_nothing_with_return_best_time",
+  complete_the_giant_mushroom_anything_no_return_race: "dungeon_hub_giant_mushroom_anything_no_return_best_time",
+  complete_the_giant_mushroom_no_pearls_no_return_race: "dungeon_hub_giant_mushroom_no_pearls_no_return_best_time",
+  complete_the_giant_mushroom_no_abilities_no_return_race:
+    "dungeon_hub_giant_mushroom_no_abilities_no_return_best_time",
+  complete_the_giant_mushroom_nothing_no_return_race: "dungeon_hub_giant_mushroom_nothing_no_return_best_time",
+  complete_the_precursor_ruins_anything_no_return_race: "dungeon_hub_precursor_ruins_anything_no_return_best_time",
+  complete_the_precursor_ruins_no_pearls_no_return_race: "dungeon_hub_precursor_ruins_no_pearls_no_return_best_time",
+  complete_the_precursor_ruins_no_abilities_no_return_race:
+    "dungeon_hub_precursor_ruins_no_abilities_no_return_best_time",
+  complete_the_precursor_ruins_nothing_no_return_race: "dungeon_hub_precursor_ruins_nothing_no_return_best_time",
+  complete_the_crystal_core_anything_no_return_race: "dungeon_hub_crystal_core_anything_no_return_best_time",
+  complete_the_crystal_core_no_pearls_no_return_race: "dungeon_hub_crystal_core_no_pearls_no_return_best_time",
+  complete_the_crystal_core_no_abilities_no_return_race: "dungeon_hub_crystal_core_no_abilities_no_return_best_time",
+  complete_the_crystal_core_nothing_no_return_race: "dungeon_hub_crystal_core_nothing_no_return_best_time",
+};
+
 export const area_names = {
   dynamic: "Private Island",
   hub: "Hub",

--- a/src/helper.js
+++ b/src/helper.js
@@ -454,8 +454,14 @@ export function titleCase(string) {
   return split.join(" ");
 }
 
-export function renderRaceTier(tierNumber) {
-  return "●".repeat(tierNumber) + "○".repeat(4 - tierNumber);
+/**
+ * returns a string with 4 dots "●" for completed tiers and "○" for incomplete tiers
+ * @param {number} completeTiers
+ * @returns {string} 4 dots
+ */
+export function renderRaceTier(completeTiers) {
+  const incompleteTiers = Math.max(0, 4 - completeTiers);
+  return "●".repeat(completeTiers) + "○".repeat(incompleteTiers);
 }
 
 /**

--- a/src/helper.js
+++ b/src/helper.js
@@ -455,14 +455,7 @@ export function titleCase(string) {
 }
 
 export function renderRaceTier(tierNumber) {
-  let res = "";
-  for (let i = 0; i < tierNumber; i++) {
-    res += "●";
-  }
-  for (let i = 0; i < 4 - tierNumber; i++) {
-    res += "○";
-  }
-  return res;
+  return "●".repeat(tierNumber) + "○".repeat(4 - tierNumber);
 }
 
 /**

--- a/src/helper.js
+++ b/src/helper.js
@@ -454,6 +454,17 @@ export function titleCase(string) {
   return split.join(" ");
 }
 
+export function renderRaceTier(tierNumber) {
+  let res = "";
+  for (let i = 0; i < tierNumber; i++) {
+    res += "●";
+  }
+  for (let i = 0; i < 4 - tierNumber; i++) {
+    res += "○";
+  }
+  return res;
+}
+
 /**
  * checks whether a string should be proceeded by a or by an
  * @param {string} string

--- a/src/lib.js
+++ b/src/lib.js
@@ -2613,12 +2613,12 @@ export const getStats = async (
   for (const key in userProfile.objectives) {
     if (key.includes("complete_the_")) {
       const isCompleted = userProfile.objectives[key].status == "COMPLETE";
-      const tierNumber = parseInt("" + key.charAt(key.length - 1)) || 0;
+      const tierNumber = parseInt("" + key.charAt(key.length - 1)) ?? 0;
       const raceName = constants.raceObjectiveToStatName[key.substring(0, key.length - 2)];
 
       if (tierNumber == 1 && !isCompleted) {
         misc.objectives.completedRaces[raceName] = 0;
-      } else if (isCompleted && tierNumber > (misc.objectives.completedRaces[raceName] || 0)) {
+      } else if (isCompleted && tierNumber > (misc.objectives.completedRaces[raceName] ?? 0)) {
         misc.objectives.completedRaces[raceName] = tierNumber;
       }
     }

--- a/src/lib.js
+++ b/src/lib.js
@@ -2614,23 +2614,12 @@ export const getStats = async (
     if (key.includes("complete_the_")) {
       const isCompleted = userProfile.objectives[key].status == "COMPLETE";
       const tierNumber = parseInt("" + key.charAt(key.length - 1)) || 0;
-
-      const raceName = key
-        .replace("complete_the_", "")
-        .substring(
-          0,
-          key.length - 15 - (key.includes("chicken") || key.includes("end") || key.includes("woods") ? 0 : 5)
-        );
-      const newKeyName =
-        (raceName.endsWith("_return") ? "dungeon_hub_" : "") +
-        raceName.replace("woods", "foraging") +
-        "_best_time" +
-        (key.includes("_chicken") ? "_2" : "");
+      const raceName = constants.raceObjectiveToStatName[key.substring(0, key.length - 2)];
 
       if (tierNumber == 1 && !isCompleted) {
-        misc.objectives.completedRaces[newKeyName] = 0;
-      } else if (isCompleted && tierNumber > (misc.objectives.completedRaces[newKeyName] || 0)) {
-        misc.objectives.completedRaces[newKeyName] = tierNumber;
+        misc.objectives.completedRaces[raceName] = 0;
+      } else if (isCompleted && tierNumber > (misc.objectives.completedRaces[raceName] || 0)) {
+        misc.objectives.completedRaces[raceName] = tierNumber;
       }
     }
   }

--- a/src/lib.js
+++ b/src/lib.js
@@ -2546,6 +2546,7 @@ export const getStats = async (
   const misc = {};
 
   misc.milestones = {};
+  misc.objectives = {};
   misc.races = {};
   misc.gifts = {};
   misc.winter = {};
@@ -2604,6 +2605,33 @@ export const getStats = async (
   for (const key of auctions_buy) {
     if (key in userProfile.stats) {
       misc.auctions_buy[key.replace("auctions_", "")] = userProfile.stats[key];
+    }
+  }
+
+  misc.objectives.completedRaces = [];
+
+  for (const key in userProfile.objectives) {
+    if (key.includes("complete_the_")) {
+      const isCompleted = userProfile.objectives[key].status == "COMPLETE";
+      const tierNumber = parseInt("" + key.charAt(key.length - 1)) || 0;
+
+      const raceName = key
+        .replace("complete_the_", "")
+        .substring(
+          0,
+          key.length - 15 - (key.includes("chicken") || key.includes("end") || key.includes("woods") ? 0 : 5)
+        );
+      const newKeyName =
+        (raceName.endsWith("_return") ? "dungeon_hub_" : "") +
+        raceName.replace("woods", "foraging") +
+        "_best_time" +
+        (key.includes("_chicken") ? "_2" : "");
+
+      if (tierNumber == 1 && !isCompleted) {
+        misc.objectives.completedRaces[newKeyName] = 0;
+      } else if (isCompleted && tierNumber > (misc.objectives.completedRaces[newKeyName] || 0)) {
+        misc.objectives.completedRaces[newKeyName] = tierNumber;
+      }
     }
   }
 

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -2467,10 +2467,14 @@ const metaDescription = getMetaDescription()
                       if(duration < 1000)
                         raceDuration = '0.' + raceDuration;
                       %>
-                      <div>
-                        <span class="stat-name"><%= helper.titleCase(type.split("_").join(" ")) %>: </span>
-                        <span class="stat-value"><%= raceDuration %></span>
-                        <span class="stat-value tier-completion"><%= helper.renderRaceTier(raceTier) %></span>
+                      <div class="narrow-info-flexsb">
+                        <div>
+                          <span class="stat-name"><%= helper.titleCase(type.split("_").join(" ")) %>: </span>
+                          <span class="stat-value"><%= raceDuration %></span>
+                        </div>
+                        <div>
+                          <span class="stat-value"><%= helper.renderRaceTier(raceTier) %></span>
+                        </div>
                       </div>
                     <% }
 
@@ -2491,10 +2495,14 @@ const metaDescription = getMetaDescription()
                       if(duration < 1000)
                         raceDuration = '0.' + raceDuration;
                       %>
-                      <div>
-                        <span class="stat-name"><%= helper.titleCase(type.split("_").join(" ")) %>: </span>
-                        <span class="stat-value"><%= raceDuration %></span>
-                        <span class="stat-value tier-completion"><%= helper.renderRaceTier(raceTier) %></span>
+                      <div class="narrow-info-flexsb">
+                        <div>
+                          <span class="stat-name"><%= helper.titleCase(type.split("_").join(" ")) %>: </span>
+                          <span class="stat-value"><%= raceDuration %></span>
+                        </div>
+                        <div>
+                          <span class="stat-value"><%= helper.renderRaceTier(raceTier) %></span>
+                        </div>
                       </div>
                     <% } %>
                   </div>
@@ -2517,10 +2525,14 @@ const metaDescription = getMetaDescription()
                       if(calculated.misc.races[key] < 1000)
                         raceDuration = '0.' + raceDuration;
                     %>
-                    <div >
-                      <span class="stat-name"> <%= raceName %>: </span>
-                      <span class="stat-value"><%= raceDuration %> </span>
-                      <span class="stat-value tier-completion"><%= helper.renderRaceTier(raceTier) %></span>
+                    <div class="narrow-info-flexsb">
+                      <div>
+                        <span class="stat-name"><%= raceName %>: </span>
+                        <span class="stat-value"><%= raceDuration %></span>
+                      </div>
+                      <div>
+                        <span class="stat-value"><%= helper.renderRaceTier(raceTier) %></span>
+                      </div>
                     </div>
                     <% } %>
                   </div>

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -2456,8 +2456,8 @@ const metaDescription = getMetaDescription()
 
                     for(const type of types){
                       const key = `${race.id}_${type}_no_return_best_time`;
-                      const duration = calculated.misc.races[key] || 0;
-                      const raceTier = calculated.misc.objectives.completedRaces[key] || 0;
+                      const duration = calculated.misc.races[key] ?? 0;
+                      const raceTier = calculated.misc.objectives.completedRaces[key] ?? 0;
 
                       if(duration == 0)
                         continue;
@@ -2480,8 +2480,8 @@ const metaDescription = getMetaDescription()
 
                     for(const type of types){
                       const key = `${race.id}_${type}_with_return_best_time`;
-                      const duration = calculated.misc.races[key] || 0;
-                      const raceTier = calculated.misc.objectives.completedRaces[key] || 0;
+                      const duration = calculated.misc.races[key] ?? 0;
+                      const raceTier = calculated.misc.objectives.completedRaces[key] ?? 0;
 
                       if(duration == 0)
                         continue;
@@ -2512,7 +2512,7 @@ const metaDescription = getMetaDescription()
 
                       const raceName = helper.capitalizeFirstLetter(key.replace(/_race_best_time.*/, "").split("_").join(" "));
                       let raceDuration = moment.duration(calculated.misc.races[key], "milliseconds").format("m:ss.SSS");
-                      const raceTier = calculated.misc.objectives.completedRaces[key] || 0;
+                      const raceTier = calculated.misc.objectives.completedRaces[key] ?? 0;
 
                       if(calculated.misc.races[key] < 1000)
                         raceDuration = '0.' + raceDuration;

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -2427,26 +2427,7 @@ const metaDescription = getMetaDescription()
 
           <% if('races' in calculated.misc){ %>
             <div class="category-header"><div class="category-icon"><div class="item-icon icon-317_0"></div></div><span>races</span></div>
-            <p class="stat-raw-values">
-              <% for(const key in calculated.misc.races){
-                if(key.startsWith('dungeon_hub'))
-                  continue;
 
-                const raceName = helper.capitalizeFirstLetter(key.replace("_best_time", "").split("_").join(" "));
-                let raceDuration = moment.duration(calculated.misc.races[key], "milliseconds").format("m:ss.SSS");
-                const raceTier = calculated.misc.objectives.completedRaces[key] || 0;
-                
-                if(calculated.misc.races[key] < 1000)
-                  raceDuration = '0.' + raceDuration;
-              %>
-              <div>
-                <span class="stat-name">[</span>
-                <span class="stat-value"><%= helper.renderRaceTier(raceTier) %></span>
-                <span class="stat-name">] <%= raceName %>: </span>
-                <span class="stat-value"><%= raceDuration %> </span>
-              </div>
-              <% } %>
-            </p>
             <div class="race-containers narrow-info-container-wrapper">
               <%
               const races = [
@@ -2477,7 +2458,7 @@ const metaDescription = getMetaDescription()
                       const key = `${race.id}_${type}_no_return_best_time`;
                       const duration = calculated.misc.races[key] || 0;
                       const raceTier = calculated.misc.objectives.completedRaces[key] || 0;
-                      
+
                       if(duration == 0)
                         continue;
 
@@ -2487,10 +2468,9 @@ const metaDescription = getMetaDescription()
                         raceDuration = '0.' + raceDuration;
                       %>
                       <div>
-                        <span class="stat-name">[</span>
-                        <span class="stat-value"><%= helper.renderRaceTier(raceTier) %></span>
-                        <span class="stat-name">] <%= helper.titleCase(type.split("_").join(" ")) %>: </span>
-                        <span class="stat-value"><%= raceDuration %> </span>
+                        <span class="stat-name"><%= helper.titleCase(type.split("_").join(" ")) %>: </span>
+                        <span class="stat-value"><%= raceDuration %></span>
+                        <span class="stat-value tier-completion"><%= helper.renderRaceTier(raceTier) %></span>
                       </div>
                     <% }
 
@@ -2502,7 +2482,7 @@ const metaDescription = getMetaDescription()
                       const key = `${race.id}_${type}_with_return_best_time`;
                       const duration = calculated.misc.races[key] || 0;
                       const raceTier = calculated.misc.objectives.completedRaces[key] || 0;
-                      
+
                       if(duration == 0)
                         continue;
 
@@ -2512,10 +2492,9 @@ const metaDescription = getMetaDescription()
                         raceDuration = '0.' + raceDuration;
                       %>
                       <div>
-                        <span class="stat-name">[</span>
-                        <span class="stat-value"><%= helper.renderRaceTier(raceTier) %></span>
-                        <span class="stat-name">] <%= helper.titleCase(type.split("_").join(" ")) %>: </span>
-                        <span class="stat-value"><%= raceDuration %> </span>
+                        <span class="stat-name"><%= helper.titleCase(type.split("_").join(" ")) %>: </span>
+                        <span class="stat-value"><%= raceDuration %></span>
+                        <span class="stat-value tier-completion"><%= helper.renderRaceTier(raceTier) %></span>
                       </div>
                     <% } %>
                   </div>
@@ -2524,6 +2503,28 @@ const metaDescription = getMetaDescription()
                 }
               }
               %>
+              <div class="narrow-info-container">
+                  <div class="narrow-info-header">Other Races</div>
+                  <div class="narrow-info-content">
+                    <% for(const key in calculated.misc.races){
+                      if(key.startsWith('dungeon_hub'))
+                        continue;
+
+                      const raceName = helper.capitalizeFirstLetter(key.replace(/_race_best_time.*/, "").split("_").join(" "));
+                      let raceDuration = moment.duration(calculated.misc.races[key], "milliseconds").format("m:ss.SSS");
+                      const raceTier = calculated.misc.objectives.completedRaces[key] || 0;
+
+                      if(calculated.misc.races[key] < 1000)
+                        raceDuration = '0.' + raceDuration;
+                    %>
+                    <div >
+                      <span class="stat-name"> <%= raceName %>: </span>
+                      <span class="stat-value"><%= raceDuration %> </span>
+                      <span class="stat-value tier-completion"><%= helper.renderRaceTier(raceTier) %></span>
+                    </div>
+                    <% } %>
+                  </div>
+              </div>
             </div>
           <% } %>
           <% if('gifts' in calculated.misc){ %>

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -2432,13 +2432,20 @@ const metaDescription = getMetaDescription()
                 if(key.startsWith('dungeon_hub'))
                   continue;
 
-                const raceName = helper.capitalizeFirstLetter(key.split("_").join(" "));
+                const raceName = helper.capitalizeFirstLetter(key.replace("_best_time", "").split("_").join(" "));
                 let raceDuration = moment.duration(calculated.misc.races[key], "milliseconds").format("m:ss.SSS");
-
+                const raceTier = calculated.misc.objectives.completedRaces[key] || 0;
+                
                 if(calculated.misc.races[key] < 1000)
                   raceDuration = '0.' + raceDuration;
               %>
-              <span class="stat-name"><%= raceName %>: </span><span class="stat-value"><%= raceDuration %></span><br>
+              <div>
+                <span class="stat-name">[</span>
+                <span class="stat-value"><%= helper.renderRaceTier(raceTier) %></span>
+                <span class="stat-name">]</span>
+                <span class="stat-name"> <%= raceName %>: </span>
+                <span class="stat-value"><%= raceDuration %> </span>
+              </div>
               <% } %>
             </p>
             <div class="race-containers narrow-info-container-wrapper">
@@ -2468,8 +2475,10 @@ const metaDescription = getMetaDescription()
                     <% }
 
                     for(const type of types){
-                      const duration = calculated.misc.races[`${race.id}_${type}_no_return_best_time`] || 0;
-
+                      const key = `${race.id}_${type}_no_return_best_time`;
+                      const duration = calculated.misc.races[key] || 0;
+                      const raceTier = calculated.misc.objectives.completedRaces[key] || 0;
+                      
                       if(duration == 0)
                         continue;
 
@@ -2478,7 +2487,11 @@ const metaDescription = getMetaDescription()
                       if(duration < 1000)
                         raceDuration = '0.' + raceDuration;
                       %>
-                      <div><span class="stat-name"><%= helper.titleCase(type.replace("_", " ")) %>: </span><span class="stat-value"><%= raceDuration %></span></div>
+                      <div>
+                        <span class="stat-name"><%= helper.titleCase(type.split("_").join(" ")) %>: </span>
+                        <span class="stat-value"><%= raceDuration %></span>
+                        <span class="stat-value" style="float:right"><%= helper.renderRaceTier(raceTier) %></span>
+                      </div>
                     <% }
 
                     if(races_with_return.length > 0){ %>
@@ -2486,8 +2499,10 @@ const metaDescription = getMetaDescription()
                     <% }
 
                     for(const type of types){
-                      const duration = calculated.misc.races[`${race.id}_${type}_with_return_best_time`] || 0;
-
+                      const key = `${race.id}_${type}_with_return_best_time`;
+                      const duration = calculated.misc.races[key] || 0;
+                      const raceTier = calculated.misc.objectives.completedRaces[key] || 0;
+                      
                       if(duration == 0)
                         continue;
 
@@ -2496,7 +2511,11 @@ const metaDescription = getMetaDescription()
                       if(duration < 1000)
                         raceDuration = '0.' + raceDuration;
                       %>
-                      <div><span class="stat-name"><%= helper.titleCase(type.replace("_", " ")) %>: </span><span class="stat-value"><%= raceDuration %></span></div>
+                      <div>
+                        <span class="stat-name"><%= helper.titleCase(type.split("_").join(" ")) %>: </span>
+                        <span class="stat-value"><%= raceDuration %></span>
+                        <span class="stat-value" style="float:right"><%= helper.renderRaceTier(raceTier) %></span>
+                      </div>
                     <% } %>
                   </div>
                 </div>

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -2442,8 +2442,7 @@ const metaDescription = getMetaDescription()
               <div>
                 <span class="stat-name">[</span>
                 <span class="stat-value"><%= helper.renderRaceTier(raceTier) %></span>
-                <span class="stat-name">]</span>
-                <span class="stat-name"> <%= raceName %>: </span>
+                <span class="stat-name">] <%= raceName %>: </span>
                 <span class="stat-value"><%= raceDuration %> </span>
               </div>
               <% } %>
@@ -2488,9 +2487,10 @@ const metaDescription = getMetaDescription()
                         raceDuration = '0.' + raceDuration;
                       %>
                       <div>
-                        <span class="stat-name"><%= helper.titleCase(type.split("_").join(" ")) %>: </span>
-                        <span class="stat-value"><%= raceDuration %></span>
-                        <span class="stat-value" style="float:right"><%= helper.renderRaceTier(raceTier) %></span>
+                        <span class="stat-name">[</span>
+                        <span class="stat-value"><%= helper.renderRaceTier(raceTier) %></span>
+                        <span class="stat-name">] <%= helper.titleCase(type.split("_").join(" ")) %>: </span>
+                        <span class="stat-value"><%= raceDuration %> </span>
                       </div>
                     <% }
 
@@ -2512,9 +2512,10 @@ const metaDescription = getMetaDescription()
                         raceDuration = '0.' + raceDuration;
                       %>
                       <div>
-                        <span class="stat-name"><%= helper.titleCase(type.split("_").join(" ")) %>: </span>
-                        <span class="stat-value"><%= raceDuration %></span>
-                        <span class="stat-value" style="float:right"><%= helper.renderRaceTier(raceTier) %></span>
+                        <span class="stat-name">[</span>
+                        <span class="stat-value"><%= helper.renderRaceTier(raceTier) %></span>
+                        <span class="stat-name">] <%= helper.titleCase(type.split("_").join(" ")) %>: </span>
+                        <span class="stat-value"><%= raceDuration %> </span>
                       </div>
                     <% } %>
                   </div>


### PR DESCRIPTION
![Screenshot 2021-12-21 at 12-18-31 john_linux (Cucumber)](https://user-images.githubusercontent.com/19228364/146923713-f3b899f6-efb7-434e-96c6-166837a4cae1.png)

Description:
Pretty much does exactly what the screenshot shows. 
It adds the completed race speed tiers from the objectives api.

~~Sidenote: 
Converting the objective names into the race names, I didn't know what would be uglier. Coding in the few edge cases that tere are or making a lot of dictionary entries... for now I chose the first option - in hindsight the second option would have been better, but I want to hear your opinion on the implementation first.~~
EDIT: changed it to the second option