### PR TITLE
enderman slayer bonus stats

### DIFF
--- a/src/constants/bonuses.js
+++ b/src/constants/bonuses.js
@@ -149,7 +149,35 @@ export const bonus_stats = {
       speed: 1,
     },
   },
-  enderman_slayer: {},
+  enderman_slayer: {
+    1: {
+      health: 1,
+    },
+    2: {
+      intelligence: 1,
+    },
+    3: {
+      health: 2,
+    },
+    4: {
+      intelligence: 2,
+    },
+    5: {
+      health: 3,
+    },
+    6: {
+      intelligence: 3,
+    },
+    7: {
+      health: 4,
+    },
+    8: {
+      intelligence: 4,
+    },
+    9: {
+      health: 5,
+    },
+  },
   enchantments: {
     sharpness: {
       1: {


### PR DESCRIPTION
adds the bonus stats that enderman slayer gives
Before(LeaPhant/Grapes, currently eman 4):
![image](https://user-images.githubusercontent.com/43897385/147377780-3edf3025-ee32-43e1-ab92-272e512f3de0.png)
After:
![image](https://user-images.githubusercontent.com/43897385/147377784-f3347bff-0f4e-44a0-90e1-50be0789e5c6.png)
