### PR TITLE
always throw Errors not strings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,7 @@
     "no-unused-vars": ["error", { "args": "none" }],
     "no-constant-condition": ["error", { "checkLoops": false }],
     "import/extensions": ["warn", "always", { "ts": "never" }],
-    "deprecation/deprecation": "warn"
+    "deprecation/deprecation": "warn",
+    "no-throw-literal": "error"
   }
 }

--- a/public/resources/ts/common-defer.ts
+++ b/public/resources/ts/common-defer.ts
@@ -6,15 +6,15 @@ tippy.setDefaultProps({ allowHTML: true });
 function validateURL(url: string) {
   const urlSegments = url.trim().split("/");
   if (urlSegments.length < 1) {
-    throw "please enter a Minecraft username or UUID";
+    throw new Error("please enter a Minecraft username or UUID");
   } else if (urlSegments.length > 2) {
-    throw `"${url}" has too many "/"`;
+    throw new Error(`"${url}" has too many "/"`);
   } else {
     if (urlSegments.length === 2) {
       if (urlSegments[1].match(/^[A-Za-z]+/)) {
         urlSegments[1] = urlSegments[1].charAt(0).toUpperCase() + urlSegments[1].substr(1).toLowerCase();
       } else if (!urlSegments[1].match(/^([0-9a-fA-F]{32})$/)) {
-        throw `"${urlSegments[1]}" is not a valid profile name or ID`;
+        throw new Error(`"${urlSegments[1]}" is not a valid profile name or ID`);
       }
     }
     if (
@@ -26,7 +26,7 @@ function validateURL(url: string) {
     } else if (urlSegments[0].match(/^[\w ]{1,16}$/)) {
       urlSegments[0] = urlSegments[0].replace(" ", "_");
     } else {
-      throw `"${urlSegments[0]}" is not a valid username or UUID`;
+      throw new Error(`"${urlSegments[0]}" is not a valid username or UUID`);
     }
     return "/stats/" + urlSegments.join("/");
   }
@@ -41,7 +41,8 @@ document.querySelectorAll<HTMLFormElement>(".lookup-player").forEach((form) => {
     } catch (error) {
       const errorTip = tippy(form.querySelector("input") as HTMLInputElement, {
         trigger: "manual",
-        content: (error as string | undefined) ?? "please enter a valid Minecraft username or UUID",
+        content:
+          error instanceof Error ? error.message : String(error ?? "please enter a valid Minecraft username or UUID"),
       });
       errorTip.show();
       setTimeout(() => {

--- a/src/app.js
+++ b/src/app.js
@@ -100,7 +100,7 @@ const cachePath = path.resolve(__dirname, "../cache");
 await fs.ensureDir(cachePath);
 
 if (credentials.hypixel_api_key.length == 0) {
-  throw "Please enter a valid Hypixel API Key. Join mc.hypixel.net and enter /api to obtain one.";
+  throw new Error("Please enter a valid Hypixel API Key. Join mc.hypixel.net and enter /api to obtain one.");
 }
 
 let isFoolsDay;
@@ -380,7 +380,7 @@ app.all("/cape/:username", cors(), async (req, res) => {
     const lastUpdated = moment(optifineCape.headers["last-modified"]);
 
     if (lastUpdated.unix() > fileStats.mtime) {
-      throw "optifine cape changed";
+      throw new Error("optifine cape changed");
     } else {
       file = await fs.readFile(filename);
     }

--- a/src/helper.js
+++ b/src/helper.js
@@ -213,7 +213,7 @@ export async function resolveUsernameOrUuid(uuid, db, cacheOnly = false) {
         if (isUuid) {
           return { uuid, display_name: uuid, skin_data };
         } else {
-          throw e?.response?.data?.reason ?? "Failed resolving username.";
+          throw new Error(e?.response?.data?.reason ?? "Failed resolving username.");
         }
       }
     }
@@ -841,7 +841,7 @@ export function parseItemGems(gems, rarity) {
         gem_tier: value,
       });
     } else {
-      throw `Error! Unknwon gemstone slot key: ${key}`;
+      throw new Error(`Error! Unknown gemstone slot key: ${key}`);
     }
   }
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -3367,7 +3367,7 @@ export function getHotmItems(userProfile, packs) {
   // Check for missing node classes
   for (const nodeId in nodes) {
     if (constants.hotm.nodes[nodeId] == undefined) {
-      throw `Missing Heart of the Mountain node: ${nodeId}`;
+      throw new Error(`Missing Heart of the Mountain node: ${nodeId}`);
     }
   }
 
@@ -3659,17 +3659,17 @@ export const getProfile = async (
       const { data } = response;
 
       if (!data.success) {
-        throw "Request to Hypixel API failed. Please try again!";
+        throw new Error("Request to Hypixel API failed. Please try again!");
       }
 
       if (data.profiles == null) {
-        throw "Player has no SkyBlock profiles.";
+        throw new Error("Player has no SkyBlock profiles.");
       }
 
       allSkyBlockProfiles = data.profiles;
     } catch (e) {
       if (e?.response?.data?.cause != undefined) {
-        throw `Hypixel API Error: ${e.response.data.cause}.`;
+        throw new Error(`Hypixel API Error: ${e.response.data.cause}.`);
       }
 
       throw e;
@@ -3677,7 +3677,7 @@ export const getProfile = async (
   }
 
   if (allSkyBlockProfiles.length == 0) {
-    throw "Player has no SkyBlock profiles.";
+    throw new Error("Player has no SkyBlock profiles.");
   }
 
   for (const profile of allSkyBlockProfiles) {
@@ -3709,7 +3709,7 @@ export const getProfile = async (
           );
 
           if (!response.data.success) {
-            throw "api request failed";
+            throw new Error("api request failed");
           }
 
           return response.data.profile;
@@ -3743,7 +3743,7 @@ export const getProfile = async (
 
     if (memberCount == 0) {
       if (paramProfile) {
-        throw "Uh oh, this SkyBlock profile has no players.";
+        throw new Error("Uh oh, this SkyBlock profile has no players.");
       }
 
       continue;
@@ -3753,7 +3753,7 @@ export const getProfile = async (
   }
 
   if (profiles.length == 0) {
-    throw "No data returned by Hypixel API, please try again!";
+    throw new Error("No data returned by Hypixel API, please try again!");
   }
 
   let highest = 0;
@@ -3812,7 +3812,7 @@ export const getProfile = async (
   }
 
   if (!profile) {
-    throw "User not found in selected profile. This is probably due to a declined co-op invite.";
+    throw new Error("User not found in selected profile. This is probably due to a declined co-op invite.");
   }
 
   const userProfile = profile.members[paramPlayer];

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <title>SkyCrypt</title>
-  <% if(error){ %> <meta name="robots" content="noindex" /> <% } %>
+  <% if (error) { %> <meta name="robots" content="noindex" /> <% } %>
   <% const description = "A beautiful site for sharing your SkyBlock profile 🍣" %>
   <meta name="description" content="<%= description %>">
   <link rel="icon" href="/resources/img/logo_square.svg" sizes="any" type="image/svg+xml">
@@ -33,16 +33,16 @@
             </p>
         </figure>
       <% } %>
-      <div id="error_box_wrapper" <% if(error){ %>class="show-error"<% } %>>
+      <div id="error_box_wrapper" <% if (error) { %>class="show-error"<% } %>>
         <div id="error_box">
           <div id="error_top">
             <div id="error_title">Error</div>
             <div id="error_text">
-              <%= error %><br>
+              <%= error instanceof Error ? error.message : String(error) %><br>
             </div>
           </div>
           <div id="error_bottom">
-            <% if(typeof error === 'string' && error.includes("Key throttle.")){ %>
+            <% if (error instanceof Error && error.message.includes("Key throttle.")) { %>
             <div id="error_subtext">
               This happens when the site reaches the Hypixel API limit.<br>
               Please try again in a minute.
@@ -144,8 +144,8 @@
     </main>
     <%- include('../includes/footer'); %>
     <script>
-      <% if(error){ %>
-        console.log("An error occured with message: \"<%= error %>\"");
+      <% if (error) { %>
+        console.error(`An error occurred with message: "<%= error instanceof Error ? error.message : String(error) %>"`);
       <% } %>
 
       const mainUsernameInput = document.querySelector('main .lookup-player input');


### PR DESCRIPTION
it is generally good practice to throw instances of `Error` and not strings. This PR makes this change and adds an eslint rule to prevent regression.