### PR TITLE
Fix wrong senither weight if farming level < uncapped level

### DIFF
--- a/public/resources/ts/globals.d.ts
+++ b/public/resources/ts/globals.d.ts
@@ -157,6 +157,7 @@ interface Level {
   levelCap: number;
   uncappedLevel: number;
   levelWithProgress: number;
+  unlockableLevelWithProgress: number;
 }
 
 declare namespace constants {

--- a/src/lib.js
+++ b/src/lib.js
@@ -170,7 +170,7 @@ export function getLevelByXp(xp, extra = {}) {
   /** the maximum level that any player can achieve (used for gold progress bars) */
   const maxLevel = constants.maxed_skill_caps[extra.skill] ?? levelCap;
 
-  /** the level ignoring the cap and using only the table*/
+  /** the level ignoring the cap and using only the table */
   let uncappedLevel = 0;
 
   /** the amount of xp over the amount required for the level (used for calculation progress to next level) */
@@ -202,6 +202,9 @@ export function getLevelByXp(xp, extra = {}) {
   /** a floating point value representing the current level for example if you are half way to level 5 it would be 4.5 */
   const levelWithProgress = level + progress;
 
+  /** a floating point value representing the current level ignoring the in-game unlockable caps for example if you are half way to level 5 it would be 4.5 */
+  const unlockableLevelWithProgress = extra.cap ? Math.min(uncappedLevel + progress, maxLevel) : levelWithProgress;
+
   return {
     xp,
     level,
@@ -212,6 +215,7 @@ export function getLevelByXp(xp, extra = {}) {
     levelCap,
     uncappedLevel,
     levelWithProgress,
+    unlockableLevelWithProgress,
   };
 }
 

--- a/src/weight/senither-weight.js
+++ b/src/weight/senither-weight.js
@@ -204,16 +204,17 @@ export function calculateSenitherWeight(profile) {
     },
   };
 
+  // skill
   for (let skillName in profile.levels) {
     let data = profile.levels[skillName];
 
-    let sw = calcSkillWeight(skillWeight[skillName], data.levelWithProgress, data.xp);
+    let sw = calcSkillWeight(skillWeight[skillName], data.unlockableLevelWithProgress, data.xp);
 
     output.skill.skills[skillName] = sw.weight + sw.weight_overflow;
     output.skill.total += output.skill.skills[skillName];
   }
 
-  //dungeon weight
+  // dungeon weight
   const dungeons = profile.dungeons;
 
   if (dungeons?.catacombs?.visited) {
@@ -225,7 +226,7 @@ export function calculateSenitherWeight(profile) {
     output.dungeon.dungeons.catacombs = dungeonsWeight;
   }
 
-  //dungeon classes
+  // dungeon classes
   if (dungeons.classes) {
     for (const className of Object.keys(dungeons.classes)) {
       const dungeonClass = dungeons.classes[className];
@@ -240,6 +241,7 @@ export function calculateSenitherWeight(profile) {
     }
   }
 
+  // slayer
   for (let slayerName in profile.slayers) {
     let data = profile.slayers[slayerName];
     let sw = calcSlayerWeight(slayerName, data.level.xp);
@@ -252,6 +254,5 @@ export function calculateSenitherWeight(profile) {
     .filter((x) => x >= 0)
     .reduce((total, value) => total + value);
 
-  //console.log(output);
   return output;
 }


### PR DESCRIPTION
Player `VedatsGT` reported that senither weight was wrong for his profile.
Basically the player has enough farming xp for level 60 but he only has unlocked up to level 53.

Senither weight ignoes the in-game unlockable level caps so it always calculates as if max level for farming is 60.

I had to introduce `unlockableLevelWithProgress` (if you have a better name for it lmk) which is a value in `Levels` which returns the user level ignoring the unlockable in-game caps, with progress (cause senither wants progress).

`uncappedLevel` can't be used because it returns values as if the max level was 60 for everything, but alchemy is still considered max level 50 for senither (same as in-game).

so now we have:
- `level`: player level considering level cap and unlocked in-game caps.
- `uncappedLevel`: player level ignoring level cap
- `unlockableLevel(WithProgress)`: player level considering level cap but ignoring unlocked in-game caps.

Hope this makes sense... otherwise... blame the skills, caps, and the weight system all using a different method to calculate which level cap to use.


---

Testing:
- Profile: https://sky.shiiyu.moe/stats/VedatsGT/Kiwi
- Senither weight: `https://hypixel-api.senither.com/v1/profiles/15c0424479564e45aced7c315159ae21/weight?key=<your-api-key>`

At the time of writing this the correct skill weight for his profile should be 7572

---

Discord thread: https://discord.com/channels/738971489411399761/926050414095376395/926215108844204112