### PR TITLE
fix livid dungeon colelction

### DIFF
--- a/src/constants/dungeons.js
+++ b/src/constants/dungeons.js
@@ -217,7 +217,7 @@ export const dungeons = {
           required: 500,
           tier: 5,
         },
-        shadow_assasin_chestplate: {
+        shadow_chestplate: {
           name: "Shadow Assasin Chestplate",
           required: 750,
           tier: 6,


### PR DESCRIPTION
changes sa chestplate in livid collection to a different name so it shows as claimed
before([VedatsGT](https://sky.shiiyu.moe/stats/VedatsGT/Kiwi#Slayer))
![image](https://user-images.githubusercontent.com/43897385/148669256-aff4c3b4-3233-4e4a-bee2-9ba484b1a929.png)
after
![image](https://user-images.githubusercontent.com/43897385/148669268-1d4e4152-decc-4644-aa29-b7791c19efc8.png)

