### PR TITLE
use SKYCRYPT_PORT as port if defined

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -132,7 +132,7 @@ updateCacheOnly();
 setInterval(updateCacheOnly, 60_000 * 5);
 
 const app = express();
-const port = 32464;
+const port = process.env.SKYCRYPT_PORT ?? 32464;
 
 let sitemap;
 


### PR DESCRIPTION
if an environment variable called `SKYCRYPT_PORT` is defined it will be used as the port number otherwise `32464` will be used as usual