### PR TITLE
fix skill icon shine

### DIFF
--- a/public/resources/scss/stats.scss
+++ b/public/resources/scss/stats.scss
@@ -137,6 +137,10 @@
         transform-origin: top left;
         filter: drop-shadow(2px 2px 2px rgba(0, 0, 0, 0.4));
       }
+
+      .piece-shine {
+        border-radius: 50%;
+      }
     }
 
     .skill-name {


### PR DESCRIPTION
bug:
![image](https://user-images.githubusercontent.com/2744227/156460004-c9e7189f-9d27-4d93-b8cd-ce436b3e6dfc.png)

we probably never noticed but the shine on skills was going outside the box... this PR makes the .piece-shine have a border-radius equal to the .skill-icon element, so it doesn't overflow