### PR TITLE
fix lilyweight [A]: no m7

### DIFF
--- a/src/weight/lily-weight.js
+++ b/src/weight/lily-weight.js
@@ -22,5 +22,8 @@ export function calculateLilyWeight(profile) {
 
   const slayerXP = slayerOrder.map((key) => profile.slayers?.[key]?.level?.xp ?? 0);
 
+  // todo: remove this when lilyweight updates, fixing M7 breaking the completions weight
+  delete masterCataCompletions["7"];
+
   return LilyWeight.getWeightRaw(skillLevels, skillXP, cataCompletions, masterCataCompletions, cataXP, slayerXP);
 }


### PR DESCRIPTION
This PR is to fix lilyweight dungeon weight returning NaN, caused by new M7 floor.

The fix temporarily ignores M7 by deleting the value from the passed object, so the M7 completions don't count towards the weight