### PR TITLE
talismanCount refactor

### DIFF
--- a/public/resources/ts/globals.d.ts
+++ b/public/resources/ts/globals.d.ts
@@ -564,7 +564,6 @@ declare const calculated: SkyCryptPlayer & {
   stats: {
     [key in StatName]: number;
   };
-  talismanCount: number;
   total_skill_xp: number;
   uuid: string;
   wardrobe_equipped_slot: number;

--- a/src/constants/talismans.js
+++ b/src/constants/talismans.js
@@ -163,7 +163,6 @@ export const talismans = {
     rarity: "legendary",
     texture: "/head/8fb265c8cc6136063b4eb15450fe1fe1ab7738b0bf54d265490e1ef49da60b7c",
   },
-
   CAMPFIRE_TALISMAN_1: {
     name: "Campfire Initiate Badge",
     rarity: "common",
@@ -189,7 +188,6 @@ export const talismans = {
     rarity: "legendary",
     texture: "/head/4080bbefca87dc0f36536b6508425cfc4b95ba6e8f5e6a46ff9e9cb488a9ed",
   },
-
   FARMING_TALISMAN: null,
   VACCINE_TALISMAN: {
     name: "Vaccine Talisman",
@@ -662,3 +660,14 @@ export const talismans = {
     texture: "/head/22f2499ab4cfc97e65f0fa9fe63cc606707a4ae96af407846b1b5354f3fad99",
   },
 };
+
+// Getting Unique Accessories Count
+const unique_accessories = { ...talismans };
+
+for (const upgrade in talisman_upgrades) {
+  if (upgrade in unique_accessories) {
+    delete unique_accessories[upgrade];
+  }
+}
+
+export const unique_accessories_count = Object.keys(unique_accessories).length;

--- a/src/lib.js
+++ b/src/lib.js
@@ -33,8 +33,6 @@ import { makeLore } from "./lore-generator.js";
 
 const parseNbt = util.promisify(nbt.parse);
 
-let TALISMAN_COUNT;
-
 function getMinMax(profiles, min, ...path) {
   let output = null;
 
@@ -1810,7 +1808,6 @@ export const getStats = async (
 
   if (!items.no_inventory) {
     output.missingTalismans = await getMissingTalismans(items.talisman_ids);
-    output.talismanCount = await getTalismanCount();
   }
 
   if (!userProfile.pets) {
@@ -3027,20 +3024,6 @@ export async function getMissingTalismans(talismans) {
     missing: other,
     upgrades: upgrades,
   };
-}
-
-export function getTalismanCount() {
-  if (TALISMAN_COUNT != null) return TALISMAN_COUNT;
-  let talismanArray = Object.keys(constants.talismans);
-
-  for (const talisman in constants.talisman_upgrades) {
-    if (talismanArray.includes(talisman)) {
-      talismanArray = talismanArray.filter((name) => name !== talisman);
-    }
-  }
-
-  TALISMAN_COUNT = talismanArray.length;
-  return talismanArray.length;
 }
 
 export async function getCollections(uuid, profile, cacheOnly = false) {

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1247,18 +1247,18 @@ const metaDescription = getMetaDescription()
           <% }else{ %>
             <p class="stat-raw-values">
               <%
-                const maxTalis = items.talismans.filter(a => a.isUnique).length >= calculated.talismanCount ? 'golden-text': ''
-                const maxRecombTalis = items.talismans.filter(a => a.isUnique && a.extra?.recombobulated).length >= calculated.talismanCount ? 'golden-text': ''
+                const maxTalis = items.talismans.filter(a => a.isUnique).length >= constants.unique_accessories_count ? 'golden-text': ''
+                const maxRecombTalis = items.talismans.filter(a => a.isUnique && a.extra?.recombobulated).length >= constants.unique_accessories_count ? 'golden-text': ''
               %>
 
               <span class="stat-name <%= maxTalis %>">Unique Accessories: </span>
-              <span class="stat-value <%= maxTalis %>"><%= items.talismans.filter(a => a.isUnique).length %> / <%= calculated.talismanCount %></span>
+              <span class="stat-value <%= maxTalis %>"><%= items.talismans.filter(a => a.isUnique).length %> / <%= constants.unique_accessories_count %></span>
               <br>
               <span class="stat-name <%= maxTalis %>">Completion: </span>
-              <span class="stat-value percent <%= maxTalis %>"><%= Math.round(items.talismans.filter(a => a.isUnique).length / calculated.talismanCount * 100) %></span>
+              <span class="stat-value percent <%= maxTalis %>"><%= Math.round(items.talismans.filter(a => a.isUnique).length / constants.unique_accessories_count * 100) %></span>
               <br>
               <span class="stat-name <%= maxRecombTalis %>">Recombobulated: </span>
-              <span class="stat-value <%= maxRecombTalis %>"><%= items.talismans.filter(a => a.isUnique && a.extra?.recombobulated).length %> / <%= calculated.talismanCount %></span>
+              <span class="stat-value <%= maxRecombTalis %>"><%= items.talismans.filter(a => a.isUnique && a.extra?.recombobulated).length %> / <%= constants.unique_accessories_count %></span>
             </p>
             <% if(items.talismans.find(a => !a.isInactive) != undefined){ %>
               <div class="accessory-list">


### PR DESCRIPTION
simply refactors calculated.talismanCount to be a constant instead, removing plenty of bad code in the meanwhile

`calculated.talismanCount` -> `constants.unique_accessories_count`