### PR TITLE
fairy souls constants

### DIFF
--- a/src/constants/misc.js
+++ b/src/constants/misc.js
@@ -408,7 +408,9 @@ export const increase_most_stats_exclude = [
   "pristine",
 ];
 
-export const MAX_SOULS = {
-  normal: 228,
-  stranded: 3,
+export const fairy_souls = {
+  max: {
+    normal: 228,
+    stranded: 3,
+  },
 };

--- a/src/lib.js
+++ b/src/lib.js
@@ -1703,7 +1703,8 @@ export const getStats = async (
       output.stats[stat] += fairyBonus[stat];
     }
   }
-  const totalSouls = profile.game_mode === "island" ? constants.MAX_SOULS.stranded : constants.MAX_SOULS.normal;
+  const totalSouls =
+    profile.game_mode === "island" ? constants.fairy_souls.max.stranded : constants.fairy_souls.max.normal;
 
   output.fairy_souls = {
     collected: userProfile.fairy_souls_collected,


### PR DESCRIPTION
Simply renames fairy souls constants variable to be more descriptive:
`MAX_SOULS` -> `fairy_souls { max: {} }`

so we can reuse that constant variable in case admins will ever add more info about fairy souls in api (like their location)