### PR TITLE
Armor dyes

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -512,7 +512,7 @@ async function processItems(base64, customTextures = false, packs, cacheOnly = f
       item.extra.skin = `PET_SKIN_${item.tag.ExtraAttributes.petInfo.skin}`;
     }
 
-    if(item.tag?.ExtraAttributes?.dye_item != undefined) {
+    if (item.tag?.ExtraAttributes?.dye_item != undefined) {
       item.extra.dye = item.tag.ExtraAttributes.dye_item;
     }
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -512,6 +512,10 @@ async function processItems(base64, customTextures = false, packs, cacheOnly = f
       item.extra.skin = `PET_SKIN_${item.tag.ExtraAttributes.petInfo.skin}`;
     }
 
+    if(item.tag?.ExtraAttributes?.dye_item != undefined) {
+      item.extra.dye = item.tag.ExtraAttributes.dye_item;
+    }
+
     // Set custom texture for colored leather armor
     if (typeof item.id === "number" && item.id >= 298 && item.id <= 301) {
       const color = item.tag?.display?.color?.toString(16).padStart(6, "0") ?? "955e3b";


### PR DESCRIPTION
adds the dye ID to the `extra` entry in the item
I *believe* dyes show up in the lore but I no longer know someone viewable with armor dyes applied