### PR TITLE
fix piece shine on firefox

### DIFF
--- a/public/resources/scss/stats.scss
+++ b/public/resources/scss/stats.scss
@@ -1226,6 +1226,7 @@ a.additional-player-stat:hover {
   transition: box-shadow 0.2s ease-in-out;
   box-shadow: rgba(var(--text-rgb), 0) 0 0 0 0px inset;
   content-visibility: auto;
+  contain: paint;
 
   &.sticky-stats,
   &:focus {


### PR DESCRIPTION
this fixes a visual bug in browsers that support [contain](https://caniuse.com/mdn-css_properties_contain) but not [content-visibility](https://caniuse.com/css-content-visibility)

what it looks like when it's broken:
![image](https://user-images.githubusercontent.com/44071655/158074069-d20574f8-e7c4-4a0e-ac33-c208022bb7d1.png)


Chrome: already works
Firefox: works after this PR is merged
Safari: works after this PR is merged for users with the latest iOS/macOS