### PR TITLE
Recomend safari 15.4

### DIFF
--- a/public/resources/scss/stats.scss
+++ b/public/resources/scss/stats.scss
@@ -1226,6 +1226,7 @@ a.additional-player-stat:hover {
   transition: box-shadow 0.2s ease-in-out;
   box-shadow: rgba(var(--text-rgb), 0) 0 0 0 0px inset;
   content-visibility: auto;
+  contain: paint;
 
   &.sticky-stats,
   &:focus {

--- a/public/resources/ts/browser-compat-check.ts
+++ b/public/resources/ts/browser-compat-check.ts
@@ -1,6 +1,6 @@
 import Bowser from "bowser";
 
-const supportedIOSVersionNumber = 14.5;
+const supportedIOSVersionNumber = 15.4;
 const iOSHelpPage = "https://support.apple.com/en-us/HT204204";
 
 const browsers: {
@@ -11,7 +11,7 @@ const browsers: {
   };
 } = {
   safari: {
-    version: "14.1",
+    version: "15.4",
     help: "https://support.apple.com/en-us/HT204416",
   },
   chrome: {


### PR DESCRIPTION
This PR recommends that iPhone users update to iOS 15.4 and Mac users update to macOS 12.3

before you merge this PR:
- [x] merge #1212
- [ ] wait for iOS 15.4 to role out to the public
- [ ] wait for macOS 12.3 to role out to the public