### PR TITLE
Recommend safari 15.4 (take 2)

### DIFF
--- a/public/resources/ts/browser-compat-check.ts
+++ b/public/resources/ts/browser-compat-check.ts
@@ -1,6 +1,6 @@
 import Bowser from "bowser";
 
-const supportedIOSVersionNumber = 14.5;
+const supportedIOSVersionNumber = 15.4;
 const iOSHelpPage = "https://support.apple.com/en-us/HT204204";
 
 const browsers: {
@@ -11,7 +11,7 @@ const browsers: {
   };
 } = {
   safari: {
-    version: "14.1",
+    version: "15.4",
     help: "https://support.apple.com/en-us/HT204416",
   },
   chrome: {


### PR DESCRIPTION
this PR is the same as #1213 lets wait to merge it until we are ready to push code to users this time.

This PR recommends that iPhone users update to iOS 15.4 and Mac users update to macOS 12.3

before you merge this PR:
- [x] merge #1212
- [x] wait for iOS 15.4 to role out to the public
- [x] wait for macOS 12.3 to role out to the public