### PR TITLE
bingo pet support

### DIFF
--- a/src/constants/pet-stats.js
+++ b/src/constants/pet-stats.js
@@ -3048,6 +3048,65 @@ class Jerry extends Pet {
   }
 }
 
+class Bingo extends Pet {
+  get stats() {
+    const baseHealth = this.rarity > 1 ? 27.5 : 25;
+    const baseStrength = this.rarity > 1 ? 5.5 : 5;
+    const multHealth = this.rarity > 1 ? (140 - 27.5) / 100 : (100 - 25) / 100;
+    const multStrength = this.rarity > 1 ? (25 - 5) / 100 : (35 - 5.5) / 100;
+    return {
+      health: floor(baseHealth + this.level * multHealth),
+      strength: floor(baseStrength + this.level * multStrength),
+    };
+  }
+
+  get abilities() {
+    let list = [this.first];
+    if (this.rarity > 0) {
+      list.push(this.second);
+    }
+    if (this.rarity > 1) {
+      list.push(this.third);
+    }
+    if (this.rarity > 2) {
+      list.push(this.fourth);
+    }
+    return list;
+  }
+
+  get first() {
+    const prc = floor(5 + this.level * 0.2, 1);
+    return {
+      name: "§6Lucky Looting",
+      desc: [`§7Gain §c${prc}% §7more collection items from any source!`],
+    };
+  }
+
+  get second() {
+    const prc = floor(5 + this.level * 0.1, 1);
+    return {
+      name: "§6Fast Learner",
+      desc: [`§7Gain §c${prc}% §7more Skill Experience and §9Slayer §7Experience.`],
+    };
+  }
+
+  get third() {
+    const prc = floor(10 + this.level * 0.3, 1);
+    return {
+      name: "§6Chimera",
+      desc: [`§7Increases your base stats of your active pet by §c${prc}% §7per level.`],
+    };
+  }
+
+  get fourth() {
+    const coins = round(0.1 + this.level * 0.009, 1);
+    return {
+      name: "§6Scavenger",
+      desc: [`§7Gain §c${coins} §7more §l§6Coins §r§7per monster level on kill.`],
+    };
+  }
+}
+
 class QuestionMark extends Pet {
   get stats() {
     return {};
@@ -3094,6 +3153,7 @@ export const petStats = {
   BAL: Bal,
   BAT: Bat,
   BEE: Bee,
+  BINGO: Bingo,
   BLACK_CAT: BlackCat,
   BLAZE: Blaze,
   BLUE_WHALE: BlueWhale,

--- a/src/constants/pets.js
+++ b/src/constants/pets.js
@@ -361,6 +361,7 @@ export const pet_data = {
     maxTier: "LEGENDARY",
     maxLevel: 100,
     emoji: "👻",
+    passivePerks: true,
   },
   GRIFFIN: {
     head: "/head/4c27e3cb52a64968e60c861ef1ab84e0a0cb5f07be103ac78da67761731f00c8",
@@ -382,6 +383,7 @@ export const pet_data = {
     maxTier: "LEGENDARY",
     maxLevel: 100,
     emoji: "👵",
+    passivePerks: true,
   },
   RAT: {
     head: "/head/a8abb471db0ab78703011979dc8b40798a941f3a4dec3ec61cbeec2af8cffe8",
@@ -423,6 +425,15 @@ export const pet_data = {
     maxTier: "LEGENDARY",
     maxLevel: 100,
     emoji: "🐾",
+  },
+  BINGO: {
+    head: "/head/d4cd9c707c7092d4759fe2b2b6a713215b6e39919ec4e7afb1ae2b6f8576674c",
+    type: "all",
+    maxTier: "EPIC",
+    maxLevel: 100,
+    emoji: "🎲",
+    passivePerks: true,
+    bingoOnly: true,
   },
 };
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -1675,7 +1675,7 @@ export const getStats = async (
   userProfile.pets.push(...items.pets);
 
   output.pets = await getPets(userProfile);
-  output.missingPets = await getMissingPets(output.pets);
+  output.missingPets = await getMissingPets(output.pets, profile.game_mode);
   output.petScore = await getPetScore(output.pets);
 
   const petScoreRequired = Object.keys(constants.pet_rewards).sort((a, b) => parseInt(b) - parseInt(a));
@@ -2620,14 +2620,18 @@ export async function getPets(profile) {
       petSkin = constants.pet_skins[`PET_SKIN_${pet.skin}`].name;
     }
 
-    let loreFirstRow = [
-      "§8",
-      `${helper.capitalizeFirstLetter(petData.type)} `,
-      petData.category ?? "Pet",
-      petSkin ? `, ${petSkin} Skin` : "",
-    ];
+    const loreFirstRow = ["§8"];
 
-    let lore = [loreFirstRow.join(""), ""];
+    if (petData.type === "all") {
+      loreFirstRow.push("All Skills");
+    } else {
+      loreFirstRow.push(helper.capitalizeFirstLetter(petData.type), " ", petData.category ?? "Pet");
+      if (petSkin) {
+        loreFirstRow.push(`, ${petSkin} Skin`);
+      }
+    }
+
+    const lore = [loreFirstRow.join(""), ""];
 
     const petName =
       petData.hatching?.level > pet.level.level
@@ -2710,6 +2714,11 @@ export async function getPets(profile) {
       lore.push(" ");
     }
 
+    // passive perks text
+    if (petData.passivePerks) {
+      lore.push("§8This pet's perks are active even when the pet is not summoned!", "");
+    }
+
     if (pet.level.level < petData.maxLevel) {
       lore.push(`§7Progress to Level ${pet.level.level + 1}: §e${(pet.level.progress * 100).toFixed(1)}%`);
 
@@ -2780,13 +2789,15 @@ export async function getPets(profile) {
   return output;
 }
 
-export async function getMissingPets(pets) {
+export async function getMissingPets(pets, gameMode) {
   const profile = {
     pets: [],
   };
 
-  for (const petType in constants.pet_data) {
-    if (pets.map((a) => a.type).includes(petType)) {
+  const ownedPetTypes = pets.map((a) => a.type);
+
+  for (const [petType, petData] of Object.entries(constants.pet_data)) {
+    if (ownedPetTypes.includes(petType) || (petData.bingoOnly === true && gameMode !== "bingo")) {
       continue;
     }
 

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1342,6 +1342,7 @@ const metaDescription = getMetaDescription()
         <div class="stat-content">
           <%
             const uniquePets = _.uniq(calculated.pets.map(a => a.type))
+            const totalPets = Object.values(constants.pet_data).filter(pet => !pet.bingoOnly === true || calculated.profile.game_mode === 'bingo').length
 
             let totalPetXp = 0
             for (const pet of calculated.pets) {
@@ -1361,8 +1362,8 @@ const metaDescription = getMetaDescription()
             let totalCandiesUsed = calculated.pets.reduce((total, pet) => total + pet.candyUsed, 0)
           %>
           <p class="stat-raw-values">
-            <% max = uniquePets.length >= Object.keys(constants.pet_data).length ? 'golden-text': '' %>
-            <span class="stat-name <%= max %>">Unique Pets: </span><span class="stat-value <%= max %>"><%= uniquePets.length %> / <%= Object.keys(constants.pet_data).length %></span><br>
+            <% max = uniquePets.length >= totalPets ? 'golden-text': '' %>
+            <span class="stat-name <%= max %>">Unique Pets: </span><span class="stat-value <%= max %>"><%= uniquePets.length %> / <%= totalPets %></span><br>
 
             <% max = userUniqueSkins >= totalUniqueSkins ? 'golden-text': '' %>
             <span class="stat-name <%= max %>">Unique Pet Skins: </span><span class="stat-value <%= max %>"><%= userUniqueSkins %> / <%= totalUniqueSkins %></span><br>


### PR DESCRIPTION
- Bingo pet support
- Only shows in Bingo profiles
- Support for passive perks pets (the `This pet's perks are active even when the pet is not summoned!` thing)

![image](https://user-images.githubusercontent.com/2744227/161854167-6f8fbd07-b638-4b35-a93d-9caaafd3f2b4.png)

Fixes #1261 