### PR TITLE
Remove sass `:where()` workaround

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "rollup-plugin-delete": "^2.0.0",
         "rollup-plugin-minify-html-literals": "^1.2.6",
         "rollup-plugin-terser": "^7.0.2",
-        "sass": "^1.49.9",
+        "sass": "^1.50.0",
         "ts-lit-plugin": "^1.2.1",
         "typescript": "^4.6.2"
       },
@@ -6975,9 +6975,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.49.9",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.9.tgz",
-      "integrity": "sha512-YlYWkkHP9fbwaFRZQRXgDi3mXZShslVmmo+FVK3kHLUELHHEYrCmL1x6IUjC7wLS6VuJSAFXRQS/DxdsC4xL1A==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.50.0.tgz",
+      "integrity": "sha512-cLsD6MEZ5URXHStxApajEh7gW189kkjn4Rc8DQweMyF+o5HF5nfEz8QYLMlPsTOD88DknatTmBWkOcw5/LnJLQ==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -14296,9 +14296,9 @@
       }
     },
     "sass": {
-      "version": "1.49.9",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.9.tgz",
-      "integrity": "sha512-YlYWkkHP9fbwaFRZQRXgDi3mXZShslVmmo+FVK3kHLUELHHEYrCmL1x6IUjC7wLS6VuJSAFXRQS/DxdsC4xL1A==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.50.0.tgz",
+      "integrity": "sha512-cLsD6MEZ5URXHStxApajEh7gW189kkjn4Rc8DQweMyF+o5HF5nfEz8QYLMlPsTOD88DknatTmBWkOcw5/LnJLQ==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "rollup-plugin-delete": "^2.0.0",
     "rollup-plugin-minify-html-literals": "^1.2.6",
     "rollup-plugin-terser": "^7.0.2",
-    "sass": "^1.49.9",
+    "sass": "^1.50.0",
     "ts-lit-plugin": "^1.2.1",
     "typescript": "^4.6.2"
   }

--- a/public/resources/scss/stats.scss
+++ b/public/resources/scss/stats.scss
@@ -325,8 +325,7 @@
     text-shadow: 0px 0px 7px rgba(0, 0, 0, 0.3);
     box-sizing: border-box;
 
-    // please remove `@at-root` and `#{}` when https://github.com/sass/sass/issues/3130 is fixed
-    @at-root :where(#{&}) {
+    :where(&) {
       background-color: var(--header-hex); // fallback for rarity color
     }
   }


### PR DESCRIPTION
we no longer need this workaround because it was fixed in https://github.com/sass/sass/pull/3283