### PR TITLE
fix grandma wolf perk description

### DIFF
--- a/src/constants/pet-stats.js
+++ b/src/constants/pet-stats.js
@@ -2158,11 +2158,7 @@ class GrandmaWolf extends Pet {
     return {
       name: "§6Kill Combo",
       desc: [
-        `§7Gain buffs for combo kills.`,
-        `§7Effects stack as you increase`,
-        `§7your combo. This pet does not`,
-        `§7need to be spawned for combos to`,
-        `§7be active!`,
+        `§7Gain buffs for combo kills. Effects stack as you increase your combo.`,
         ``,
         `§a5 Combo §8(lasts §a${Math.floor((8 + this.level * 0.02) * 10) / 10}s§8)`,
         `§8+§b3% §b${symbols.magic_find} Magic Find`,


### PR DESCRIPTION
As reported by #1268 (but that issue is not fixed yet), fix the description of grandma wolf pet:

New:
![image](https://user-images.githubusercontent.com/2744227/162741813-1fed3f04-974b-407a-8308-81acc5d7bcfd.png)

Before:
![image](https://user-images.githubusercontent.com/2744227/162741852-fd887694-95a0-42fe-a51d-eed0030f7fdf.png)
