### PR TITLE
development-defer only in stats page

### DIFF
--- a/includes/resources.ejs
+++ b/includes/resources.ejs
@@ -43,7 +43,7 @@
     <link rel="preload" href="/resources/js/<%- fileNameMap['inventory-view'] %>" as="script">
   <% } %>
 
-  <% if (process.env.NODE_ENV === "development") { %>
+  <% if (page === "stats" && process.env.NODE_ENV === "development") { %>
     <script defer type="module" src="/resources/js/<%- fileNameMap['development-defer'] %>"></script>
   <% } %>
 


### PR DESCRIPTION
Noticed that while the website is in development `development-defer.ts` imports `stats-defer` which causes some console errors to display when on the home page... but since `development-defer` is only needed in stats page anyway I made it so it only gets inserted if the page is stats.