### PR TITLE
Magic Power PR: minor improvement

### DIFF
--- a/src/constants/talismans.js
+++ b/src/constants/talismans.js
@@ -732,3 +732,12 @@ for (const upgrade in talisman_upgrades) {
 }
 
 export const unique_accessories_count = Object.keys(unique_accessories).length;
+
+export const magical_power = {
+  common: 3,
+  uncommon: 5,
+  rare: 8,
+  epic: 12,
+  legendary: 16,
+  mythic: 22,
+};

--- a/src/lib.js
+++ b/src/lib.js
@@ -1010,10 +1010,7 @@ export const getItems = async (
     epic: 0,
     legendary: 0,
     mythic: 0,
-    hegemony: {
-      rarity: "legendary",
-      exists: false,
-    },
+    hegemony: null,
   };
 
   // Modify talismans on armor and add
@@ -1081,7 +1078,9 @@ export const getItems = async (
     talismans.push(insertTalisman);
     talisman_ids.push(id);
     accessory_rarities[insertTalisman.rarity]++;
-    if (id == "HEGEMONY_ARTIFACT") accessory_rarities.hegemony = { rarity: insertTalisman.rarity, exists: true };
+    if (id == "HEGEMONY_ARTIFACT") {
+      accessory_rarities.hegemony = { rarity: insertTalisman.rarity };
+    }
   }
 
   // Add inactive talismans from enderchest and backpacks

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1272,8 +1272,7 @@ const metaDescription = getMetaDescription()
               <span style='color: var(--§6);' class='grey-text'>5 MP</span> × <span style='color: var(--§a);' class='grey-text'><%= rarities.uncommon %> Accs.</span> = <span style='color: var(--§6);' class='grey-text'><%= player_magical_power.uncommon.toLocaleString() %> MP</span><br>
               <span style='color: var(--§6);' class='grey-text'>3 MP</span> × <span style='color: var(--§f);' class='grey-text'><%= rarities.common %> Accs.</span> = <span style='color: var(--§6);' class='grey-text'><%= player_magical_power.common.toLocaleString() %> MP</span><br><br>
               <% if(rarities.hegemony) { %>
-                <% if(rarities.hegemony.rarity == "legendary") %>
-                <span style='color: var(--<%= rarities.hegemony.rarity === "legendary" ? "§6" : "§d" %>);' class='grey-text'>Hegemony Artifact</span> = <span style='color: var(--§6);' class='grey-text'>+<%= mp_hegemony.toLocaleString() %> MP</span><br><br>
+                <span style='color: var(--§<%= constants.rarityColors[rarities.hegemony.rarity] %>);' class='grey-text'>Hegemony Artifact</span> = <span style='color: var(--§6);' class='grey-text'>+<%= mp_hegemony.toLocaleString() %> MP</span><br><br>
               <% } %>
               Total: <span style='color: var(--§6);' class='grey-text'><%= mp_total.toLocaleString() %> Magical Power</span>
               ">

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1250,36 +1250,35 @@ const metaDescription = getMetaDescription()
               <span class="stat-name <%= maxRecombTalis %>">Recombobulated: </span>
               <span class="stat-value <%= maxRecombTalis %>"><%= items.talismans.filter(a => a.isUnique && a.extra?.recombobulated).length %> / <%= constants.unique_accessories_count %></span>
               <br>
-              <% 
+              <%
                 const rarities = items.accessory_rarities;
-                const magical_power = {
-                  common: 3,
-                  uncommon: 5,
-                  rare: 8,
-                  epic: 12,
-                  legendary: 16,
-                  mythic: 22,
-                };
-                for(const rarity in magical_power){
-                  magical_power[rarity] = items.accessory_rarities[rarity] * magical_power[rarity];
+                const player_magical_power = {}
+
+                for (const rarity in constants.magical_power) {
+                  player_magical_power[rarity] = 0
+                  player_magical_power[rarity] += rarities[rarity] * constants.magical_power[rarity];
                 }
-                const mp_total = Object.values(magical_power).reduce((a, b) => a + b) + (rarities.hegemony.exists ? rarities.hegemony.rarity == "legendary" ? 16 : 22 : 0);
+
+                const mp_hegemony = rarities.hegemony ? constants.magical_power[rarities.hegemony.rarity] : 0
+                const mp_total = Object.values(player_magical_power).reduce((a, b) => a + b) + mp_hegemony;
               %>
               <span data-tippy-content="
               Accessories Breakdown<br>
               <span style='color: var(--§8);' class='grey-text'>From your accessory bag</span><br><br>
-              <span style='color: var(--§6);' class='grey-text'>22 MP</span> x <span style='color: var(--§d);' class='grey-text'><%= rarities.mythic %> Accs.</span> = <span style='color: var(--§6);' class='grey-text'><%= magical_power.mythic %> MP</span><br>
-              <span style='color: var(--§6);' class='grey-text'>16 MP</span> x <span style='color: var(--§6);' class='grey-text'><%= rarities.legendary %> Accs.</span> = <span style='color: var(--§6);' class='grey-text'><%= magical_power.legendary %> MP</span><br>
-              <span style='color: var(--§6);' class='grey-text'>12 MP</span> x <span style='color: var(--§5);' class='grey-text'><%= rarities.epic %> Accs.</span> = <span style='color: var(--§6);' class='grey-text'><%= magical_power.epic %> MP</span><br>
-              <span style='color: var(--§6);' class='grey-text'>8 MP</span> x <span style='color: var(--§1);' class='grey-text'><%= rarities.rare %> Accs.</span> = <span style='color: var(--§6);' class='grey-text'><%= magical_power.rare %> MP</span><br>
-              <span style='color: var(--§6);' class='grey-text'>5 MP</span> x <span style='color: var(--§a);' class='grey-text'><%= rarities.uncommon %> Accs.</span> = <span style='color: var(--§6);' class='grey-text'><%= magical_power.uncommon %> MP</span><br>
-              <span style='color: var(--§6);' class='grey-text'>3 MP</span> x <span style='color: var(--§f);' class='grey-text'><%= rarities.common %> Accs.</span> = <span style='color: var(--§6);' class='grey-text'><%= magical_power.common %> MP</span><br><br>
-              <% if(rarities.hegemony.exists) { %>
+              <span style='color: var(--§6);' class='grey-text'>22 MP</span> × <span style='color: var(--§d);' class='grey-text'><%= rarities.mythic %> Accs.</span> = <span style='color: var(--§6);' class='grey-text'><%= player_magical_power.mythic.toLocaleString() %> MP</span><br>
+              <span style='color: var(--§6);' class='grey-text'>16 MP</span> × <span style='color: var(--§6);' class='grey-text'><%= rarities.legendary %> Accs.</span> = <span style='color: var(--§6);' class='grey-text'><%= player_magical_power.legendary.toLocaleString() %> MP</span><br>
+              <span style='color: var(--§6);' class='grey-text'>12 MP</span> × <span style='color: var(--§5);' class='grey-text'><%= rarities.epic %> Accs.</span> = <span style='color: var(--§6);' class='grey-text'><%= player_magical_power.epic.toLocaleString() %> MP</span><br>
+              <span style='color: var(--§6);' class='grey-text'>8 MP</span> × <span style='color: var(--§1);' class='grey-text'><%= rarities.rare %> Accs.</span> = <span style='color: var(--§6);' class='grey-text'><%= player_magical_power.rare.toLocaleString() %> MP</span><br>
+              <span style='color: var(--§6);' class='grey-text'>5 MP</span> × <span style='color: var(--§a);' class='grey-text'><%= rarities.uncommon %> Accs.</span> = <span style='color: var(--§6);' class='grey-text'><%= player_magical_power.uncommon.toLocaleString() %> MP</span><br>
+              <span style='color: var(--§6);' class='grey-text'>3 MP</span> × <span style='color: var(--§f);' class='grey-text'><%= rarities.common %> Accs.</span> = <span style='color: var(--§6);' class='grey-text'><%= player_magical_power.common.toLocaleString() %> MP</span><br><br>
+              <% if(rarities.hegemony) { %>
                 <% if(rarities.hegemony.rarity == "legendary") %>
-                <span <% if(rarities.hegemony.rarity == "legendary") { %>style='color: var(--§6);'<% } else { %>style='color: var(--§d);'<% } %> class='grey-text'>Hegemony Artifact</span> = <span style='color: var(--§6);' class='grey-text'>+<% if(rarities.hegemony.rarity == "legendary") { %>16<% } else { %>22<% } %> MP</span>.<br><br>
+                <span style='color: var(--<%= rarities.hegemony.rarity === "legendary" ? "§6" : "§d" %>);' class='grey-text'>Hegemony Artifact</span> = <span style='color: var(--§6);' class='grey-text'>+<%= mp_hegemony.toLocaleString() %> MP</span><br><br>
               <% } %>
-              Total: <span style='color: var(--§6);' class='grey-text'><%= mp_total %> Magical Power</span>
-              "><span class="stat-name">Magical Power: </span><span class="stat-value"><%= mp_total %></span></span>
+              Total: <span style='color: var(--§6);' class='grey-text'><%= mp_total.toLocaleString() %> Magical Power</span>
+              ">
+                <span class="stat-name">Magical Power: </span><span class="stat-value"><%= mp_total.toLocaleString() %></span>
+              </span>
             </p>
             <% if(items.talismans.find(a => !a.isInactive) != undefined){ %>
               <div class="accessory-list">


### PR DESCRIPTION
Changed a couple things in the Magic Power PR:
- moved the `magical_power` values in constants
- simplified the hegemony object so it only has rarity property
- ⚠ before you were overwriting the constant values of `magic_power`... it's best to create a new object for the `player_magical_power`
- using the `×` character instead of `x` because it looks a bit better in my opinion
- adding `.toLocaleString()` to format numbers
- ❓ removed an extra `<% if(rarities.hegemony.rarity == "legendary") %>` ...was there a reason for this?
- less color code hardcoding with `constants.rarityColors[rarities.hegemony.rarity]`

### Before/After:
![image](https://user-images.githubusercontent.com/2744227/165090390-4b29548d-93c1-4aa9-90ea-2f83551b2cbb.png) ![image](https://user-images.githubusercontent.com/2744227/165090245-8bb6139d-5f7d-4f46-a9b3-76e621a4edef.png)

I thought about not hardcoding the hegemony thing, but at the same time I don't really see another case in the near future where they will add a similar accessory so... it's good like this