### PR TITLE
fix item render name

### DIFF
--- a/public/resources/scss/stats.scss
+++ b/public/resources/scss/stats.scss
@@ -318,10 +318,15 @@
       color: white;
       text-shadow: 0 0 7px rgba(0, 0, 0, 0.3);
       margin: 0;
-      padding: 4px 10px;
-      border-radius: 1rem;
-      background-color: var(--lore_background-hex);
       flex: 1;
+      &[data-multicolor="true"] {
+        background-color: var(--lore_background-hex);
+        border-radius: 1rem;
+        padding: 4px 10px;
+        --§9: #929292;
+        --§8: #929292;
+        --§0: #929292;
+      }
     }
 
     .close-lore {

--- a/public/resources/ts/stats-defer.ts
+++ b/public/resources/ts/stats-defer.ts
@@ -268,9 +268,13 @@ function fillLore(element: HTMLElement) {
   }
 
   itemName.className = `item-name piece-${item.rarity || "common"}-bg nice-colors-dark`;
-  itemNameContent.innerHTML = renderLore((item as Item).tag.display.Name ?? item.display_name) || "null";
+  const itemNameHtml = renderLore((item as Item).tag?.display?.Name ?? item.display_name ?? "???");
+  const isMulticolor = (itemNameHtml.match(/<\/span>/g) || []).length > 1;
+  itemNameContent.dataset.multicolor = String(isMulticolor);
+  itemNameContent.innerHTML = isMulticolor ? itemNameHtml : item.display_name ?? "???";
 
   if (element.hasAttribute("data-pet-index")) {
+    itemNameContent.dataset.multicolor = "false";
     itemNameContent.innerHTML = `[Lvl ${(item as Pet).level.level}] ${item.display_name}`;
   }
 


### PR DESCRIPTION
This PR changes item tooltips:
- The new layout/style is displayed only for multicolor names, monochrome names will display as they used to
- When displaying multicolor names, convert dark blue, black and dark gray to the equivalent of white
- Fixes bug with pets (woops)

![image](https://user-images.githubusercontent.com/2744227/167318834-466b73d9-bead-49d4-b34a-17112d7c4957.png)
![image](https://user-images.githubusercontent.com/2744227/167318838-32fa1d65-7925-466b-bf23-312d7304e5b7.png)
![image](https://user-images.githubusercontent.com/2744227/167318848-4736e287-8e04-43fe-a06a-f882863b23c6.png)
![image](https://user-images.githubusercontent.com/2744227/167318857-633d8867-cb5f-49e8-920e-f7ccf81c5163.png)
![image](https://user-images.githubusercontent.com/2744227/167318862-f7c99203-0af5-4725-b220-9548b10e94a7.png)
![image](https://user-images.githubusercontent.com/2744227/167318873-f399a2d8-82a8-44f6-8eed-c17a1e24cd26.png)
![image](https://user-images.githubusercontent.com/2744227/167318882-9d9457cb-b1da-440b-863a-7bde48f0a0d5.png)
