### PR TITLE
Fixed Inferno minion having 12 tiers instead of 11

### DIFF
--- a/src/constants/minions.js
+++ b/src/constants/minions.js
@@ -302,7 +302,6 @@ export const minions = {
   INFERNO: {
     type: "combat",
     head: "/head/665c54366f88fb3280b1c3fc500ce2b799c8dd327ab6d41c9bc959488f5cfd92",
-    tiers: 12,
   },
 };
 


### PR DESCRIPTION
This affects the maximum number of minions as well as the max tier of the inferno minion.
(Found while trying to find max number of minions for Skyhelper lol)