### PR TITLE
fix talisman_enrichment

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -1159,8 +1159,8 @@ export const getItems = async (
       accessory.reforge = accessory.tag.ExtraAttributes.modifier;
     }
 
-    if (accessory.tag?.ExtraAttributes?.accessory_enrichment != undefined) {
-      accessory.enrichment = accessory.tag.ExtraAttributes.accessory_enrichment;
+    if (accessory.tag?.ExtraAttributes?.talisman_enrichment != undefined) {
+      accessory.enrichment = accessory.tag.ExtraAttributes.talisman_enrichment;
     }
   }
 

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -232,7 +232,7 @@ function enrichmentToStatName(enrichment) {
 function getEnrichments(accessories) {
   const enrichmentCounts = {}
   const filteredAccessories = accessories
-    .filter(acc => ['legendary', 'mythic'].includes(acc.rarity.toLowerCase()))
+    .filter(acc => ['legendary', 'mythic', 'divine', 'special', 'very_special'].includes(acc.rarity.toLowerCase()))
 
   if (filteredAccessories.length > 0) {
     filteredAccessories.forEach(acc => {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2744227/173117381-08f55834-0d44-48ed-a532-124e1b576e21.png)

We have to blame @metalcupcake5 for this one 😛 

joking, I also didn't see this... it happened while changing all the "talisman" variables to "accessory"... but this one shouldn't have changed ofc

Also made sure enrichments count for divine, special and very special accessories (divine doesn't exist yet... but future proof)