### PR TITLE
Show EHP and Damage Reduction in stats section

### DIFF
--- a/public/resources/ts/elements/player-stat.ts
+++ b/public/resources/ts/elements/player-stat.ts
@@ -14,6 +14,9 @@ export class PlayerStat extends LitElement {
   @property({ attribute: "data" })
   data?: string;
 
+  @property({ attribute: "special" })
+  special?: string;
+
   protected render(): TemplateResult | undefined {
     if (!this.stat || !this.value || !this.data) {
       return;
@@ -24,8 +27,9 @@ export class PlayerStat extends LitElement {
     const name = constants.statsData[this.stat].nameShort;
     const suffix = constants.statsData[this.stat].suffix;
     const data = JSON.parse(window.atob(this.data));
+    const special = this.special ? JSON.parse(window.atob(this.special)) : undefined;
 
-    const tooltip = this.getTooltip(data, name, suffix, value);
+    const tooltip = this.getTooltip(data, name, suffix, value, special);
 
     return html`
       <div data-stat="${this.stat}" class="basic-stat stat-${this.stat.replaceAll("_", "-")}">
@@ -42,7 +46,8 @@ export class PlayerStat extends LitElement {
     data: { [key: string]: number },
     name: string | undefined,
     suffix: string,
-    value: number
+    value: number,
+    special: { [key: string]: number } | undefined
   ): string[] {
     const tooltip: string[] = [];
     const tooltip_bonus: string[] = [];
@@ -77,6 +82,13 @@ export class PlayerStat extends LitElement {
         "<br/>",
         `<span class='tippy-explanation'>Bonus value obtain from: <br>${tooltip_bonus.join("<br>")}</span>`
       );
+    }
+
+    if (special && Object.keys(special).length > 0) {
+      tooltip.push("<br/>");
+      for (const [key, val] of Object.entries(special)) {
+        tooltip.push("<br/>", `<span class="stat-name">${key}: </span>`, `<span class="stat-value">${val}</span>`);
+      }
     }
 
     return tooltip;

--- a/public/resources/ts/stats-defer.ts
+++ b/public/resources/ts/stats-defer.ts
@@ -995,6 +995,36 @@ export function formatNumber(number: number, floor: boolean, rounding = 10): str
     );
     node.setAttribute("data", window.btoa(JSON.stringify(stats[stat])));
 
+    // Special additions for some stats
+    const totalHealth = Object.values(stats.health).reduce((a, b) => a + b, 0);
+    const totalDefense = Object.values(stats.defense).reduce((a, b) => a + b, 0);
+    const totalTrueDefense = Object.values(stats.true_defense).reduce((a, b) => a + b, 0);
+
+    switch (stat) {
+      case "defense":
+        node.setAttribute(
+          "special",
+          window.btoa(
+            JSON.stringify({
+              "Damage Reduction": `${Math.round((totalDefense / (totalDefense + 100)) * 100)}%`,
+              "Effective Health": `${Math.round(totalHealth * (1 + totalDefense / 100)).toLocaleString()}`,
+            })
+          )
+        );
+        break;
+
+      case "true_defense":
+        node.setAttribute(
+          "special",
+          window.btoa(
+            JSON.stringify({
+              "True Damage Reduction": `${Math.round((totalTrueDefense / (totalTrueDefense + 100)) * 100)}%`,
+            })
+          )
+        );
+        break;
+    }
+
     nodeWrapper.appendChild(node);
     parent?.appendChild(nodeWrapper);
   }


### PR DESCRIPTION
Shows `EHP` and `Damage Reduction` in the `Defense` stat, `True Damage Reduction` in the `True Damage` stat.
Followed the math here: https://hypixel-skyblock.fandom.com/wiki/Damage_Reduction

![image](https://user-images.githubusercontent.com/2744227/173207659-0f95abac-c524-41fe-b3ab-e0d88d34efdd.png)
![image](https://user-images.githubusercontent.com/2744227/173207663-83ef0d4d-8aff-4596-8ce5-f90a1407c1ec.png)
