### PR TITLE
fix development alt click on items

### DIFF
--- a/public/resources/scss/stats.scss
+++ b/public/resources/scss/stats.scss
@@ -1269,6 +1269,7 @@ a.additional-player-stat:hover {
   left: 0;
   bottom: 0;
   right: 0;
+  pointer-events: none;
   overflow: hidden;
   @supports (contain: paint) {
     overflow: initial;


### PR DESCRIPTION
This is a small fix that makes the .piece-shine overlay on an item not count for click events, so the alt+click in development mode always works.

Nothing changes for users on production website