### PR TITLE
fix getStatsFromItem() values above 999

### DIFF
--- a/common/helper.js
+++ b/common/helper.js
@@ -14,7 +14,7 @@ export function removeFormatting(string) {
  * @returns {ItemStats}
  */
 export function getStatsFromItem(piece) {
-  const regex = /^([A-Za-z ]+): ([+-]([0-9]+\.?[0-9]*))/;
+  const regex = /^([A-Za-z ]+): ([+-]([0-9]+(?:,[0-9]{3})*(?:\.[0-9]{0,2})?))/;
   const stats = {};
 
   if (!piece) {
@@ -31,7 +31,7 @@ export function getStatsFromItem(piece) {
     }
 
     const statName = Object.keys(constants.statsData).find((key) => constants.statsData[key].nameLore === match[1]);
-    const statValue = parseFloat(match[2]);
+    const statValue = parseFloat(match[2].replace(/,/g, ""));
 
     if (statName) {
       stats[statName] ??= 0;


### PR DESCRIPTION
Basically the function getStatsFromItem() which parses items lore and gets the stats from it was not working for values > 999 because hypixels puts a comma to separate thousands, like: "+1,543.5"

This PR allows for those values to be correctly parsed (even "+999,999,999,999,999,999.99")

Tested on https://sky.shiiyu.moe/stats/minhperry02/Papaya#Armor (while in dungeons)

Before
![image](https://user-images.githubusercontent.com/2744227/174650552-040f8e75-182a-4f19-8f36-3cf80513a440.png)

After
![image](https://user-images.githubusercontent.com/2744227/174650565-aefe4320-6040-4a91-801f-c9a7b85de06c.png)

Discord report: https://discord.com/channels/738971489411399761/738990246825427084/988238116265529448