### PR TITLE
Update SkyCrypt logo and tagline in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-<p align="center"><img src="https://i.imgur.com/Ij5J9G9.png"></p>
-<h1 align="center">SkyCrypt: A Hypixel Skyblock Profile Viewer</h1>
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="public/resources/img/logo_black.png">
+    <img alt="SkyCrypt 🍣" height="96px" src="public/resources/img/logo.png">
+  </picture>
+</p>
+<h1 align="center">A Hypixel Skyblock Profile Viewer</h1>
 
 The SkyCrypt Project, which is based on [LeaPhant's skyblock-stats](https://github.com/LeaPhant/skyblock-stats), allows you to share your <a href="https://hypixel.net/">Hypixel</a> SkyBlock profile with other players with a quick overview of your Stats, Skills, Armor, Weapons and Accessories.
 


### PR DESCRIPTION
## Changes:
- add support for light mode (don't worry dark mode still works)
- add alt text to logo
- make logo slightly larger
- use logo files in this repo instead of on Imgur
- remove redundant "SkyCrypt" from tagline


## Before:
![image](https://user-images.githubusercontent.com/44071655/174687667-c7ac9f11-5ade-4465-b967-74d3a7e7ba98.png)
## After:
![image](https://user-images.githubusercontent.com/44071655/174687674-d4935fe5-bed2-47b1-b2b2-e8377d1570f5.png)


inspired by https://github.com/LeaPhant/skyblock-stats/commit/7912ac8ef1e603e77c26de162f0333d550843566