### PR TITLE
stop using atob() btoa() to pass objects to LitElements (also fixes french language issue)

### DIFF
--- a/public/resources/ts/elements/bonus-stats.ts
+++ b/public/resources/ts/elements/bonus-stats.ts
@@ -6,15 +6,11 @@ import * as constants from "../../../../common/constants.js";
 
 @customElement("bonus-stats")
 export class BonusStats extends LitElement {
-  @property({ attribute: "data" })
-  data?: string;
+  @property({ attribute: false })
+  data = {};
 
   protected render(): TemplateResult | undefined {
-    if (!this.data) {
-      return;
-    }
-    const data = JSON.parse(window.atob(this.data));
-    const stats = this.getStats(data);
+    const stats = this.getStats(this.data);
 
     return html`
       <p>

--- a/public/resources/ts/elements/player-stat.ts
+++ b/public/resources/ts/elements/player-stat.ts
@@ -11,14 +11,14 @@ export class PlayerStat extends LitElement {
   @property({ attribute: "value" })
   value?: string;
 
-  @property({ attribute: "data" })
-  data?: string;
+  @property({ attribute: false })
+  data = {};
 
-  @property({ attribute: "special" })
-  special?: string;
+  @property({ attribute: false })
+  special = {};
 
   protected render(): TemplateResult | undefined {
-    if (!this.stat || !this.value || !this.data) {
+    if (!this.stat || !this.value) {
       return;
     }
 
@@ -26,10 +26,8 @@ export class PlayerStat extends LitElement {
     const icon = constants.statsData[this.stat].symbol;
     const name = constants.statsData[this.stat].nameShort;
     const suffix = constants.statsData[this.stat].suffix;
-    const data = JSON.parse(window.atob(this.data));
-    const special = this.special ? JSON.parse(window.atob(this.special)) : undefined;
 
-    const tooltip = this.getTooltip(data, name, suffix, value, special);
+    const tooltip = this.getTooltip(this.data, name, suffix, value, this.special);
 
     return html`
       <div data-stat="${this.stat}" class="basic-stat stat-${this.stat.replaceAll("_", "-")}">

--- a/public/resources/ts/stats-defer.ts
+++ b/public/resources/ts/stats-defer.ts
@@ -881,7 +881,8 @@ export function formatNumber(number: number, floor: boolean, rounding = 10): str
         .reduce((a, b) => a + b, 0)
         .toString()
     );
-    node.setAttribute("data", window.btoa(JSON.stringify(stats[stat])));
+
+    node.data = stats[stat];
 
     // Special additions for some stats
     const totalHealth = Object.values(stats.health).reduce((a, b) => a + b, 0);
@@ -890,26 +891,16 @@ export function formatNumber(number: number, floor: boolean, rounding = 10): str
 
     switch (stat) {
       case "defense":
-        node.setAttribute(
-          "special",
-          window.btoa(
-            JSON.stringify({
-              "Damage Reduction": `${Math.round((totalDefense / (totalDefense + 100)) * 100)}%`,
-              "Effective Health": `${Math.round(totalHealth * (1 + totalDefense / 100)).toLocaleString()}`,
-            })
-          )
-        );
+        node.special = {
+          "Damage Reduction": `${Math.round((totalDefense / (totalDefense + 100)) * 100)}%`,
+          "Effective Health": `${Math.round(totalHealth * (1 + totalDefense / 100)).toLocaleString()}`,
+        };
         break;
 
       case "true_defense":
-        node.setAttribute(
-          "special",
-          window.btoa(
-            JSON.stringify({
-              "True Damage Reduction": `${Math.round((totalTrueDefense / (totalTrueDefense + 100)) * 100)}%`,
-            })
-          )
-        );
+        node.special = {
+          "True Damage Reduction": `${Math.round((totalTrueDefense / (totalTrueDefense + 100)) * 100)}%`,
+        };
         break;
     }
 
@@ -938,7 +929,7 @@ export function formatNumber(number: number, floor: boolean, rounding = 10): str
     }
 
     const node = document.createElement("bonus-stats");
-    node.setAttribute("data", window.btoa(JSON.stringify(bonusStats)));
+    node.data = bonusStats;
 
     element.appendChild(node);
   });


### PR DESCRIPTION
Fix an issue with french language causing an error while rendering stats, more details here
https://discord.com/channels/738971489411399761/738990246825427084/991094407145066557

Converts all `window.atob()` e `window.btoa()` to the proper way of passing object data to a Lit element (thanks Nate)