### PR TITLE
fix error when perfect gem has uuid

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -710,14 +710,14 @@ export function parseItemGems(gems, rarity) {
         slot_type,
         slot_number: +key.split("_")[1],
         gem_type: gems[`${key}_gem`],
-        gem_tier: value,
+        gem_tier: value?.quality || value,
       });
     } else if (slots.normal.includes(slot_type)) {
       parsed.push({
         slot_type,
         slot_number: +key.split("_")[1],
         gem_type: key.split("_")[0],
-        gem_tier: value,
+        gem_tier: value?.quality || value,
       });
     } else {
       throw new Error(`Error! Unknown gemstone slot key: ${key}`);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/43897385/177497240-ec71df39-9767-4f13-b046-68dfef8157a0.png)
some gems apparently have uuid in an object now, this pr makes sure its checked for

tested on SophiaChan/Peach, withered deathripper dagger
![image](https://user-images.githubusercontent.com/43897385/177497635-52e91d0f-3678-4310-85bc-d93b0a124e99.png)
