### PR TITLE
change max Flame level to 2

### DIFF
--- a/common/constants/enchantments.js
+++ b/common/constants/enchantments.js
@@ -31,7 +31,7 @@ export const maxEnchants = new Set([
   "Fire Aspect III",
   "Fire Protection VII",
   "First Strike V",
-  "Flame I",
+  "Flame II",
   "Fortune IV",
   "Frail VI",
   "Frost Walker II",


### PR DESCRIPTION
fixes #1561

I went in-game and confirmed that flame 2 exists and can be made with 2 flame 1 books