### PR TITLE
Lint Variable Case

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
   "rules": {
     "curly": ["warn", "multi-line", "consistent"],
     "no-unused-vars": ["error", { "args": "none" }],
+    "prefer-const": ["warn", { "destructuring": "all" }],
     "no-constant-condition": ["error", { "checkLoops": false }],
     "import/extensions": ["warn", "always", { "ts": "never" }],
     "deprecation/deprecation": "warn",

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
   "extends": ["eslint:recommended", "plugin:import/recommended", "prettier"],
-  "plugins": ["deprecation"],
+  "plugins": ["deprecation", "@typescript-eslint"],
   "env": {
     "commonjs": true,
     "es2021": true,
@@ -17,6 +17,13 @@
     "no-constant-condition": ["error", { "checkLoops": false }],
     "import/extensions": ["warn", "always", { "ts": "never" }],
     "deprecation/deprecation": "warn",
-    "no-throw-literal": "error"
+    "no-throw-literal": "error",
+    "@typescript-eslint/naming-convention": [
+      "warn",
+      { "selector": "variableLike", "format": ["camelCase"] },
+      { "selector": "variable", "modifiers": ["const"], "format": ["camelCase", "UPPER_CASE"] },
+      { "selector": "variable", "modifiers": ["const", "exported"], "format": ["UPPER_CASE"] },
+      { "selector": "typeLike", "format": ["PascalCase"] }
+    ]
   }
 }

--- a/common/constants/bonuses.js
+++ b/common/constants/bonuses.js
@@ -1,4 +1,4 @@
-export const stats_bonus = {
+export const STATS_BONUS = {
   // Skills
   skill_farming: {
     1: { health: 2, farming_fortune: 4 },

--- a/common/constants/enchantments.js
+++ b/common/constants/enchantments.js
@@ -1,4 +1,4 @@
-export const maxEnchants = new Set([
+export const MAX_ENCHANTS = new Set([
   "Angler VI",
   "Aqua Affinity I",
   "Bane of Arthropods VII",

--- a/common/constants/items.js
+++ b/common/constants/items.js
@@ -1,7 +1,7 @@
 /** @typedef {"common"|"uncommon"|"rare"|"epic"|"legendary"|"mythic"|"divine"|"supreme"|"special"|"very_special"} Rarity */
 
 /** @type {Rarity[]} */
-export const rarities = [
+export const RARITIES = [
   "common",
   "uncommon",
   "rare",
@@ -17,7 +17,7 @@ export const rarities = [
 /** @typedef {"0"|"1"|"2"|"3"|"4"|"5"|"6"|"7"|"8"|"9"|"a"|"b"|"c"|"d"|"e"|"f"} ColorCode */
 
 /** @type {{[key:Rarity]:ColorCode}} */
-export const rarityColors = {
+export const RARITY_COLORS = {
   common: "f",
   uncommon: "a",
   rare: "9",

--- a/common/constants/potions.js
+++ b/common/constants/potions.js
@@ -1,4 +1,4 @@
-export const potionColors = {
+export const POTION_COLORS = {
   0: "375cc4", // None
   1: "cb5ba9", // Regeneration
   2: "420a09", // Speed

--- a/common/constants/rewards.js
+++ b/common/constants/rewards.js
@@ -1,4 +1,4 @@
-export const pet_rewards = {
+export const PET_REWARDS = {
   0: { magic_find: 0 },
   10: { magic_find: 1 },
   25: { magic_find: 2 },

--- a/common/constants/stats.js
+++ b/common/constants/stats.js
@@ -9,7 +9,7 @@
  *   color: string
  * }
  */
-export const statsData = {
+export const STATS_DATA = {
   health: {
     name: "Health",
     nameLore: "Health",
@@ -183,15 +183,15 @@ export const statsData = {
   },
 };
 
-const _symbols = {
+const symbols = {
   powder: "᠅",
   soulflow: "⸎",
   dungeon_upgrade: "⚚",
   dye: "✿",
 };
-for (const stat in statsData) {
-  _symbols[stat] = statsData[stat].symbol;
+for (const stat in STATS_DATA) {
+  symbols[stat] = STATS_DATA[stat].symbol;
 }
-export const symbols = _symbols;
+export const SYMBOLS = symbols;
 
 // todo: grab these constants from src/constants/misc: base_stats, stat_template

--- a/common/formatting.js
+++ b/common/formatting.js
@@ -1,4 +1,4 @@
-import { maxEnchants } from "./constants.js";
+import { MAX_ENCHANTS } from "./constants.js";
 
 /**
  * @typedef {"0"|"1"|"2"|"3"|"4"|"5"|"6"|"7"|"8"|"9"|"a"|"b"|"c"|"d"|"e"|"f"} ColorCode
@@ -58,7 +58,7 @@ export function renderLore(text) {
     output += "<span";
 
     if (color !== null) {
-      if (color == "9" && maxEnchants.has(part)) {
+      if (color == "9" && MAX_ENCHANTS.has(part)) {
         output += ` style='color: var(--§6)'`;
       } else {
         output += ` style='color: var(--§${color});'`;
@@ -85,7 +85,7 @@ export function renderLore(text) {
  * @example formatNumber(123456798, true, 10) = "123.4M"
  * @example formatNumber(123456798, true, 100) = "123.45M"
  */
-export const formatNumber = (number, floor, rounding = 10) => {
+export function formatNumber(number, floor, rounding = 10) {
   if (number < 1000) {
     return String(Math.floor(number));
   } else if (number < 10000) {
@@ -118,4 +118,4 @@ export const formatNumber = (number, floor, rounding = 10) => {
       "B"
     );
   }
-};
+}

--- a/common/helper.js
+++ b/common/helper.js
@@ -1,4 +1,4 @@
-import * as constants from "./constants.js";
+import { STATS_DATA } from "./constants.js";
 
 /**
  * removes Minecraft formatting codes from a string
@@ -30,7 +30,7 @@ export function getStatsFromItem(piece) {
       continue;
     }
 
-    const statName = Object.keys(constants.statsData).find((key) => constants.statsData[key].nameLore === match[1]);
+    const statName = Object.keys(STATS_DATA).find((key) => STATS_DATA[key].nameLore === match[1]);
     const statValue = parseFloat(match[2].replace(/,/g, ""));
 
     if (statName) {

--- a/public/resources/ts/calculate-player-stats.ts
+++ b/public/resources/ts/calculate-player-stats.ts
@@ -168,13 +168,13 @@ export function getPlayerStats() {
 
 function getBonusStat(level: number, key: BonusType, max: number) {
   const bonus: ItemStats = {};
-  const ObjOfLevelBonuses: StatBonusType = constants.stats_bonus[key];
+  const objOfLevelBonuses: StatBonusType = constants.stats_bonus[key];
 
-  if (!ObjOfLevelBonuses) {
+  if (!objOfLevelBonuses) {
     return bonus;
   }
 
-  const steps = Object.keys(ObjOfLevelBonuses)
+  const steps = Object.keys(objOfLevelBonuses)
     .sort((a, b) => Number(a) - Number(b))
     .map((a) => Number(a));
 
@@ -189,7 +189,7 @@ function getBonusStat(level: number, key: BonusType, max: number) {
       .find((a) => a <= x);
 
     if (step) {
-      const stepBonuses: ItemStats = ObjOfLevelBonuses[step];
+      const stepBonuses: ItemStats = objOfLevelBonuses[step];
 
       for (const statNameString in stepBonuses) {
         const statName: StatName = statNameString as StatName;

--- a/public/resources/ts/calculate-player-stats.ts
+++ b/public/resources/ts/calculate-player-stats.ts
@@ -1,5 +1,5 @@
 import * as helper from "../../../common/helper.js";
-import * as constants from "../../../common/constants.js";
+import { STATS_BONUS } from "../../../common/constants.js";
 
 export function getPlayerStats() {
   const stats: PlayerStats = {
@@ -168,7 +168,7 @@ export function getPlayerStats() {
 
 function getBonusStat(level: number, key: BonusType, max: number) {
   const bonus: ItemStats = {};
-  const objOfLevelBonuses: StatBonusType = constants.stats_bonus[key];
+  const objOfLevelBonuses: StatBonusType = STATS_BONUS[key];
 
   if (!objOfLevelBonuses) {
     return bonus;

--- a/public/resources/ts/development-defer.ts
+++ b/public/resources/ts/development-defer.ts
@@ -1,4 +1,4 @@
-import { allItems } from "./stats-defer";
+import { ALL_ITEMS } from "./stats-defer";
 
 // Announce dev mode in console
 console.log(
@@ -26,7 +26,7 @@ document.addEventListener("click", (e) => {
 
   if (element.hasAttribute("data-item-id")) {
     const itemId = element.getAttribute("data-item-id") as string;
-    item = allItems.get(itemId) as Item;
+    item = ALL_ITEMS.get(itemId) as Item;
   } else if (element.hasAttribute("data-pet-index")) {
     item = calculated.pets[parseInt(element.getAttribute("data-pet-index") as string)];
   } else if (element.hasAttribute("data-missing-pet-index")) {

--- a/public/resources/ts/elements/bonus-stats.ts
+++ b/public/resources/ts/elements/bonus-stats.ts
@@ -2,7 +2,7 @@ import { html, LitElement, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import * as helper from "../../../../common/helper.js";
-import * as constants from "../../../../common/constants.js";
+import { STATS_DATA } from "../../../../common/constants.js";
 
 @customElement("bonus-stats")
 export class BonusStats extends LitElement {
@@ -26,9 +26,9 @@ export class BonusStats extends LitElement {
     for (const [stat, value] of Object.entries(data)) {
       result.push(/* html */ `
         <span class="bonus-stat stat-name color-${stat.replaceAll("_", "-")}">
-          ${helper.round(value, 1).toLocaleString()}${constants.statsData[stat as StatName].suffix}
-          <abbr title="${constants.statsData[stat as StatName].name}">
-            ${constants.statsData[stat as StatName].nameTiny}
+          ${helper.round(value, 1).toLocaleString()}${STATS_DATA[stat as StatName].suffix}
+          <abbr title="${STATS_DATA[stat as StatName].name}">
+            ${STATS_DATA[stat as StatName].nameTiny}
           </abbr>
         </span>
       `);

--- a/public/resources/ts/elements/inventory-view.ts
+++ b/public/resources/ts/elements/inventory-view.ts
@@ -1,6 +1,6 @@
 import { html, LitElement, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
-import { allItems, isSlotItem, isBackpack, isItem, showBackpack } from "../stats-defer";
+import { ALL_ITEMS, isSlotItem, isBackpack, isItem, showBackpack } from "../stats-defer";
 import("./rich-item");
 
 @customElement("inventory-view")
@@ -28,7 +28,7 @@ export class InventoryView extends LitElement {
       if (!this.backpackID) {
         throw new Error("backpack id is required when inventory type is backpack");
       }
-      const backpack = allItems.get(this.backpackID);
+      const backpack = ALL_ITEMS.get(this.backpackID);
       if (!backpack || !isItem(backpack) || !isBackpack(backpack)) {
         throw new Error("backpack id must be the id of a backpack");
       }

--- a/public/resources/ts/elements/player-stat.ts
+++ b/public/resources/ts/elements/player-stat.ts
@@ -48,7 +48,7 @@ export class PlayerStat extends LitElement {
     special: { [key: string]: number } | undefined
   ): string[] {
     const tooltip: string[] = [];
-    const tooltip_bonus: string[] = [];
+    const tooltipBonus: string[] = [];
 
     if (!name) {
       return tooltip;
@@ -67,7 +67,7 @@ export class PlayerStat extends LitElement {
           continue;
         }
 
-        tooltip_bonus.push(
+        tooltipBonus.push(
           `- ${this.getPrettyDataName(key)} ${val < 0 ? "" : "+"}${helper.round(val, 1).toLocaleString()}${suffix}`
         );
       }
@@ -78,7 +78,7 @@ export class PlayerStat extends LitElement {
         `<span class="stat-name">Bonus ${name}: </span>`,
         `<span class="stat-value">${helper.round(value - data.base, 1).toLocaleString()}${suffix}</span>`,
         "<br/>",
-        `<span class='tippy-explanation'>Bonus value obtain from: <br>${tooltip_bonus.join("<br>")}</span>`
+        `<span class='tippy-explanation'>Bonus value obtain from: <br>${tooltipBonus.join("<br>")}</span>`
       );
     }
 

--- a/public/resources/ts/elements/player-stat.ts
+++ b/public/resources/ts/elements/player-stat.ts
@@ -1,7 +1,7 @@
 import { html, LitElement, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import * as helper from "../../../../common/helper.js";
-import * as constants from "../../../../common/constants.js";
+import { STATS_DATA } from "../../../../common/constants.js";
 
 @customElement("player-stat")
 export class PlayerStat extends LitElement {
@@ -23,9 +23,9 @@ export class PlayerStat extends LitElement {
     }
 
     const value = Math.round(+this.value);
-    const icon = constants.statsData[this.stat].symbol;
-    const name = constants.statsData[this.stat].nameShort;
-    const suffix = constants.statsData[this.stat].suffix;
+    const icon = STATS_DATA[this.stat].symbol;
+    const name = STATS_DATA[this.stat].nameShort;
+    const suffix = STATS_DATA[this.stat].suffix;
 
     const tooltip = this.getTooltip(this.data, name, suffix, value, this.special);
 

--- a/public/resources/ts/elements/rich-item.ts
+++ b/public/resources/ts/elements/rich-item.ts
@@ -3,7 +3,7 @@ import { customElement, property } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import {
-  allItems,
+  ALL_ITEMS,
   clickLoreListener,
   isEnchanted,
   isItem,
@@ -22,7 +22,7 @@ export class InventoryView extends LitElement {
     if (this.itemId == undefined) {
       throw new Error("item id is required");
     }
-    const item = allItems.get(this.itemId);
+    const item = ALL_ITEMS.get(this.itemId);
     if (!item || !isItem(item)) {
       throw new Error("item id must be the id of an item");
     }

--- a/public/resources/ts/globals.d.ts
+++ b/public/resources/ts/globals.d.ts
@@ -163,7 +163,7 @@ interface Level {
 }
 
 declare namespace constants {
-  const max_favorites: number;
+  const MAX_FAVORITES: number;
 }
 
 declare const calculated: SkyCryptPlayer & {
@@ -522,7 +522,7 @@ declare const calculated: SkyCryptPlayer & {
   };
   slayer_xp: number;
   slayers: {
-    [key in slayerName]: {
+    [key in SlayerName]: {
       boss_kills_tier_0?: number;
       boss_kills_tier_1?: number;
       boss_kills_tier_2?: number;
@@ -625,7 +625,7 @@ interface Profile {
   profile_id: string;
 }
 
-type slayerName = "enderman" | "spider" | "wolf" | "zombie" | "blaze";
+type SlayerName = "enderman" | "spider" | "wolf" | "zombie" | "blaze";
 
 interface Navigator {
   userAgentData: NavigatorUAData;

--- a/public/resources/ts/stats-defer.ts
+++ b/public/resources/ts/stats-defer.ts
@@ -35,16 +35,16 @@ if ("share" in navigator) {
   });
 }
 
-function getCookie(c_name: string) {
+function getCookie(cookieName: string) {
   if (document.cookie.length > 0) {
-    let c_start = document.cookie.indexOf(c_name + "=");
-    if (c_start != -1) {
-      c_start = c_start + c_name.length + 1;
-      let c_end = document.cookie.indexOf(";", c_start);
-      if (c_end == -1) {
-        c_end = document.cookie.length;
+    let cookieStart = document.cookie.indexOf(cookieName + "=");
+    if (cookieStart != -1) {
+      cookieStart = cookieStart + cookieName.length + 1;
+      let cookieEnd = document.cookie.indexOf(";", cookieStart);
+      if (cookieEnd == -1) {
+        cookieEnd = document.cookie.length;
       }
-      return decodeURIComponent(document.cookie.substring(c_start, c_end));
+      return decodeURIComponent(document.cookie.substring(cookieStart, cookieEnd));
     }
   }
   return "";
@@ -125,7 +125,7 @@ tippy(".interactive-tooltip", {
   },
 });
 
-export const allItems = new Map(
+export const ALL_ITEMS = new Map(
   [
     items.armor,
     items.inventory,
@@ -251,7 +251,7 @@ function fillLore(element: HTMLElement) {
 
   if (element.hasAttribute("data-item-id")) {
     const itemId = element.getAttribute("data-item-id") as string;
-    item = allItems.get(itemId) as Item;
+    item = ALL_ITEMS.get(itemId) as Item;
   } else if (element.hasAttribute("data-pet-index")) {
     item = calculated.pets[parseInt(element.getAttribute("data-pet-index") as string)];
   } else if (element.hasAttribute("data-missing-pet-index")) {
@@ -341,12 +341,12 @@ function fillLore(element: HTMLElement) {
   }
 }
 
-function showLore(element: HTMLElement, _resize?: boolean) {
+function showLore(element: HTMLElement, shouldResize = true) {
   statsContent.classList.add("sticky-stats");
   element.classList.add("sticky-stats");
   dimmer.classList.add("show-dimmer");
 
-  if (_resize != false) {
+  if (shouldResize) {
     resize();
   }
 }
@@ -583,8 +583,8 @@ favoriteElement.addEventListener("click", () => {
       cookieArray.splice(cookieArray.indexOf(uuid), 1);
 
       favoriteNotification.setContent("Removed favorite!");
-    } else if (cookieArray.length >= constants.max_favorites) {
-      favoriteNotification.setContent(`You can only have ${constants.max_favorites} favorites!`);
+    } else if (cookieArray.length >= constants.MAX_FAVORITES) {
+      favoriteNotification.setContent(`You can only have ${constants.MAX_FAVORITES} favorites!`);
     } else {
       cookieArray.push(uuid);
 

--- a/public/resources/ts/themes.ts
+++ b/public/resources/ts/themes.ts
@@ -257,9 +257,9 @@ window.addEventListener(
 // Load the theme from localStorage if it exists
 {
   // TODO remove this once users are migrated to currentThemeUrl
-  const OldTheme = localStorage.getItem("currentTheme");
-  if (OldTheme) {
-    localStorage.setItem("currentThemeUrl", `/resources/themes/${OldTheme}.json`);
+  const oldTheme = localStorage.getItem("currentTheme");
+  if (oldTheme) {
+    localStorage.setItem("currentThemeUrl", `/resources/themes/${oldTheme}.json`);
     localStorage.removeItem("currentTheme");
   }
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,7 +14,7 @@ const production = !process.env.ROLLUP_WATCH;
 /**
  * @type {import('rollup').RollupOptions}
  */
-const config = {
+const CONFIG = {
   input: [
     "public/resources/ts/browser-compat-check.ts",
     "public/resources/ts/common-defer.ts",
@@ -54,4 +54,4 @@ const config = {
   ],
 };
 
-export default config;
+export default CONFIG;

--- a/src/app.js
+++ b/src/app.js
@@ -298,7 +298,7 @@ app.all("/stats/:player/:profile?", async (req, res, next) => {
       },
       (err, html) => {
         if (err) console.error(err);
-        else console.debug(`${debugId}: page succesfully rendered. (${Date.now() - renderStart}ms)`);
+        else console.debug(`${debugId}: page successfully rendered. (${Date.now() - renderStart}ms)`);
 
         res.set("X-Debug-ID", `${debugId}`);
         res.set("X-Process-Time", `${Date.now() - timeStarted}`);
@@ -308,7 +308,7 @@ app.all("/stats/:player/:profile?", async (req, res, next) => {
   } catch (e) {
     const favorites = parseFavorites(req.cookies.favorite);
 
-    console.debug(`${debugId}: an error has occured.`);
+    console.debug(`${debugId}: an error has occurred.`);
     console.error(e);
 
     res.render(
@@ -318,7 +318,7 @@ app.all("/stats/:player/:profile?", async (req, res, next) => {
         error: e,
         player: playerUsername,
         extra: await getExtra("index", favorites, cacheOnly),
-        promotion: weightedRandom(constants.promotions),
+        promotion: weightedRandom(constants.PROMOTIONS),
         fileHashes,
         fileNameMap,
         helper,
@@ -661,7 +661,7 @@ app.all("/", async (req, res, next) => {
       error: null,
       player: null,
       extra: await getExtra("index", favorites, cacheOnly),
-      promotion: weightedRandom(constants.promotions),
+      promotion: weightedRandom(constants.PROMOTIONS),
       fileHashes,
       fileNameMap,
       helper,

--- a/src/app.js
+++ b/src/app.js
@@ -177,7 +177,7 @@ function parseFavorites(cookie) {
 }
 
 async function getFavoritesFormUUIDs(uuids) {
-  let favorites = [];
+  const favorites = [];
   for (let uuid of uuids) {
     if (uuid == null) continue;
     uuid = sanitize(uuid);
@@ -188,27 +188,27 @@ async function getFavoritesFormUUIDs(uuids) {
       favorites.push(cache[0]);
       continue;
     } else {
-      let output_cache = { uuid };
+      let outputCache = { uuid };
 
       const user = await db.collection("usernames").find({ uuid }).toArray();
 
       if (user[0]) {
-        output_cache = user[0];
+        outputCache = user[0];
 
-        let profiles = await db.collection("profileStore").find({ uuid }).toArray();
+        const profiles = await db.collection("profileStore").find({ uuid }).toArray();
 
         if (profiles[0]) {
           const profile = profiles[0];
-          output_cache.last_updated = profile.last_save;
+          outputCache.last_updated = profile.last_save;
         } else {
-          output_cache.error = "Profile doesn't exist.";
+          outputCache.error = "Profile doesn't exist.";
         }
       } else {
-        output_cache.error = "User doesn't exist.";
+        outputCache.error = "User doesn't exist.";
       }
 
-      await db.collection("favoriteCache").insertOne(output_cache);
-      favorites.push(output_cache);
+      await db.collection("favoriteCache").insertOne(outputCache);
+      favorites.push(outputCache);
     }
   }
   return favorites;
@@ -234,7 +234,7 @@ async function getExtra(page = null, favoriteUUIDs = [], cacheOnly) {
 }
 
 function weightedRandom(array) {
-  let weights = [];
+  const weights = [];
 
   for (let i = 0; i < array.length; i++) weights[i] = array[i].weight + (weights[i - 1] || 0);
 
@@ -249,11 +249,11 @@ app.all("/stats/:player/:profile?", async (req, res, next) => {
 
   console.debug(`${debugId}: stats page was called.`);
 
-  let paramPlayer = req.params.player
+  const paramPlayer = req.params.player
     .toLowerCase()
     .replaceAll(/[ +]/g, "_")
     .replaceAll(/[^a-z\d\-_:]/g, "");
-  let paramProfile = req.params.profile ? req.params.profile.toLowerCase() : null;
+  const paramProfile = req.params.profile ? req.params.profile.toLowerCase() : null;
 
   const cacheOnly = req.query.cache === "true" || forceCacheOnly;
 

--- a/src/constants/accessories.js
+++ b/src/constants/accessories.js
@@ -1,4 +1,4 @@
-export const accessory_upgrades = {
+export const ACCESSORY_UPGRADES = {
   WOLF_TALISMAN: ["WOLF_RING"],
   RING_POTION_AFFINITY: ["ARTIFACT_POTION_AFFINITY"],
   POTION_AFFINITY_TALISMAN: ["RING_POTION_AFFINITY", "ARTIFACT_POTION_AFFINITY"],
@@ -114,7 +114,7 @@ export const accessory_upgrades = {
   BURSTSTOPPER_TALISMAN: ["BURSTSTOPPER_ARTIFACT"],
 };
 
-export const accessory_duplicates = {
+export const ACCESSORY_DUPLICATES = {
   WEDDING_RING_0: ["WEDDING_RING_1"],
   WEDDING_RING_2: ["WEDDING_RING_3"],
   WEDDING_RING_4: ["WEDDING_RING_5", "WEDDING_RING_6"],
@@ -144,7 +144,7 @@ export const accessory_duplicates = {
   ],
 };
 
-export const accessories = {
+export const ACCESSORIES = {
   WEDDING_RING_0: {
     name: "Shiny Yellow Rock",
     rarity: "common",
@@ -740,17 +740,17 @@ export const accessories = {
 };
 
 // Getting Unique Accessories Count
-const unique_accessories = { ...accessories };
+const uniqueAccessories = { ...ACCESSORIES };
 
-for (const upgrade in accessory_upgrades) {
-  if (upgrade in unique_accessories) {
-    delete unique_accessories[upgrade];
+for (const upgrade in ACCESSORY_UPGRADES) {
+  if (upgrade in uniqueAccessories) {
+    delete uniqueAccessories[upgrade];
   }
 }
 
-export const unique_accessories_count = Object.keys(unique_accessories).length;
+export const UNIQUE_ACCESSORIES_COUNT = Object.keys(uniqueAccessories).length;
 
-export const magical_power = {
+export const MAGICAL_POWER = {
   common: 3,
   uncommon: 5,
   rare: 8,

--- a/src/constants/armor.js
+++ b/src/constants/armor.js
@@ -1,4 +1,4 @@
-export const special_sets = [
+export const SPECIAL_SETS = [
   {
     pieces: ["SKELETON_HELMET", "GUARDIAN_CHESTPLATE", "CREEPER_LEGGINGS", "SPIDER_BOOTS"],
     name: "Monster Hunter Armor",

--- a/src/constants/collections.js
+++ b/src/constants/collections.js
@@ -1,6 +1,6 @@
-export const collection_types = ["farming", "mining", "combat", "foraging", "fishing"];
+export const COLLECTION_TYPES = ["farming", "mining", "combat", "foraging", "fishing"];
 
-export const collection_data = [
+export const COLLECTION_DATA = [
   {
     type: "farming",
     skyblockId: "WHEAT",

--- a/src/constants/dungeons.js
+++ b/src/constants/dungeons.js
@@ -1,4 +1,4 @@
-export const dungeons = {
+export const DUNGEONS = {
   bosses: {
     bonzo: {
       name: "Bonzo",

--- a/src/constants/forge.js
+++ b/src/constants/forge.js
@@ -1,5 +1,5 @@
 // forge times, value in minutes
-export const forge_times = {
+export const FORGE_TIMES = {
   REFINED_DIAMOND: 8 * 60,
   REFINED_MITHRIL: 6 * 60,
   REFINED_TITANIUM: 12 * 60,
@@ -69,7 +69,7 @@ export const forge_times = {
   DIAMONITE: 6 * 60,
 };
 
-export const quick_forge_multiplier = {
+export const QUICK_FORGE_MULTIPLIER = {
   1: 0.895,
   2: 0.89,
   3: 0.885,

--- a/src/constants/gemstones.js
+++ b/src/constants/gemstones.js
@@ -3,7 +3,7 @@
  * - int: exact value
  * - null: unknown value
  */
-export const gemstones = {
+export const GEMSTONES = {
   JADE: {
     name: "Jade",
     color: "a",

--- a/src/constants/hotm.js
+++ b/src/constants/hotm.js
@@ -1,7 +1,7 @@
 import { symbols } from "../../common/constants.js";
 import { round, floor, ceil, convertHMS, titleCase } from "../helper.js";
 
-const upgrade_types = {
+const UPGRADE_TYPES = {
   mithril_powder: {
     name: "Mithril Powder",
     color: "2",
@@ -248,7 +248,7 @@ class HotM {
   }
 
   get position7x9() {
-    return 9 * (hotm.tiers - this.tier) + 1;
+    return 9 * (HOTM.tiers - this.tier) + 1;
   }
 }
 
@@ -274,7 +274,7 @@ class Node {
   }
 
   get position7x9() {
-    return this.position + 1 + (ceil(this.position / hotm.tiers) - 1) * 2;
+    return this.position + 1 + (ceil(this.position / HOTM.tiers) - 1) * 2;
   }
 
   get itemData() {
@@ -334,8 +334,8 @@ class Node {
       output.push(
         "",
         "§7Cost",
-        `§${upgrade_types[this.upgrade_type].color}${this.upgradeCost.toLocaleString()} ${
-          upgrade_types[this.upgrade_type].name
+        `§${UPGRADE_TYPES[this.upgrade_type].color}${this.upgradeCost.toLocaleString()} ${
+          UPGRADE_TYPES[this.upgrade_type].name
         }`
       );
     }
@@ -350,7 +350,7 @@ class Node {
       output.push("", "§7Cost");
       for (const [upgradeId, upgradeQty] of Object.entries(this.unlockCost)) {
         output.push(
-          `§${upgrade_types[upgradeId].color}${upgradeQty > 0 ? `${upgradeQty} ` : ""}${upgrade_types[upgradeId].name}`
+          `§${UPGRADE_TYPES[upgradeId].color}${upgradeQty > 0 ? `${upgradeQty} ` : ""}${UPGRADE_TYPES[upgradeId].name}`
         );
       }
     }
@@ -1193,7 +1193,7 @@ class MiningSpeed extends Node {
 
 class HotmItem {
   get position7x9() {
-    return 9 * (hotm.tiers - this.position) + 9;
+    return 9 * (HOTM.tiers - this.position) + 9;
   }
 }
 
@@ -1413,7 +1413,7 @@ for (const nodeClass of Object.values(nodeClasses)) {
   }
 }
 
-export const hotm = {
+export const HOTM = {
   tiers: Object.keys(rewards.hotm).length,
   rewards: rewards,
   names: nodeNames,
@@ -1423,7 +1423,7 @@ export const hotm = {
   powder_for_max_nodes: powderForMaxNodes,
 };
 
-export const precursor_parts = {
+export const PRECURSOR_PARTS = {
   ELECTRON_TRANSMITTER: "Electron Transmitter",
   FTX_3070: "FTX 3070",
   ROBOTRON_REFLECTOR: "Robotron Reflector",

--- a/src/constants/hotm.js
+++ b/src/constants/hotm.js
@@ -1,4 +1,4 @@
-import { symbols } from "../../common/constants.js";
+import { SYMBOLS } from "../../common/constants.js";
 import { round, floor, ceil, convertHMS, titleCase } from "../helper.js";
 
 const UPGRADE_TYPES = {
@@ -468,7 +468,7 @@ class MiningSpeed2 extends Node {
 
   perk(level) {
     const val = level * 40;
-    return [`§7Grants §a+${val} §6${symbols.mining_speed} Mining Speed§7.`];
+    return [`§7Grants §a+${val} §6${SYMBOLS.mining_speed} Mining Speed§7.`];
   }
 }
 
@@ -512,7 +512,7 @@ class MiningFortune2 extends Node {
 
   perk(level) {
     const val = level * 5;
-    return [`§7Grants §a+${val} §6${symbols.mining_fortune} Mining Fortune§7.`];
+    return [`§7Grants §a+${val} §6${SYMBOLS.mining_fortune} Mining Fortune§7.`];
   }
 }
 
@@ -567,7 +567,7 @@ class LonesomeMiner extends Node {
   perk(level) {
     const val = round(5 + (level - 1) * 0.5);
     return [
-      `§7Increases §c${symbols.strength} Strength, §9${symbols.crit_chance} Crit Chance, §9${symbols.crit_damage} Crit Damage, §a${symbols.defense} Defense, and §c${symbols.health} Health §7statistics gain by §a${val}% §7while in the Crystal Hollows.`,
+      `§7Increases §c${SYMBOLS.strength} Strength, §9${SYMBOLS.crit_chance} Crit Chance, §9${SYMBOLS.crit_damage} Crit Damage, §a${SYMBOLS.defense} Defense, and §c${SYMBOLS.health} Health §7statistics gain by §a${val}% §7while in the Crystal Hollows.`,
     ];
   }
 }
@@ -590,7 +590,7 @@ class Professional extends Node {
 
   perk(level) {
     const val = 50 + level * 5;
-    return [`§7Gain §a+${val}§7 §6${symbols.mining_speed} Mining Speed§7 when mining Gemstones.`];
+    return [`§7Gain §a+${val}§7 §6${SYMBOLS.mining_speed} Mining Speed§7 when mining Gemstones.`];
   }
 }
 
@@ -658,7 +658,7 @@ class Fortunate extends Node {
 
   perk(level) {
     const val = 20 + level * 4;
-    return [`§7Grants §a+${val}§7 §6${symbols.mining_fortune} Mining Fortune§7 when mining Gemstone.`];
+    return [`§7Grants §a+${val}§7 §6${SYMBOLS.mining_fortune} Mining Fortune§7 when mining Gemstone.`];
   }
 }
 
@@ -706,7 +706,7 @@ class ManiacMiner extends Node {
     const cooldown = [60, 59, 59][this.pickaxeAbilityLevel - 1];
     return [
       "§6Pickaxe Ability: Maniac Miner",
-      `§7Spends all your Mana and grants §a+${speed} §6${symbols.mining_speed} Mining Speed §7for every 10 Mana spent, for §a${duration}s§7.`,
+      `§7Spends all your Mana and grants §a+${speed} §6${SYMBOLS.mining_speed} Mining Speed §7for every 10 Mana spent, for §a${duration}s§7.`,
       `§8Cooldown: §a${cooldown}s`,
       "",
       "§8Pickaxe Abilities apply to all of your pickaxes. You can select a Pickaxe Ability from your Heart of the Mountain.",
@@ -816,8 +816,8 @@ class SkyMall extends Node {
       "§7Every SkyBlock day, you receive a random buff in the §2Dwarven Mines§7.",
       "",
       "§7Possible Buffs",
-      `§8 ■ §7Gain §a+100 §6${symbols.mining_speed} Mining Speed.`,
-      `§8 ■ §7Gain §a+50 §6${symbols.mining_fortune} Mining Fortune.`,
+      `§8 ■ §7Gain §a+100 §6${SYMBOLS.mining_speed} Mining Speed.`,
+      `§8 ■ §7Gain §a+50 §6${SYMBOLS.mining_fortune} Mining Fortune.`,
       "§8 ■ §7Gain §a+15% §7chance to gain extra Powder while mining.",
       "§8 ■ §7Reduce Pickaxe Ability cooldown by §a20%",
       "§8 ■ §7§a10x §7chance to find Goblins while mining.",
@@ -843,7 +843,7 @@ class MiningMadness extends Node {
 
   perk(level) {
     return [
-      `§7Grants §a+50 §6${symbols.mining_speed} Mining Speed §7and §6${symbols.mining_fortune} Mining Fortune§7.`,
+      `§7Grants §a+50 §6${SYMBOLS.mining_speed} Mining Speed §7and §6${SYMBOLS.mining_fortune} Mining Fortune§7.`,
     ];
   }
 }
@@ -932,7 +932,7 @@ class FrontLoaded extends Node {
 
   perk(level) {
     return [
-      `§7Grants §a+100 §6${symbols.mining_speed} Mining Speed §7and §6${symbols.mining_fortune} Mining Fortune §7for the first §e2,500 §7ores you mine in a day.`,
+      `§7Grants §a+100 §6${SYMBOLS.mining_speed} Mining Speed §7and §6${SYMBOLS.mining_fortune} Mining Fortune §7for the first §e2,500 §7ores you mine in a day.`,
     ];
   }
 }
@@ -954,7 +954,7 @@ class PrecisionMining extends Node {
 
   perk(level) {
     return [
-      `§7When mining ore, a particle target appears on the block that increases your §6${symbols.mining_speed} Mining Speed §7by §a30% §7when aiming at it.`,
+      `§7When mining ore, a particle target appears on the block that increases your §6${SYMBOLS.mining_speed} Mining Speed §7by §a30% §7when aiming at it.`,
     ];
   }
 }
@@ -1022,7 +1022,7 @@ class Crystallized extends Node {
   perk(level) {
     const val = 20 + (level - 1) * 6;
     return [
-      `§7Grants §a+${val} §6${symbols.mining_speed} Mining Speed §7and a §a${val}% §7chance to deal §a+1 §7extra damage near §5Fallen Stars§7.`,
+      `§7Grants §a+${val} §6${SYMBOLS.mining_speed} Mining Speed §7and a §a${val}% §7chance to deal §a+1 §7extra damage near §5Fallen Stars§7.`,
     ];
   }
 }
@@ -1049,7 +1049,7 @@ class MiningSpeedBoost extends Node {
     const cooldown = [120, 120, 120][this.pickaxeAbilityLevel - 1];
     return [
       "§6Pickaxe Ability: Mining Speed Boost",
-      `§7Grants §a+${effect}% §6${symbols.mining_speed} Mining Speed §7for §a${duration}s§7.`,
+      `§7Grants §a+${effect}% §6${SYMBOLS.mining_speed} Mining Speed §7for §a${duration}s§7.`,
       `§8Cooldown: §a${cooldown}s`,
       "",
       "§8Pickaxe Abilities apply to all of your pickaxes. You can select a Pickaxe Ability from your Heart of the Mountain.",
@@ -1099,7 +1099,7 @@ class MiningFortune extends Node {
 
   perk(level) {
     const val = level * 5;
-    return [`§7Grants §a+${val} §6${symbols.mining_fortune} Mining Fortune§7.`];
+    return [`§7Grants §a+${val} §6${SYMBOLS.mining_fortune} Mining Fortune§7.`];
   }
 }
 
@@ -1177,7 +1177,7 @@ class MiningSpeed extends Node {
 
   perk(level) {
     const val = level * 20;
-    return [`§7Grants §a+${val} §6${symbols.mining_speed} Mining Speed§7.`];
+    return [`§7Grants §a+${val} §6${SYMBOLS.mining_speed} Mining Speed§7.`];
   }
 }
 
@@ -1221,7 +1221,7 @@ class HotmStats extends HotmItem {
       "",
       "§7§8Use §5Token of the Mountain §8to unlock perks and abilities above!",
       "",
-      `§9${symbols.powder} Powder`,
+      `§9${SYMBOLS.powder} Powder`,
       "§9Powders §8are dropped from mining ores in the §2Dwarven Mines §8and are used to upgrade the perks you've unlocked!",
       "",
       `§7Mithril Powder: §2${this.resources.mithril_powder.toLocaleString()}`,

--- a/src/constants/items.js
+++ b/src/constants/items.js
@@ -1,4 +1,4 @@
-export const typeToCategories = {
+export const TYPE_TO_CATEGORIES = {
   helmet: ["armor", "helmet"],
   chestplate: ["armor", "chestplate"],
   leggings: ["armor", "leggings"],

--- a/src/constants/leveling.js
+++ b/src/constants/leveling.js
@@ -1,4 +1,4 @@
-export const leveling_xp = {
+export const LEVELING_XP = {
   1: 50,
   2: 125,
   3: 200,
@@ -61,7 +61,7 @@ export const leveling_xp = {
   60: 7000000,
 };
 
-export const default_skill_caps = {
+export const DEFAULT_SKILL_CAPS = {
   farming: 50,
   mining: 60,
   combat: 60,
@@ -75,11 +75,11 @@ export const default_skill_caps = {
   social: 25,
 };
 
-export const maxed_skill_caps = {
+export const MAXED_SKILL_CAPS = {
   farming: 60,
 };
 
-export const runecrafting_xp = {
+export const RUNECRAFTING_XP = {
   1: 50,
   2: 100,
   3: 125,
@@ -107,7 +107,7 @@ export const runecrafting_xp = {
   25: 19050,
 };
 
-export const social_xp = {
+export const SOCIAL_XP = {
   1: 50,
   2: 100,
   3: 150,
@@ -135,7 +135,7 @@ export const social_xp = {
   25: 50000,
 };
 
-export const dungeoneering_xp = {
+export const DUNGEONEERING_XP = {
   1: 50,
   2: 75,
   3: 110,
@@ -188,12 +188,12 @@ export const dungeoneering_xp = {
   50: 116250000,
 };
 
-export const guild_xp = [
+export const GUILD_XP = [
   100000, 150000, 250000, 500000, 750000, 1000000, 1250000, 1500000, 2000000, 2500000, 2500000, 2500000, 2500000,
   2500000, 3000000,
 ];
 
-export const slayer_xp = {
+export const SLAYER_XP = {
   zombie: {
     1: 5,
     2: 15,
@@ -251,7 +251,7 @@ export const slayer_xp = {
   },
 };
 
-export const hotm_xp = {
+export const HOTM_XP = {
   1: 0,
   2: 3000,
   3: 9000,

--- a/src/constants/minions.js
+++ b/src/constants/minions.js
@@ -1,6 +1,6 @@
-export const minion_types = ["farming", "mining", "combat", "foraging", "fishing"];
+export const MINION_TYPES = ["farming", "mining", "combat", "foraging", "fishing"];
 
-export const minion_slots = {
+export const MINION_SLOTS = {
   0: 5,
   5: 6,
   15: 7,
@@ -27,9 +27,9 @@ export const minion_slots = {
 };
 
 // From unique tiers (excludes community shop upgrades)
-export const minions_max_slots = 26;
+export const MINIONS_MAX_SLOTS = 26;
 
-export const minions = {
+export const MINIONS = {
   COBBLESTONE: {
     type: "mining",
     head: "/head/2f93289a82bd2a06cbbe61b733cfdc1f1bd93c4340f7a90abd9bdda774109071",
@@ -305,10 +305,10 @@ export const minions = {
   },
 };
 
-let total_unique_minions = 0;
+let totalUniqueMinions = 0;
 
-for (const minion in minions) {
-  total_unique_minions += minions[minion].tiers ?? 11;
+for (const minion in MINIONS) {
+  totalUniqueMinions += MINIONS[minion].tiers ?? 11;
 }
 
-export const minions_max_uniques = total_unique_minions;
+export const MINIONS_MAX_UNIQUES = totalUniqueMinions;

--- a/src/constants/misc.js
+++ b/src/constants/misc.js
@@ -1,17 +1,17 @@
 // prevent specific players from appearing in leaderboards
-export const blocked_players = [
+export const BLOCKED_PLAYERS = [
   "20934ef9488c465180a78f861586b4cf", // Minikloon (Admin)
   "f025c1c7f55a4ea0b8d93f47d17dfe0f", // Plancke (Admin)
 ];
 
 // Number of kills required for each level of expertise
-export const expertise_kills_ladder = [50, 100, 250, 500, 1000, 2500, 5500, 10000, 15000];
+export const EXPERTISE_KILLS_LADDER = [50, 100, 250, 500, 1000, 2500, 5500, 10000, 15000];
 
 // Walking distance required for each rarity level of the prehistoric egg
-export const prehistoric_egg_blocks_walked_ladder = [4000, 10000, 20000, 40000, 100000];
+export const PREHISTORIC_EGG_BLOCKS_WALKED_LADDER = [4000, 10000, 20000, 40000, 100000];
 
 // api names and their max value from the profile upgrades
-export const profile_upgrades = {
+export const PROFILE_UPGRADES = {
   island_size: 10,
   minion_slots: 5,
   guests_count: 5,
@@ -20,7 +20,7 @@ export const profile_upgrades = {
 };
 
 // Player stats on a completely new profile
-export const base_stats = {
+export const BASE_STATS = {
   health: 100,
   defense: 0,
   effective_health: 100,
@@ -44,7 +44,7 @@ export const base_stats = {
   damage_increase: 0,
 };
 
-export const stat_template = {
+export const STAT_TEMPLATE = {
   health: 0,
   defense: 0,
   effective_health: 0,
@@ -68,7 +68,7 @@ export const stat_template = {
   damage_increase: 0,
 };
 
-export const slayer_cost = {
+export const SLAYER_COST = {
   1: 2000,
   2: 7500,
   3: 20000,
@@ -76,12 +76,12 @@ export const slayer_cost = {
   5: 100000,
 };
 
-export const mob_mounts = {
+export const MOB_MOUNTS = {
   sea_emperor: ["guardian_emperor", "skeleton_emperor"],
   monster_of_the_deep: ["zombie_deep", "chicken_deep"],
 };
 
-export const mob_names = {
+export const MOB_NAMES = {
   pond_squid: "Squid",
   unburried_zombie: "Crypt Ghoul",
   zealot_enderman: "Zealot",
@@ -100,7 +100,7 @@ export const mob_names = {
   maxor: "Necron",
 };
 
-export const raceObjectiveToStatName = {
+export const RACE_OBJECTIVE_TO_STAT_NAME = {
   complete_the_end_race: "end_race_best_time",
   complete_the_woods_race: "foraging_race_best_time",
   complete_the_chicken_race: "chicken_race_best_time_2",
@@ -136,7 +136,7 @@ export const raceObjectiveToStatName = {
   complete_the_crystal_core_nothing_no_return_race: "dungeon_hub_crystal_core_nothing_no_return_best_time",
 };
 
-export const area_names = {
+export const AREA_NAMES = {
   dynamic: "Private Island",
   hub: "Hub",
   mining_1: "Gold Mine",
@@ -151,7 +151,7 @@ export const area_names = {
   winter: "Jerry's Workshop",
 };
 
-export const color_names = {
+export const COLOR_NAMES = {
   BLACK: "0",
   DARK_BLUE: "1",
   DARK_GREEN: "2",
@@ -170,7 +170,7 @@ export const color_names = {
   WHITE: "f",
 };
 
-export const ranks = {
+export const RANKS = {
   OWNER: {
     color: "c",
     tag: "OWNER",
@@ -242,7 +242,7 @@ export const ranks = {
   NONE: null,
 };
 
-export const farming_crops = {
+export const FARMING_CROPS = {
   "INK_SACK:3": {
     name: "Cocoa Beans",
     icon: "351_3",
@@ -285,7 +285,7 @@ export const farming_crops = {
   },
 };
 
-export const experiments = {
+export const EXPERIMENTS = {
   games: {
     simon: {
       name: "Chronomatron",
@@ -325,9 +325,9 @@ export const experiments = {
   ],
 };
 
-export const max_favorites = 10;
+export const MAX_FAVORITES = 10;
 
-export const increase_most_stats_exclude = [
+export const INCREASE_MOST_STATS_EXCLUDE = [
   "mining_speed",
   "mining_fortune",
   "farming_fortune",
@@ -335,14 +335,14 @@ export const increase_most_stats_exclude = [
   "pristine",
 ];
 
-export const fairy_souls = {
+export const FAIRY_SOULS = {
   max: {
     normal: 238,
     stranded: 3,
   },
 };
 
-export const essence = {
+export const ESSENCE = {
   // Catacombs essences
   ice: {
     name: "Ice",
@@ -379,6 +379,6 @@ export const essence = {
   },
 };
 
-export const stat_mappings = {
+export const STAT_MAPPINGS = {
   walk_speed: "speed",
 };

--- a/src/constants/pet-stats.js
+++ b/src/constants/pet-stats.js
@@ -1,12 +1,12 @@
-import { symbols, rarities } from "../../common/constants.js";
+import { SYMBOLS, RARITIES } from "../../common/constants.js";
 import { round, floor } from "../helper.js";
 
-const COMMON = rarities.indexOf("common");
-const UNCOMMON = rarities.indexOf("uncommon");
-const RARE = rarities.indexOf("rare");
-const EPIC = rarities.indexOf("epic");
-const LEGENDARY = rarities.indexOf("legendary");
-const MYTHIC = rarities.indexOf("mythic");
+const COMMON = RARITIES.indexOf("common");
+const UNCOMMON = RARITIES.indexOf("uncommon");
+const RARE = RARITIES.indexOf("rare");
+const EPIC = RARITIES.indexOf("epic");
+const LEGENDARY = RARITIES.indexOf("legendary");
+const MYTHIC = RARITIES.indexOf("mythic");
 
 function formatStat(stat) {
   const statFloored = Math.floor(stat);
@@ -148,10 +148,10 @@ class Bee extends Pet {
     return {
       name: "§6Hive",
       desc: [
-        `§7Gain §b+${round(this.level * intMult + 1, 1)} ${symbols.intelligence} Intelligence §7and §c+${round(
+        `§7Gain §b+${round(this.level * intMult + 1, 1)} ${SYMBOLS.intelligence} Intelligence §7and §c+${round(
           this.level * strMult + 1,
           1
-        )} ${symbols.strength} Strength §7for each nearby bee.`,
+        )} ${SYMBOLS.strength} Strength §7for each nearby bee.`,
         `§8Max 15 bees`,
       ],
     };
@@ -169,7 +169,7 @@ class Bee extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.2 });
     return {
       name: "§6Weaponized Honey",
-      desc: [`§7Gain §a${round(5 + this.level * mult, 1)}% §7of received damage as §6${symbols.health} Absorption`],
+      desc: [`§7Gain §a${round(5 + this.level * mult, 1)}% §7of received damage as §6${SYMBOLS.health} Absorption`],
     };
   }
 }
@@ -241,7 +241,7 @@ class Elephant extends Pet {
     return {
       name: "§6Stomp",
       desc: [
-        `§7Gain §a${round(this.level * mult, 1)} ${symbols.defense} Defense §7for every §f100 ${symbols.speed} Speed`,
+        `§7Gain §a${round(this.level * mult, 1)} ${SYMBOLS.defense} Defense §7for every §f100 ${SYMBOLS.speed} Speed`,
       ],
     };
   }
@@ -251,7 +251,7 @@ class Elephant extends Pet {
     return {
       name: "§6Walking Fortress",
       desc: [
-        `§7Gain §c${round(this.level * mult, 1)} ${symbols.health} Health §7for every §a10 ${symbols.defense} Defense`,
+        `§7Gain §c${round(this.level * mult, 1)} ${SYMBOLS.health} Health §7for every §a10 ${SYMBOLS.defense} Defense`,
       ],
     };
   }
@@ -262,7 +262,7 @@ class Elephant extends Pet {
       name: "§6Trunk Efficiency",
       desc: [
         `§7Grants §a+${round(this.level * mult, 1)} §6${
-          symbols.farming_fortune
+          SYMBOLS.farming_fortune
         } Farming Fortune§7, which increases your chance for multiple drops`,
       ],
     };
@@ -419,8 +419,8 @@ class Armadillo extends Pet {
     return {
       name: "§6Mobile Tank",
       desc: [
-        `§7For every §a${round(100 - this.level * mult, 1)} §7Defense, gain §f+1 ${symbols.speed} Speed §7and §6+1 ${
-          symbols.mining_speed
+        `§7For every §a${round(100 - this.level * mult, 1)} §7Defense, gain §f+1 ${SYMBOLS.speed} Speed §7and §6+1 ${
+          SYMBOLS.mining_speed
         } Mining Speed`,
       ],
     };
@@ -467,10 +467,10 @@ class Bat extends Pet {
     return {
       name: "§6Nightmare",
       desc: [
-        `§7During night, gain §a${round(this.level * multIntel, 1)} §9${symbols.intelligence} Intelligence, §a${round(
+        `§7During night, gain §a${round(this.level * multIntel, 1)} §9${SYMBOLS.intelligence} Intelligence, §a${round(
           this.level * multSpeed,
           1
-        )} §f${symbols.speed} Speed§7, and night vision`,
+        )} §f${SYMBOLS.speed} Speed§7, and night vision`,
       ],
     };
   }
@@ -562,7 +562,7 @@ class MithrilGolem extends Pet {
     const mult = getValue(this.rarity, { common: 0.5, uncommon: 0.75, epic: 1 });
     return {
       name: "§6Mithril Affinity",
-      desc: [`§7Gain +§a${round(this.level * mult, 1)} §6${symbols.mining_speed} Mining Speed §7when mining §eMithril`],
+      desc: [`§7Gain +§a${round(this.level * mult, 1)} §6${SYMBOLS.mining_speed} Mining Speed §7when mining §eMithril`],
     };
   }
 
@@ -656,7 +656,7 @@ class Scatha extends Pet {
     const mult = getValue(this.rarity, { rare: 1, epic: 1.25 });
     return {
       name: "§6Grounded",
-      desc: [`§7Gain §6+${round(this.level * mult - 0.01, 1)}${symbols.mining_fortune} Mining Fortune§7`],
+      desc: [`§7Gain §6+${round(this.level * mult - 0.01, 1)}${SYMBOLS.mining_fortune} Mining Fortune§7`],
     };
   }
 
@@ -700,7 +700,7 @@ class Silverfish extends Pet {
     const mult = getValue(this.rarity, { common: 0.05, uncommon: 0.1, epic: 0.15 });
     return {
       name: "§6True Defense Boost",
-      desc: [`§7Boosts your §f${symbols.true_defense} True Defense §7by §a${floor(this.level * mult, 1)}`],
+      desc: [`§7Boosts your §f${SYMBOLS.true_defense} True Defense §7by §a${floor(this.level * mult, 1)}`],
     };
   }
 
@@ -852,7 +852,7 @@ class BlackCat extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.15 });
     return {
       name: "§6Omen",
-      desc: [`§7Grants §d${floor(this.level * mult, 1)} ${symbols.pet_luck} Pet Luck`],
+      desc: [`§7Grants §d${floor(this.level * mult, 1)} ${SYMBOLS.pet_luck} Pet Luck`],
     };
   }
 
@@ -860,7 +860,7 @@ class BlackCat extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.15 });
     return {
       name: "§6Supernatural",
-      desc: [`§7Grants §b${floor(this.level * mult, 1)} ${symbols.magic_find} Magic Find`],
+      desc: [`§7Grants §b${floor(this.level * mult, 1)} ${SYMBOLS.magic_find} Magic Find`],
     };
   }
 }
@@ -938,8 +938,8 @@ class EnderDragon extends Pet {
       name: "§6One With The Dragon",
       desc: [
         `§7Buffs the Aspect of the Dragons sword by §a${round(this.level * 0.5, 1)} §c${
-          symbols.strength
-        } Damage and §a${round(this.level * 0.3, 1)} §c${symbols.strength} Strength`,
+          SYMBOLS.strength
+        } Damage and §a${round(this.level * 0.3, 1)} §c${SYMBOLS.strength} Strength`,
       ],
     };
   }
@@ -996,7 +996,7 @@ class GoldenDragon extends Pet {
     const value = Math.max(0, this.level - 100) * 0.5 + 50;
     return {
       name: "§6Gold's Power",
-      desc: [`§7Adds §c+${round(value, 1)} ${symbols.strength} Strength §7to all §6golden §7weapons`],
+      desc: [`§7Adds §c+${round(value, 1)} ${SYMBOLS.strength} Strength §7to all §6golden §7weapons`],
     };
   }
 
@@ -1004,7 +1004,7 @@ class GoldenDragon extends Pet {
     return {
       name: "§6Shining Scales",
       desc: [
-        `§7For each digit in your §6gold collection §7gain §c+10 ${symbols.strength} Strength §7and §b+2 ${symbols.magic_find} Magic Find`,
+        `§7For each digit in your §6gold collection §7gain §c+10 ${SYMBOLS.strength} Strength §7and §b+2 ${SYMBOLS.magic_find} Magic Find`,
       ],
     };
   }
@@ -1014,7 +1014,7 @@ class GoldenDragon extends Pet {
     return {
       name: "§6Dragon's Greed",
       desc: [
-        `§7Gain §a${round(value, 1)}% §7of your §b${symbols.magic_find} Magic Find §7as §c${symbols.strength} Strength`,
+        `§7Gain §a${round(value, 1)}% §7of your §b${SYMBOLS.magic_find} Magic Find §7as §c${SYMBOLS.strength} Strength`,
       ],
     };
   }
@@ -1243,7 +1243,7 @@ class Griffin extends Pet {
     return {
       name: "§6King of Kings",
       desc: [
-        `§7Gain §c+${round(1 + this.level * mult, 1)}% §c${symbols.strength} Strength §7when above §c85% §7health.`,
+        `§7Gain §c+${round(1 + this.level * mult, 1)}% §c${SYMBOLS.strength} Strength §7when above §c85% §7health.`,
       ],
     };
   }
@@ -1274,7 +1274,7 @@ class Guardian extends Pet {
       name: "§6Lazerbeam",
       desc: [
         `§7Zap your enemies for §b${round(this.level * mult, 1)}x §7your §b${
-          symbols.intelligence
+          SYMBOLS.intelligence
         } Intelligence §7every §a3s`,
       ],
     };
@@ -1380,7 +1380,7 @@ class Hound extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.1 });
     return {
       name: "§6Fury Claws",
-      desc: [`§7Grants ${round(this.level * mult, 1)}	§e${symbols.bonus_attack_speed} Bonus Attack Speed`],
+      desc: [`§7Grants ${round(this.level * mult, 1)}	§e${SYMBOLS.bonus_attack_speed} Bonus Attack Speed`],
     };
   }
 }
@@ -1455,7 +1455,7 @@ class Phoenix extends Pet {
       name: "§6Rekindle",
       desc: [
         `§7Before death, become §eimmune §7and gain §c${startStrength + round(this.level * multStrength, 1)} ${
-          symbols.strength
+          SYMBOLS.strength
         } Strength §7for ${2 + round(this.level * multTime, 1)} §7seconds`,
         `§73 minutes cooldown`,
       ],
@@ -1469,7 +1469,7 @@ class Phoenix extends Pet {
       name: "§6Fourth Flare",
       desc: [
         `§7On 4th melee strike, §6ignite §7mobs, dealing §c${1 + round(this.level * multDamage, 1)}x §7your §9${
-          symbols.crit_damage
+          SYMBOLS.crit_damage
         } Crit Damage §7each second for §a${2 + floor(this.level * multTime, 0)} §7seconds`,
       ],
     };
@@ -1522,8 +1522,8 @@ class Pigman extends Pet {
       name: "§6Pork Master",
       desc: [
         `§7Buffs the Pigman sword by §a${round(this.level * multDamage, 1)} §c${
-          symbols.strength
-        } Damage and §7§a${round(this.level * multStrength, 1)} §c${symbols.strength} Strength`,
+          SYMBOLS.strength
+        } Damage and §7§a${round(this.level * multStrength, 1)} §c${SYMBOLS.strength} Strength`,
       ],
     };
   }
@@ -1578,7 +1578,7 @@ class Rat extends Pet {
       name: "§6Rat's Blessing",
       desc: [
         `§7Has a chance to grant a random player §b+${floor(2 + this.level * multMf, 1)} ${
-          symbols.magic_find
+          SYMBOLS.magic_find
         } Magic Find §7for §a${round(
           20 + this.level * multTime,
           0
@@ -1657,7 +1657,7 @@ class Skeleton extends Pet {
     return {
       name: "§6Combo",
       desc: [
-        `§7Gain a combo stack for every bow hit granting +§a3 §c${symbols.strength} Strength§7. Max §a${round(
+        `§7Gain a combo stack for every bow hit granting +§a3 §c${SYMBOLS.strength} Strength§7. Max §a${round(
           this.level * mult,
           1
         )} §7stacks, stacks disappear after 8 seconds`,
@@ -1669,7 +1669,7 @@ class Skeleton extends Pet {
     return {
       name: "§6Skeletal Defense",
       desc: [
-        `§7Your skeleton shoots an arrow dealing §a30x §7your §9${symbols.crit_damage} Crit Damage §7when a mob gets close to you (5s cooldown)`,
+        `§7Your skeleton shoots an arrow dealing §a30x §7your §9${SYMBOLS.crit_damage} Crit Damage §7when a mob gets close to you (5s cooldown)`,
       ],
     };
   }
@@ -1714,7 +1714,7 @@ class Snowman extends Pet {
     return {
       name: "§6Snow Cannon",
       desc: [
-        `§7Your snowman fires a snowball dealing §a5x §7your §c${symbols.strength} Strength §7when a mob gets close to you (1s cooldown)`,
+        `§7Your snowman fires a snowball dealing §a5x §7your §c${SYMBOLS.strength} Strength §7when a mob gets close to you (1s cooldown)`,
       ],
     };
   }
@@ -1744,7 +1744,7 @@ class Spider extends Pet {
     return {
       name: "§6One With The Spider",
       desc: [
-        `§7Gain §a${round(this.level * mult, 1)} §c${symbols.strength} Strength §7for every nearby spider`,
+        `§7Gain §a${round(this.level * mult, 1)} §c${SYMBOLS.strength} Strength §7for every nearby spider`,
         `§8Max 10 spiders`,
       ],
     };
@@ -1875,7 +1875,7 @@ class Tiger extends Pet {
     const mult = getValue(this.rarity, { common: 0.1, uncommon: 0.2, epic: 0.3 });
     return {
       name: "§6Merciless Swipe",
-      desc: [`§7Gain 	§c+${round(this.level * mult, 1)}% ${symbols.ferocity} Ferocity.`],
+      desc: [`§7Gain 	§c+${round(this.level * mult, 1)}% ${SYMBOLS.ferocity} Ferocity.`],
     };
   }
 
@@ -1919,7 +1919,7 @@ class Turtle extends Pet {
     const mult = getValue(this.rarity, { epic: 0.27 });
     return {
       name: "§6Turtle Tactics",
-      desc: [`§7Gain §a+${round(3 + this.level * mult, 1)}% ${symbols.defense} Defense`],
+      desc: [`§7Gain §a+${round(3 + this.level * mult, 1)}% ${SYMBOLS.defense} Defense`],
     };
   }
 
@@ -1929,7 +1929,7 @@ class Turtle extends Pet {
       name: "§6Genius Amniote",
       desc: [
         `§7Grants §a+${round(5 + this.level * mult, 1)} ${
-          symbols.defense
+          SYMBOLS.defense
         } Defense §7for every player around you, up to 4 nearby players.`,
       ],
     };
@@ -1986,7 +1986,7 @@ class Wolf extends Pet {
       name: "§6Pack Leader",
       desc: [
         `§7Gain §a${round(this.level * mult, 1)} §9 ${
-          symbols.crit_damage
+          SYMBOLS.crit_damage
         } Crit Damage §7for every nearby wolf monsters`,
         `§8Max 10 wolves`,
       ],
@@ -2022,15 +2022,15 @@ class GrandmaWolf extends Pet {
         `§7Gain buffs for combo kills. Effects stack as you increase your combo.`,
         ``,
         `§a5 Combo §8(lasts §a${Math.floor((8 + this.level * 0.02) * 10) / 10}s§8)`,
-        `§8+§b3% §b${symbols.magic_find} Magic Find`,
+        `§8+§b3% §b${SYMBOLS.magic_find} Magic Find`,
         `§a10 Combo §8(lasts §a${Math.floor((6 + this.level * 0.02) * 10) / 10}s§8)`,
         `§8+§610 §7coins per kill`,
         `§a15 Combo §8(lasts §a${Math.floor((4 + this.level * 0.02) * 10) / 10}s§8)`,
-        `§8+§b3% §b${symbols.magic_find} Magic Find`,
+        `§8+§b3% §b${SYMBOLS.magic_find} Magic Find`,
         `§a20 Combo §8(lasts §a${Math.floor((3 + this.level * 0.02) * 10) / 10}s§8)`,
         `§8+§315% §7Combat Exp`,
         `§a25 Combo §8(lasts §a${Math.floor((3 + this.level * 0.01) * 10) / 10}s§8)`,
-        `§8+§b3% §b${symbols.magic_find} Magic Find`,
+        `§8+§b3% §b${SYMBOLS.magic_find} Magic Find`,
         `§a30 Combo §8(lasts §a${Math.floor((2 + this.level * 0.01) * 10) / 10}s§8)`,
         `§8+§610 §7coins per kill`,
       ],
@@ -2105,7 +2105,7 @@ class Giraffe extends Pet {
     const mult = getValue(this.rarity, { common: 0.05, uncommon: 0.1, rare: 0.15, epic: 0.2, legendary: 0.25 });
     return {
       name: "§6Good Heart",
-      desc: [`§7Regen §c${round(this.level * mult, 1)} ${symbols.health} §7per second`],
+      desc: [`§7Regen §c${round(this.level * mult, 1)} ${SYMBOLS.health} §7per second`],
     };
   }
 
@@ -2115,10 +2115,10 @@ class Giraffe extends Pet {
     return {
       name: "§6Higher Ground",
       desc: [
-        `§7Grants §c+${round(this.level * multStrength, 1)} ${symbols.strength} Strength §7and §9+${round(
+        `§7Grants §c+${round(this.level * multStrength, 1)} ${SYMBOLS.strength} Strength §7and §9+${round(
           this.level * multCd + 20,
           1
-        )} ${symbols.crit_damage} Crit Damage §7when mid air or jumping`,
+        )} ${SYMBOLS.crit_damage} Crit Damage §7when mid air or jumping`,
       ],
     };
   }
@@ -2157,8 +2157,8 @@ class Lion extends Pet {
     return {
       name: "§6Primal Force",
       desc: [
-        `§7Adds §c+${round(this.level * mult, 1)} ${symbols.strength} Damage §7and §c+${round(this.level * mult, 1)} ${
-          symbols.strength
+        `§7Adds §c+${round(this.level * mult, 1)} ${SYMBOLS.strength} Damage §7and §c+${round(this.level * mult, 1)} ${
+          SYMBOLS.strength
         } Strength §7to your weapons`,
       ],
     };
@@ -2179,7 +2179,7 @@ class Lion extends Pet {
     return {
       name: "§6King of the Jungle",
       desc: [
-        `§7Deal §c+${round(this.level * mult, 1)}% ${symbols.strength} Damage §7against mobs that have attacked you.`,
+        `§7Deal §c+${round(this.level * mult, 1)}% ${SYMBOLS.strength} Damage §7against mobs that have attacked you.`,
       ],
     };
   }
@@ -2210,7 +2210,7 @@ class Monkey extends Pet {
       name: "§6Treeborn",
       desc: [
         `§7Grants §a+${round(this.level * mult, 1)} §6${
-          symbols.foraging_fortune
+          SYMBOLS.foraging_fortune
         } Foraging Fortune§7, which increases your chance at double logs`,
       ],
     };
@@ -2220,7 +2220,7 @@ class Monkey extends Pet {
     const mult = getValue(this.rarity, { rare: 0.75, epic: 1 });
     return {
       name: "§6Vine Swing",
-      desc: [`§7Gain +§a${round(this.level * mult, 1)}	§f${symbols.speed} Speed §7while in The Park`],
+      desc: [`§7Gain +§a${round(this.level * mult, 1)}	§f${SYMBOLS.speed} Speed §7while in The Park`],
     };
   }
 
@@ -2298,8 +2298,8 @@ class BabyYeti extends Pet {
     return {
       name: "§6Cold Breeze",
       desc: [
-        `§7Gives §a${round(this.level * mult, 1)} §c${symbols.strength} Strength §7and §9${
-          symbols.crit_damage
+        `§7Gives §a${round(this.level * mult, 1)} §c${SYMBOLS.strength} Strength §7and §9${
+          SYMBOLS.crit_damage
         } Crit Damage §7when near snow`,
       ],
     };
@@ -2309,7 +2309,7 @@ class BabyYeti extends Pet {
     const mult = getValue(this.rarity, { epic: 0.5, legendary: 0.75 });
     return {
       name: "§6Ice Shields",
-      desc: [`§7Gain §a${floor(this.level * mult, 1)}% §7of your strength as §a${symbols.defense} Defense`],
+      desc: [`§7Gain §a${floor(this.level * mult, 1)}% §7of your strength as §a${SYMBOLS.defense} Defense`],
     };
   }
 
@@ -2318,8 +2318,8 @@ class BabyYeti extends Pet {
     return {
       name: "§6Yeti Fury",
       desc: [
-        `§7Buff the Yeti sword by §a${round(this.level * mult, 1)} §c${symbols.strength} Damage §7and §9${
-          symbols.intelligence
+        `§7Buff the Yeti sword by §a${round(this.level * mult, 1)} §c${SYMBOLS.strength} Damage §7and §9${
+          SYMBOLS.intelligence
         } Intelligence`,
       ],
     };
@@ -2348,7 +2348,7 @@ class BlueWhale extends Pet {
     const mult = getValue(this.rarity, { common: 0.5, uncommon: 1, rare: 1.5, epic: 2, legendary: 2.5 });
     return {
       name: "§6Ingest",
-      desc: [`§7All potions heal §c+${round(this.level * mult, 1)} ${symbols.health}`],
+      desc: [`§7All potions heal §c+${round(this.level * mult, 1)} ${SYMBOLS.health}`],
     };
   }
 
@@ -2358,8 +2358,8 @@ class BlueWhale extends Pet {
     return {
       name: "§6Bulk",
       desc: [
-        `§7Gain §a${round(this.level * mult, 1)} ${symbols.defense} Defense §7per §c${health} Max ${
-          symbols.health
+        `§7Gain §a${round(this.level * mult, 1)} ${SYMBOLS.defense} Defense §7per §c${health} Max ${
+          SYMBOLS.health
         } Health`,
       ],
     };
@@ -2369,7 +2369,7 @@ class BlueWhale extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.2 });
     return {
       name: "§6Archimedes",
-      desc: [`§7Gain §c+${round(this.level * mult, 1)}% Max ${symbols.health} Health`],
+      desc: [`§7Gain §c+${round(this.level * mult, 1)}% Max ${SYMBOLS.health} Health`],
     };
   }
 }
@@ -2392,7 +2392,7 @@ class Ammonite extends Pet {
       name: "§6Heart of the Sea",
       desc: [
         `§7Each Heart of the Mountain level grants §3+${round(this.level * mult, 1)} ${
-          symbols.sea_creature_chance
+          SYMBOLS.sea_creature_chance
         } Sea Creature Chance`,
       ],
     };
@@ -2404,8 +2404,8 @@ class Ammonite extends Pet {
       name: "§6Not a Snail",
       desc: [
         `§7Each fishing and mining level grants §f+${round(this.level * mult, 1)} ${
-          symbols.speed
-        } Speed §7and §a+${round(this.level * mult, 1)} ${symbols.defense} Defense`,
+          SYMBOLS.speed
+        } Speed §7and §a+${round(this.level * mult, 1)} ${SYMBOLS.defense} Defense`,
       ],
     };
   }
@@ -2501,8 +2501,8 @@ class FlyingFish extends Pet {
     return {
       name: getValue(this.rarity, { rare: "§6Water Bender", mythic: "§6Lava Bender" }),
       desc: [
-        `§7Gives §a${round(this.level * mult, 1)} §c${symbols.strength} Strength §7and §a${
-          symbols.defense
+        `§7Gives §a${round(this.level * mult, 1)} §c${SYMBOLS.strength} Strength §7and §a${
+          SYMBOLS.defense
         } Defense §7when near ${type}`,
       ],
     };
@@ -2549,7 +2549,7 @@ class Megalodon extends Pet {
       name: "§6Blood Scent",
       desc: [
         `§7Deal up to §c+${round(mult * this.level, 1)}% ${
-          symbols.strength
+          SYMBOLS.strength
         } §7Damage based on the enemy's missing health`,
       ],
     };
@@ -2568,8 +2568,8 @@ class Megalodon extends Pet {
     return {
       name: "§6Feeding frenzy",
       desc: [
-        `§7On kill gain §c${round(mult * this.level, 1)} ${symbols.strength} Damage §7and §f${
-          symbols.speed
+        `§7On kill gain §c${round(mult * this.level, 1)} ${SYMBOLS.strength} Damage §7and §f${
+          SYMBOLS.speed
         } Speed §7for 5 seconds`,
       ],
     };
@@ -2609,10 +2609,10 @@ class Squid extends Pet {
     return {
       name: "§6Ink Specialty",
       desc: [
-        `§7Buffs the Ink Wand by §a${round(this.level * multDamage, 1)} §c${symbols.strength} Damage §7and §a${round(
+        `§7Buffs the Ink Wand by §a${round(this.level * multDamage, 1)} §c${SYMBOLS.strength} Damage §7and §a${round(
           this.level * multStrength,
           1
-        )} §c${symbols.strength} Strength`,
+        )} §c${SYMBOLS.strength} Strength`,
       ],
     };
   }
@@ -2715,7 +2715,7 @@ class Parrot extends Pet {
     return {
       name: "§6Bird Discourse",
       desc: [
-        `§7Gives §c+${round(5 + this.level * mult, 1)} ${symbols.strength} Strength §7to players within §a20 §7blocks`,
+        `§7Gives §c+${round(5 + this.level * mult, 1)} ${SYMBOLS.strength} Strength §7to players within §a20 §7blocks`,
         `§7Doesn't stack`,
       ],
     };
@@ -2963,10 +2963,10 @@ class Wisp extends Pet {
       name: "§6Bulwark",
       desc: [
         `§7Kill Blazes to gain defense against them`,
-        `§7Bonus: §a+${current.defense} ${symbols.defense} §7& §f+${current.true_defense} ${symbols.true_defense}`,
+        `§7Bonus: §a+${current.defense} ${SYMBOLS.defense} §7& §f+${current.true_defense} ${SYMBOLS.true_defense}`,
         !maxTier
-          ? `§7Next Upgrade: §a+${next.defense} ${symbols.defense} §7& §f+${next.true_defense} ${
-              symbols.true_defense
+          ? `§7Next Upgrade: §a+${next.defense} ${SYMBOLS.defense} §7& §f+${next.true_defense} ${
+              SYMBOLS.true_defense
             } §7(§a${blazeKills.toLocaleString()}§7/§c${next.kills.toLocaleString()}§7)`
           : "§aMAXED OUT!",
       ],
@@ -2991,7 +2991,7 @@ class Wisp extends Pet {
     return {
       name: "§6Extinguish",
       desc: [
-        `§7While in combat on the Crimson Isle, spawn a pool every §a8s§7. Bathing in it heals §c${val1}% ${symbols.health} Health §7now and §c${val2}% ${symbols.health} Health§7/s for §a8s`,
+        `§7While in combat on the Crimson Isle, spawn a pool every §a8s§7. Bathing in it heals §c${val1}% ${SYMBOLS.health} Health §7now and §c${val2}% ${SYMBOLS.health} Health§7/s for §a8s`,
       ],
     };
   }
@@ -3049,8 +3049,8 @@ class MooshroomCow extends Pet {
     return {
       name: "§6Farming Strength",
       desc: [
-        `§7Gain §6+1 ${symbols.farming_fortune} Farming Fortune §7per every §c${round(40 - this.level * mult, 1)} ${
-          symbols.strength
+        `§7Gain §6+1 ${SYMBOLS.farming_fortune} Farming Fortune §7per every §c${round(40 - this.level * mult, 1)} ${
+          SYMBOLS.strength
         } Strength`,
       ],
     };
@@ -3090,8 +3090,8 @@ class Snail extends Pet {
     return {
       name: "§6Slow Moving",
       desc: [
-        `§7Converts all §f${symbols.speed} Speed §7over 100 into §6${
-          symbols.mining_fortune
+        `§7Converts all §f${SYMBOLS.speed} Speed §7over 100 into §6${
+          SYMBOLS.mining_fortune
         } Mining Fortune §7for Non-Ores at §a${round(this.level * mult, 1)}% §7efficiency`,
         // `Current bonus: +0 ${symbols.mining_fortune} Mining Fortune`,
       ],
@@ -3105,7 +3105,7 @@ class Snail extends Pet {
       name: "§6Slow But Efficient",
       desc: [
         `§7Reduces the mana cost of §9Utility Abilities §7by §a${round(this.level * mult, 1)}% §7for every +15 §f${
-          symbols.speed
+          SYMBOLS.speed
         } Speed §7converted`,
       ],
     };
@@ -3158,7 +3158,7 @@ class Kuudra extends Pet {
     return {
       name: "§6Kuudra Fortune",
       desc: [
-        `§7Gain §6+${round(this.level * mult, 1)} ${symbols.mining_fortune} Mining Fortune §7while on the Crimson Isle`,
+        `§7Gain §6+${round(this.level * mult, 1)} ${SYMBOLS.mining_fortune} Mining Fortune §7while on the Crimson Isle`,
       ],
     };
   }

--- a/src/constants/pet-stats.js
+++ b/src/constants/pet-stats.js
@@ -462,13 +462,13 @@ class Bat extends Pet {
   }
 
   get second() {
-    const mult_intel = getValue(this.rarity, { rare: 0.2, epic: 0.3 });
-    const mult_speed = getValue(this.rarity, { rare: 0.4, epic: 0.5 });
+    const multIntel = getValue(this.rarity, { rare: 0.2, epic: 0.3 });
+    const multSpeed = getValue(this.rarity, { rare: 0.4, epic: 0.5 });
     return {
       name: "§6Nightmare",
       desc: [
-        `§7During night, gain §a${round(this.level * mult_intel, 1)} §9${symbols.intelligence} Intelligence, §a${round(
-          this.level * mult_speed,
+        `§7During night, gain §a${round(this.level * multIntel, 1)} §9${symbols.intelligence} Intelligence, §a${round(
+          this.level * multSpeed,
           1
         )} §f${symbols.speed} Speed§7, and night vision`,
       ],
@@ -1448,29 +1448,29 @@ class Phoenix extends Pet {
   }
 
   get first() {
-    const start_strength = getValue(this.rarity, { epic: 10, legendary: 15 });
-    const mult_strength = getValue(this.rarity, { epic: 0.1, legendary: 0.15 });
-    const mult_time = getValue(this.rarity, { epic: 0.02 });
+    const startStrength = getValue(this.rarity, { epic: 10, legendary: 15 });
+    const multStrength = getValue(this.rarity, { epic: 0.1, legendary: 0.15 });
+    const multTime = getValue(this.rarity, { epic: 0.02 });
     return {
       name: "§6Rekindle",
       desc: [
-        `§7Before death, become §eimmune §7and gain §c${start_strength + round(this.level * mult_strength, 1)} ${
+        `§7Before death, become §eimmune §7and gain §c${startStrength + round(this.level * multStrength, 1)} ${
           symbols.strength
-        } Strength §7for ${2 + round(this.level * mult_time, 1)} §7seconds`,
+        } Strength §7for ${2 + round(this.level * multTime, 1)} §7seconds`,
         `§73 minutes cooldown`,
       ],
     };
   }
 
   get second() {
-    const mult_damage = getValue(this.rarity, { epic: 0.12, legendary: 0.14 });
-    const mult_time = getValue(this.rarity, { epic: 0.04 });
+    const multDamage = getValue(this.rarity, { epic: 0.12, legendary: 0.14 });
+    const multTime = getValue(this.rarity, { epic: 0.04 });
     return {
       name: "§6Fourth Flare",
       desc: [
-        `§7On 4th melee strike, §6ignite §7mobs, dealing §c${1 + round(this.level * mult_damage, 1)}x §7your §9${
+        `§7On 4th melee strike, §6ignite §7mobs, dealing §c${1 + round(this.level * multDamage, 1)}x §7your §9${
           symbols.crit_damage
-        } Crit Damage §7each second for §a${2 + floor(this.level * mult_time, 0)} §7seconds`,
+        } Crit Damage §7each second for §a${2 + floor(this.level * multTime, 0)} §7seconds`,
       ],
     };
   }
@@ -1516,14 +1516,14 @@ class Pigman extends Pet {
   }
 
   get second() {
-    const mult_damage = getValue(this.rarity, { epic: 0.4 });
-    const mult_strength = getValue(this.rarity, { epic: 0.25 });
+    const multDamage = getValue(this.rarity, { epic: 0.4 });
+    const multStrength = getValue(this.rarity, { epic: 0.25 });
     return {
       name: "§6Pork Master",
       desc: [
-        `§7Buffs the Pigman sword by §a${round(this.level * mult_damage, 1)} §c${
+        `§7Buffs the Pigman sword by §a${round(this.level * multDamage, 1)} §c${
           symbols.strength
-        } Damage and §7§a${round(this.level * mult_strength, 1)} §c${symbols.strength} Strength`,
+        } Damage and §7§a${round(this.level * multStrength, 1)} §c${symbols.strength} Strength`,
       ],
     };
   }
@@ -1572,15 +1572,15 @@ class Rat extends Pet {
   }
 
   get third() {
-    const mult_mf = getValue(this.rarity, { legendary: 0.05 });
-    const mult_time = getValue(this.rarity, { legendary: 0.2 });
+    const multMf = getValue(this.rarity, { legendary: 0.05 });
+    const multTime = getValue(this.rarity, { legendary: 0.2 });
     return {
       name: "§6Rat's Blessing",
       desc: [
-        `§7Has a chance to grant a random player §b+${floor(2 + this.level * mult_mf, 1)} ${
+        `§7Has a chance to grant a random player §b+${floor(2 + this.level * multMf, 1)} ${
           symbols.magic_find
         } Magic Find §7for §a${round(
-          20 + this.level * mult_time,
+          20 + this.level * multTime,
           0
         )} §7seconds after finding a yummy piece of Cheese! If the player gets a drop during this buff, you have a §a20% §7to get it too.`,
       ],
@@ -2110,13 +2110,13 @@ class Giraffe extends Pet {
   }
 
   get second() {
-    const mult_strength = getValue(this.rarity, { rare: 0.4, epic: 0.5 });
-    const mult_cd = getValue(this.rarity, { rare: 0.1, epic: 0.25, legendary: 0.4 });
+    const multStrength = getValue(this.rarity, { rare: 0.4, epic: 0.5 });
+    const multCd = getValue(this.rarity, { rare: 0.1, epic: 0.25, legendary: 0.4 });
     return {
       name: "§6Higher Ground",
       desc: [
-        `§7Grants §c+${round(this.level * mult_strength, 1)} ${symbols.strength} Strength §7and §9+${round(
-          this.level * mult_cd + 20,
+        `§7Grants §c+${round(this.level * multStrength, 1)} ${symbols.strength} Strength §7and §9+${round(
+          this.level * multCd + 20,
           1
         )} ${symbols.crit_damage} Crit Damage §7when mid air or jumping`,
       ],
@@ -2604,13 +2604,13 @@ class Squid extends Pet {
   }
 
   get second() {
-    const mult_damage = getValue(this.rarity, { rare: 0.3, epic: 0.4 });
-    const mult_strength = getValue(this.rarity, { rare: 0.1, epic: 0.2 });
+    const multDamage = getValue(this.rarity, { rare: 0.3, epic: 0.4 });
+    const multStrength = getValue(this.rarity, { rare: 0.1, epic: 0.2 });
     return {
       name: "§6Ink Specialty",
       desc: [
-        `§7Buffs the Ink Wand by §a${round(this.level * mult_damage, 1)} §c${symbols.strength} Damage §7and §a${round(
-          this.level * mult_strength,
+        `§7Buffs the Ink Wand by §a${round(this.level * multDamage, 1)} §c${symbols.strength} Damage §7and §a${round(
+          this.level * multStrength,
           1
         )} §c${symbols.strength} Strength`,
       ],
@@ -2642,15 +2642,15 @@ class Jellyfish extends Pet {
   }
 
   get first() {
-    const mult_health = getValue(this.rarity, { epic: 1 });
-    const mult_mana = getValue(this.rarity, { epic: 0.5 });
+    const multHealth = getValue(this.rarity, { epic: 1 });
+    const multMana = getValue(this.rarity, { epic: 0.5 });
     return {
       name: "§6Radiant Regeneration",
       desc: [
         `§7While in dungeons, increase your base health regen by §a${round(
-          this.level * mult_health,
+          this.level * multHealth,
           1
-        )}% §7and reduces the mana cost of Power Orbs by §a${round(this.level * mult_mana, 1)}%§7.`,
+        )}% §7and reduces the mana cost of Power Orbs by §a${round(this.level * multMana, 1)}%§7.`,
       ],
     };
   }
@@ -2921,7 +2921,7 @@ class Wisp extends Pet {
   }
 
   get second() {
-    const bonuses = [
+    const BONUSES = [
       { kills: 0, defense: 0, true_defense: 0 },
       { kills: 100, defense: 30, true_defense: 3 },
       { kills: 200, defense: 60, true_defense: 6 },
@@ -2942,21 +2942,21 @@ class Wisp extends Pet {
       { kills: 200000, defense: 600, true_defense: 60 },
     ];
 
-    const blaze_kills = this.extra?.blaze_kills ?? 0;
+    const blazeKills = this.extra?.blaze_kills ?? 0;
 
     let maxTier = false;
-    let bonusIndex = bonuses.findIndex((x) => x.kills > blaze_kills);
+    let bonusIndex = BONUSES.findIndex((x) => x.kills > blazeKills);
 
     if (bonusIndex === -1) {
-      bonusIndex = bonuses.length;
+      bonusIndex = BONUSES.length;
       maxTier = true;
     }
 
-    const current = bonuses[bonusIndex - 1];
+    const current = BONUSES[bonusIndex - 1];
 
     let next = null;
     if (!maxTier) {
-      next = bonuses[bonusIndex];
+      next = BONUSES[bonusIndex];
     }
 
     return {
@@ -2967,7 +2967,7 @@ class Wisp extends Pet {
         !maxTier
           ? `§7Next Upgrade: §a+${next.defense} ${symbols.defense} §7& §f+${next.true_defense} ${
               symbols.true_defense
-            } §7(§a${blaze_kills.toLocaleString()}§7/§c${next.kills.toLocaleString()}§7)`
+            } §7(§a${blazeKills.toLocaleString()}§7/§c${next.kills.toLocaleString()}§7)`
           : "§aMAXED OUT!",
       ],
     };
@@ -3218,7 +3218,7 @@ class QuestionMark extends Pet {
   }
 }
 
-export const petStats = {
+export const PET_STATS = {
   "???": QuestionMark,
   AMMONITE: Ammonite,
   ARMADILLO: Armadillo,

--- a/src/constants/pets.js
+++ b/src/constants/pets.js
@@ -1,6 +1,6 @@
 import { symbols } from "../../common/constants.js";
 
-export const pet_rarity_offset = {
+export const PET_RARITY_OFFSET = {
   common: 0,
   uncommon: 6,
   rare: 11,
@@ -9,7 +9,7 @@ export const pet_rarity_offset = {
   mythic: 20,
 };
 
-export const pet_levels = [
+export const PET_LEVELS = [
   100, 110, 120, 130, 145, 160, 175, 190, 210, 230, 250, 275, 300, 330, 360, 400, 440, 490, 540, 600, 660, 730, 800,
   880, 960, 1050, 1150, 1260, 1380, 1510, 1650, 1800, 1960, 2130, 2310, 2500, 2700, 2920, 3160, 3420, 3700, 4000, 4350,
   4750, 5200, 5700, 6300, 7000, 7800, 8700, 9700, 10800, 12000, 13300, 14700, 16200, 17800, 19500, 21300, 23200, 25200,
@@ -45,7 +45,7 @@ export const pet_levels = [
     typeGroup?: string (default: equal to PET_TYPE),
   }
  */
-export const pet_data = {
+export const PET_DATA = {
   ARMADILLO: {
     head: "/head/c1eb6df4736ae24dd12a3d00f91e6e3aa7ade6bbefb0978afef2f0f92461018f",
     type: "mining",
@@ -523,7 +523,7 @@ export const pet_data = {
   },
 };
 
-export const pet_value = {
+export const PET_VALUE = {
   common: 1,
   uncommon: 2,
   rare: 3,
@@ -543,7 +543,7 @@ export const pet_value = {
     multAllStats?: {stat: value},
   }
 */
-export const pet_items = {
+export const PET_ITEMS = {
   PET_ITEM_ALL_SKILLS_BOOST_COMMON: {
     name: "All Skills Exp Boost",
     tier: "COMMON",

--- a/src/constants/pets.js
+++ b/src/constants/pets.js
@@ -1,4 +1,4 @@
-import { symbols } from "../../common/constants.js";
+import { SYMBOLS } from "../../common/constants.js";
 
 export const PET_RARITY_OFFSET = {
   common: 0,
@@ -552,7 +552,7 @@ export const PET_ITEMS = {
   PET_ITEM_BIG_TEETH_COMMON: {
     name: "Big Teeth",
     tier: "COMMON",
-    description: `§7Increases §9${symbols.crit_chance} Crit Chance §7by §a5`,
+    description: `§7Increases §9${SYMBOLS.crit_chance} Crit Chance §7by §a5`,
     stats: {
       crit_chance: 5,
     },
@@ -560,7 +560,7 @@ export const PET_ITEMS = {
   PET_ITEM_IRON_CLAWS_COMMON: {
     name: "Iron Claws",
     tier: "COMMON",
-    description: `§7Increases the pet's §9${symbols.crit_damage} Crit Damage §7by §a40% §7and §9${symbols.crit_chance} Crit Chance §7by §a40%`,
+    description: `§7Increases the pet's §9${SYMBOLS.crit_damage} Crit Damage §7by §a40% §7and §9${SYMBOLS.crit_chance} Crit Chance §7by §a40%`,
     multStats: {
       crit_chance: 1.4,
       crit_damage: 1.4,
@@ -569,7 +569,7 @@ export const PET_ITEMS = {
   PET_ITEM_SHARPENED_CLAWS_UNCOMMON: {
     name: "Sharpened Claws",
     tier: "UNCOMMON",
-    description: `§7Increases §9${symbols.crit_damage} Crit Damage §7by §a15`,
+    description: `§7Increases §9${SYMBOLS.crit_damage} Crit Damage §7by §a15`,
     stats: {
       crit_damage: 15,
     },
@@ -577,7 +577,7 @@ export const PET_ITEMS = {
   PET_ITEM_HARDENED_SCALES_UNCOMMON: {
     name: "Hardened Scales",
     tier: "UNCOMMON",
-    description: `§7Increases §a${symbols.defense} Defense §7by §a25`,
+    description: `§7Increases §a${SYMBOLS.defense} Defense §7by §a25`,
     stats: {
       defense: 25,
     },
@@ -590,7 +590,7 @@ export const PET_ITEMS = {
   PET_ITEM_LUCKY_CLOVER: {
     name: "Lucky Clover",
     tier: "EPIC",
-    description: `§7Increases §b${symbols.magic_find} Magic Find §7by §a7`,
+    description: `§7Increases §b${SYMBOLS.magic_find} Magic Find §7by §a7`,
     stats: {
       magic_find: 7,
     },
@@ -598,7 +598,7 @@ export const PET_ITEMS = {
   PET_ITEM_TEXTBOOK: {
     name: "Textbook",
     tier: "LEGENDARY",
-    description: `§7Increases the pet's §b${symbols.intelligence} Intelligence §7by §a100%`,
+    description: `§7Increases the pet's §b${SYMBOLS.intelligence} Intelligence §7by §a100%`,
     multStats: {
       intelligence: 2,
     },
@@ -722,7 +722,7 @@ export const PET_ITEMS = {
   REINFORCED_SCALES: {
     name: "Reinforced Scales",
     tier: "RARE",
-    description: `§7Increases §a${symbols.defense} Defense §7by §a40`,
+    description: `§7Increases §a${SYMBOLS.defense} Defense §7by §a40`,
     stats: {
       defense: 40,
     },
@@ -730,7 +730,7 @@ export const PET_ITEMS = {
   GOLD_CLAWS: {
     name: "Gold Claws",
     tier: "UNCOMMON",
-    description: `§7Increases the pet's §9${symbols.crit_damage} Crit Damage §7by §a50% §7and §9${symbols.crit_chance} Crit Chance §7by §a50%`,
+    description: `§7Increases the pet's §9${SYMBOLS.crit_damage} Crit Damage §7by §a50% §7and §9${SYMBOLS.crit_chance} Crit Chance §7by §a50%`,
     multStats: {
       crit_chance: 1.5,
       crit_damage: 1.5,
@@ -744,7 +744,7 @@ export const PET_ITEMS = {
   BIGGER_TEETH: {
     name: "Bigger Teeth",
     tier: "UNCOMMON",
-    description: `§7Increases §9${symbols.crit_chance} Crit Chance §7by §a10`,
+    description: `§7Increases §9${SYMBOLS.crit_chance} Crit Chance §7by §a10`,
     stats: {
       crit_chance: 10,
     },
@@ -752,7 +752,7 @@ export const PET_ITEMS = {
   SERRATED_CLAWS: {
     name: "Serrated Claws",
     tier: "RARE",
-    description: `§7Increases §9${symbols.crit_damage} Crit Damage §7by §a25`,
+    description: `§7Increases §9${SYMBOLS.crit_damage} Crit Damage §7by §a25`,
     stats: {
       crit_damage: 25,
     },
@@ -760,7 +760,7 @@ export const PET_ITEMS = {
   WASHED_UP_SOUVENIR: {
     name: "Washed-up Souvenir",
     tier: "LEGENDARY",
-    description: `§7Increases §3${symbols.sea_creature_chance} Sea Creature Chance §7by §a5`,
+    description: `§7Increases §3${SYMBOLS.sea_creature_chance} Sea Creature Chance §7by §a5`,
     stats: {
       sea_creature_chance: 5,
     },
@@ -768,7 +768,7 @@ export const PET_ITEMS = {
   ANTIQUE_REMEDIES: {
     name: "Antique Remedies",
     tier: "EPIC",
-    description: `§7Increases the pet's §c${symbols.strength} Strength §7by §a80%`,
+    description: `§7Increases the pet's §c${SYMBOLS.strength} Strength §7by §a80%`,
     multStats: {
       strength: 1.8,
     },
@@ -776,7 +776,7 @@ export const PET_ITEMS = {
   CROCHET_TIGER_PLUSHIE: {
     name: "Crochet Tiger Plushie",
     tier: "EPIC",
-    description: `§7Increases §e${symbols.bonus_attack_speed} Bonus Attack Speed §7by §a35`,
+    description: `§7Increases §e${SYMBOLS.bonus_attack_speed} Bonus Attack Speed §7by §a35`,
     stats: {
       bonus_attack_speed: 35,
     },
@@ -794,7 +794,7 @@ export const PET_ITEMS = {
   PET_ITEM_SPOOKY_CUPCAKE: {
     name: "Spooky Cupcake",
     tier: "UNCOMMON",
-    description: `§7Increases §c${symbols.strength} Strength §7by §a30 §7and §f${symbols.speed} Speed §7by §a20`,
+    description: `§7Increases §c${SYMBOLS.strength} Strength §7by §a30 §7and §f${SYMBOLS.speed} Speed §7by §a20`,
     stats: {
       strength: 30,
       speed: 20,
@@ -814,7 +814,7 @@ export const PET_ITEMS = {
   REAPER_GEM: {
     name: "Reaper Gem",
     tier: "LEGENDARY",
-    description: `§7Gain §c8${symbols.ferocity} Ferocity §7for 5s on kill`,
+    description: `§7Gain §c8${SYMBOLS.ferocity} Ferocity §7for 5s on kill`,
   },
   PET_ITEM_FLYING_PIG: {
     name: "Flying Pig",
@@ -824,7 +824,7 @@ export const PET_ITEMS = {
   PET_ITEM_QUICK_CLAW: {
     name: "Quick Claw",
     tier: "RARE",
-    description: `§7Every 2 pet level you gain §6+1 ${symbols.mining_speed} Mining Speed §7and §6+1 §6${symbols.mining_fortune} Mining Fortune§7.`,
+    description: `§7Every 2 pet level you gain §6+1 ${SYMBOLS.mining_speed} Mining Speed §7and §6+1 §6${SYMBOLS.mining_fortune} Mining Fortune§7.`,
     statsPerLevel: {
       mining_speed: 0.5,
       mining_fortune: 0.5,

--- a/src/constants/promotions.js
+++ b/src/constants/promotions.js
@@ -1,7 +1,7 @@
 /**
  * @type {{title: string, description: string, image: string, url: string}[]}
  */
-export const promotions = [
+export const PROMOTIONS = [
   {
     title: '<span class="grey-text">SkyCrypt\'s</span> Discord',
     description: "Announcements, Community, Bug Reports, Feature Requests, Support",

--- a/src/constants/skills.js
+++ b/src/constants/skills.js
@@ -1,1 +1,1 @@
-export const cosmetic_skills = ["runecrafting", "carpentry", "social"];
+export const COSMETIC_SKILLS = ["runecrafting", "carpentry", "social"];

--- a/src/constants/skins-animations.js
+++ b/src/constants/skins-animations.js
@@ -46,7 +46,7 @@
 ..######..##....##.####.##....##..######.
 */
 
-const skins = [
+const SKINS = [
   {
     id: "PET_SKIN_ENDERMAN",
     name: "Spooky",
@@ -545,7 +545,7 @@ const skins = [
 .##.....##.##....##.####.##.....##.##.....##....##....####..#######..##....##..######.
 */
 
-const animations = [
+export const ITEM_ANIMATIONS = [
   {
     id: "PET_SKIN_TIGER_TWILIGHT",
     texture: "/resources/img/items/pet_skin_tiger_twilight.png",
@@ -1215,44 +1215,43 @@ const animations = [
 ..######...########.##....##....########.##.....##.##.........#######..##.....##....##.....######.
 */
 
-const gen_pet_skins = {};
-const gen_item_skins = {};
-const gen_animated_items = {};
+const petSkins = {};
+const itemSkins = {};
+const animatedItems = {};
 
-skins.forEach((skin) => {
+SKINS.forEach((skin) => {
   if (skin.id.startsWith("PET_SKIN_")) {
-    gen_pet_skins[skin.id] = {
+    petSkins[skin.id] = {
       name: skin.name,
       texture: skin.texture,
       release: skin.release,
     };
   } else {
-    gen_item_skins[skin.id] = {
+    itemSkins[skin.id] = {
       name: skin.name,
       texture: skin.texture,
     };
   }
 });
 
-animations.forEach((anim) => {
+ITEM_ANIMATIONS.forEach((anim) => {
   // Update texture in pet_skins
-  if (gen_pet_skins[anim.id]) {
-    gen_pet_skins[anim.id].texture = anim.texture;
+  if (petSkins[anim.id]) {
+    petSkins[anim.id].texture = anim.texture;
   }
 
   // Update texture in item_skins
-  if (gen_item_skins[anim.id]) {
-    gen_item_skins[anim.id].texture = anim.texture;
+  if (itemSkins[anim.id]) {
+    itemSkins[anim.id].texture = anim.texture;
   }
 
   // Push the item in animated_items (skins too!)
-  if (!gen_animated_items[anim.id]) {
-    gen_animated_items[anim.id] = {};
+  if (!animatedItems[anim.id]) {
+    animatedItems[anim.id] = {};
   }
-  gen_animated_items[anim.id].texture = anim.texture;
+  animatedItems[anim.id].texture = anim.texture;
 });
 
-export const pet_skins = gen_pet_skins;
-export const item_skins = gen_item_skins;
-export const animated_items = gen_animated_items;
-export const animated_items_arr = animations;
+export const PET_SKINS = petSkins;
+export const ITEM_SKINS = itemSkins;
+export const ANIMATED_ITEMS = animatedItems;

--- a/src/constants/tags.js
+++ b/src/constants/tags.js
@@ -1,4 +1,4 @@
-export const itemTags = {
+export const ITEM_TAGS = {
   SUPER_COMPACTOR_3000: "sc3000 sc3k",
   ENCHANTED_LAPIS_LAZULI: "elapis",
   ENCHANTED_IRON_INGOT: "eiron",

--- a/src/constants/tags.js
+++ b/src/constants/tags.js
@@ -1,4 +1,4 @@
-export const item_tags = {
+export const itemTags = {
   SUPER_COMPACTOR_3000: "sc3000 sc3k",
   ENCHANTED_LAPIS_LAZULI: "elapis",
   ENCHANTED_IRON_INGOT: "eiron",

--- a/src/helper.js
+++ b/src/helper.js
@@ -11,7 +11,22 @@ export { renderLore, formatNumber } from "../common/formatting.js";
 export * from "../common/helper.js";
 import { titleCase } from "../common/helper.js";
 
-import * as constants from "./constants.js";
+import {
+  GUILD_XP,
+  COLOR_NAMES,
+  RANKS,
+  GEMSTONES,
+  STATS_DATA,
+  RARITIES,
+  RARITY_COLORS,
+  HOTM,
+  TYPE_TO_CATEGORIES,
+  PET_DATA,
+  PET_RARITY_OFFSET,
+  PET_LEVELS,
+  ITEM_ANIMATIONS,
+} from "./constants.js";
+
 import credentials from "./credentials.js";
 
 const hypixel = axios.create({
@@ -349,7 +364,7 @@ export function getGuildLevel(xp) {
   let level = 0;
 
   while (true) {
-    const xpNeeded = constants.GUILD_XP[Math.min(constants.GUILD_XP.length - 1, level)];
+    const xpNeeded = GUILD_XP[Math.min(GUILD_XP.length - 1, level)];
 
     if (xp > xpNeeded) {
       xp -= xpNeeded;
@@ -484,12 +499,12 @@ export function parseRank(player) {
     ? player.packageRank
     : "NONE";
 
-  if (constants.RANKS[rankName]) {
-    const { tag, color, plus, plusColor } = constants.RANKS[rankName];
+  if (RANKS[rankName]) {
+    const { tag, color, plus, plusColor } = RANKS[rankName];
     output.rankText = tag;
 
     if (rankName == "SUPERSTAR") {
-      output.rankColor = constants.COLOR_NAMES[player.monthlyRankColor] ?? color;
+      output.rankColor = COLOR_NAMES[player.monthlyRankColor] ?? color;
     } else {
       output.rankColor = color;
     }
@@ -498,7 +513,7 @@ export function parseRank(player) {
       output.plusText = plus;
 
       if (rankName == "SUPERSTAR" || rankName == "MVP_PLUS") {
-        output.plusColor = constants.COLOR_NAMES[player.rankPlusColor] ?? plusColor;
+        output.plusColor = COLOR_NAMES[player.rankPlusColor] ?? plusColor;
       } else {
         output.plusColor = plusColor;
       }
@@ -692,7 +707,7 @@ export function parseItemGems(gems, rarity) {
   /** @type {Gem[]} */
 
   const slots = {
-    normal: Object.keys(constants.GEMSTONES),
+    normal: Object.keys(GEMSTONES),
     special: ["UNIVERSAL", "COMBAT", "OFFENSIVE", "DEFENSIVE", "MINING"],
     ignore: ["unlocked_slots"],
   };
@@ -747,11 +762,11 @@ export function generateGemLore(type, tier, rarity) {
   const stats = [];
 
   // Gem color
-  const color = `§${constants.GEMSTONES[type.toUpperCase()].color}`;
+  const color = `§${GEMSTONES[type.toUpperCase()].color}`;
 
   // Gem stats
   if (rarity) {
-    const gemstone_stats = constants.GEMSTONES[type.toUpperCase()]?.stats?.[tier.toUpperCase()];
+    const gemstone_stats = GEMSTONES[type.toUpperCase()]?.stats?.[tier.toUpperCase()];
     if (gemstone_stats) {
       Object.keys(gemstone_stats).forEach((stat) => {
         let stat_value = gemstone_stats[stat][rarityNameToInt(rarity)];
@@ -763,9 +778,7 @@ export function generateGemLore(type, tier, rarity) {
         }
 
         if (stat_value) {
-          stats.push(
-            ["§", constants.statsData[stat].color, "+", stat_value, " ", constants.statsData[stat].symbol].join("")
-          );
+          stats.push(["§", STATS_DATA[stat].color, "+", stat_value, " ", STATS_DATA[stat].symbol].join(""));
         } else {
           stats.push("§c§oMISSING VALUE§r");
         }
@@ -784,7 +797,7 @@ export function generateGemLore(type, tier, rarity) {
 }
 
 export function rarityNameToInt(string) {
-  return constants.rarities.indexOf(string.toLowerCase());
+  return RARITIES.indexOf(string.toLowerCase());
 }
 
 /**
@@ -842,7 +855,7 @@ export function generateItem(data) {
   if (data.display_name && !data.tag.display.Name) {
     data.tag = data.tag ?? {};
     data.tag.display = data.tag.display ?? {};
-    const rarityColor = data.rarity ? `§${constants.rarityColors[data.rarity ?? "common"]}` : "";
+    const rarityColor = data.rarity ? `§${RARITY_COLORS[data.rarity ?? "common"]}` : "";
     data.tag.display.Name = `${rarityColor}${data.display_name}`;
   }
 
@@ -859,11 +872,11 @@ export function calcHotmTokens(hotmTier, potmTier) {
   let tokens = 0;
 
   for (let tier = 1; tier <= hotmTier; tier++) {
-    tokens += constants.HOTM.rewards.hotm[tier]?.token_of_the_mountain || 0;
+    tokens += HOTM.rewards.hotm[tier]?.token_of_the_mountain || 0;
   }
 
   for (let tier = 1; tier <= potmTier; tier++) {
-    tokens += constants.HOTM.rewards.potm[tier]?.token_of_the_mountain || 0;
+    tokens += HOTM.rewards.potm[tier]?.token_of_the_mountain || 0;
   }
 
   return tokens;
@@ -902,9 +915,9 @@ export function convertHMS(seconds, format = "clock", alwaysTwoDigits = false) {
 
 export function parseItemTypeFromLore(lore) {
   const regex = new RegExp(
-    `^(?<recomb>a )?(?<shiny>SHINY )?(?:(?<rarity>${constants.rarities
-      .map((x) => x.replaceAll("_", " ").toUpperCase())
-      .join("|")}) ?)(?<dungeon>DUNGEON )?(?<type>[A-Z ]+)?(?<recomb2>a)?$`
+    `^(?<recomb>a )?(?<shiny>SHINY )?(?:(?<rarity>${RARITIES.map((x) => x.replaceAll("_", " ").toUpperCase()).join(
+      "|"
+    )}) ?)(?<dungeon>DUNGEON )?(?<type>[A-Z ]+)?(?<recomb2>a)?$`
   );
 
   // Executing the regex on every lore line
@@ -975,17 +988,13 @@ export function getCacheFilePath(dirPath, type, name) {
 }
 
 function getCategoriesFromType(type) {
-  if (type in constants.TYPE_TO_CATEGORIES) {
-    return constants.TYPE_TO_CATEGORIES[type];
-  }
-
-  return ["unknown"];
+  return TYPE_TO_CATEGORIES[type] ?? ["unknown"];
 }
 
 export function generateDebugPets(type = "ALL") {
   const pets = [];
 
-  for (const [petType, petData] of Object.entries(constants.PET_DATA)) {
+  for (const [petType, petData] of Object.entries(PET_DATA)) {
     if (type !== "ALL" && petType !== type) {
       continue;
     }
@@ -1036,13 +1045,13 @@ export function generateDebugPets(type = "ALL") {
  * @description takes rarity and level and returns the required pet exp to reach the level
  */
 export function getPetExp(rarity, level) {
-  const rarityOffset = constants.PET_RARITY_OFFSET[rarity.toLowerCase()];
+  const rarityOffset = PET_RARITY_OFFSET[rarity.toLowerCase()];
 
-  return constants.PET_LEVELS.slice(rarityOffset, rarityOffset + level - 1).reduce((prev, curr) => prev + curr, 0);
+  return PET_LEVELS.slice(rarityOffset, rarityOffset + level - 1).reduce((prev, curr) => prev + curr, 0);
 }
 
 export function getAnimatedTexture(item) {
-  const results = constants.ITEM_ANIMATIONS.filter((x) => x.id === getId(item));
+  const results = ITEM_ANIMATIONS.filter((x) => x.id === getId(item));
 
   if (results.length === 0) {
     return false;

--- a/src/leaderboards.js
+++ b/src/leaderboards.js
@@ -1,4 +1,4 @@
-import { collection_data } from "./constants/collections.js";
+import { COLLECTION_DATA } from "./constants/collections.js";
 import moment from "moment";
 import momentDurationFormat from "moment-duration-format";
 momentDurationFormat(moment);
@@ -84,7 +84,7 @@ export default (name) => {
 
   if (lbName.startsWith("collection_")) {
     const collectionName = lbName.split("_").slice(1).join("_").toUpperCase();
-    const collectionData = collection_data.filter((a) => a.skyblockId == collectionName);
+    const collectionData = COLLECTION_DATA.filter((a) => a.skyblockId == collectionName);
 
     if (collectionData.length > 0) {
       options["name"] = collectionData[0].name + " Collection";

--- a/src/lib.js
+++ b/src/lib.js
@@ -1481,7 +1481,7 @@ export async function getStats(
   }
 
   if (!items.no_inventory) {
-    output.missingAccessories = await getMissingAccessories(items.accessory_ids);
+    output.missingAccessories = getMissingAccessories(items.accessory_ids);
   }
 
   if (!userProfile.pets) {
@@ -1490,15 +1490,14 @@ export async function getStats(
   userProfile.pets.push(...items.pets);
 
   output.pets = await getPets(userProfile);
-  output.missingPets = await getMissingPets(output.pets, profile.game_mode);
-  output.petScore = await getPetScore(output.pets);
+  output.missingPets = getMissingPets(output.pets, profile.game_mode);
+  output.petScore = getPetScore(output.pets);
 
   const petScoreRequired = Object.keys(constants.PET_REWARDS).sort((a, b) => parseInt(b) - parseInt(a));
 
   output.pet_bonus = {};
 
-  // eslint-disable-next-line no-unused-vars
-  for (const [index, score] of petScoreRequired.entries()) {
+  for (const score of petScoreRequired) {
     if (parseInt(score) > output.petScore) {
       continue;
     }
@@ -1692,9 +1691,9 @@ export async function getStats(
   output.collections = await getCollections(profile.uuid, profile, options.cacheOnly);
   output.social = hypixelProfile.socials;
 
-  output.dungeons = await getDungeons(userProfile, hypixelProfile);
+  output.dungeons = getDungeons(userProfile, hypixelProfile);
 
-  output.essence = await getEssence(userProfile, hypixelProfile);
+  output.essence = getEssence(userProfile, hypixelProfile);
 
   output.fishing = {
     total: userProfile.stats.items_fished || 0,
@@ -1959,7 +1958,7 @@ export async function getStats(
     }
   }
 
-  misc.profile_upgrades = await getProfileUpgrades(profile);
+  misc.profile_upgrades = getProfileUpgrades(profile);
 
   const auctions_buy = ["auctions_bids", "auctions_highest_bid", "auctions_won", "auctions_gold_spent"];
   const auctions_sell = ["auctions_fees", "auctions_gold_earned"];
@@ -2206,6 +2205,7 @@ export async function getPets(profile) {
     pet.rarity = pet.tier.toLowerCase();
     pet.stats = {};
     pet.ignoresTierBoost = petData.ignoresTierBoost;
+    /** @type {string[]} */
     const lore = [];
 
     // Rarity upgrades
@@ -2385,8 +2385,7 @@ export async function getPets(profile) {
 
     pet.lore = "";
 
-    // eslint-disable-next-line no-unused-vars
-    for (const [index, line] of lore.entries()) {
+    for (const line of lore) {
       pet.lore += '<span class="lore-row wrap">' + helper.renderLore(line) + "</span>";
     }
 
@@ -2431,7 +2430,7 @@ export async function getPets(profile) {
   return output;
 }
 
-async function getMissingPets(pets, gameMode) {
+function getMissingPets(pets, gameMode) {
   const profile = {
     pets: [],
   };
@@ -2476,7 +2475,7 @@ async function getMissingPets(pets, gameMode) {
   return getPets(profile);
 }
 
-async function getPetScore(pets) {
+function getPetScore(pets) {
   const highestRarity = {};
 
   for (const pet of pets) {
@@ -2488,7 +2487,7 @@ async function getPetScore(pets) {
   return Object.values(highestRarity).reduce((a, b) => a + b, 0);
 }
 
-async function getMissingAccessories(accessories) {
+function getMissingAccessories(accessories) {
   const unique = Object.keys(constants.ACCESSORIES);
   unique.forEach((name) => {
     if (name in constants.ACCESSORY_DUPLICATES) {
@@ -2614,7 +2613,7 @@ export async function getCollections(uuid, profile, cacheOnly = false) {
   return output;
 }
 
-export async function getDungeons(userProfile, hypixelProfile) {
+export function getDungeons(userProfile, hypixelProfile) {
   const output = {};
 
   const dungeons = userProfile.dungeons;
@@ -2761,11 +2760,11 @@ export async function getDungeons(userProfile, hypixelProfile) {
       continue;
     }
 
-    for (const reward_id in coll.rewards) {
-      const reward = coll.rewards[reward_id];
+    for (const rewardId in coll.rewards) {
+      const reward = coll.rewards[rewardId];
       if (collections[coll_id].killed >= reward.required) {
         collections[coll_id].tier = reward.tier;
-        if (reward_id != "coming_soon") collections[coll_id].unclaimed++;
+        if (rewardId != "coming_soon") collections[coll_id].unclaimed++;
       } else {
         break;
       }
@@ -2883,7 +2882,8 @@ export async function getDungeons(userProfile, hypixelProfile) {
   return output;
 }
 
-async function getEssence(userProfile, hypixelProfile) {
+function getEssence(userProfile, hypixelProfile) {
+  /** @type {{[key:string]: number}} */
   const output = {};
 
   for (const essence in constants.ESSENCE) {
@@ -3122,7 +3122,7 @@ async function getForge(userProfile) {
   return output;
 }
 
-async function getProfileUpgrades(profile) {
+function getProfileUpgrades(profile) {
   const output = {};
   for (const upgrade in constants.PROFILE_UPGRADES) {
     output[upgrade] = 0;
@@ -3135,12 +3135,12 @@ async function getProfileUpgrades(profile) {
   return output;
 }
 
-export const getProfile = async (
+export async function getProfile(
   db,
   paramPlayer,
   paramProfile,
   options = { cacheOnly: false, debugId: `${helper.getClusterId()}/unknown@getProfile` }
-) => {
+) {
   console.debug(`${options.debugId}: getProfile called.`);
   const timeStarted = Date.now();
 
@@ -3282,8 +3282,7 @@ export const getProfile = async (
 
   const profiles = [];
 
-  // eslint-disable-next-line no-unused-vars
-  for (const [index, profile] of skyBlockProfiles.entries()) {
+  for (const profile of skyBlockProfiles) {
     let memberCount = 0;
 
     for (const member in profile.members) {
@@ -3348,8 +3347,7 @@ export const getProfile = async (
     }
   }
 
-  // eslint-disable-next-line no-unused-vars
-  for (const [index, _profile] of profiles.entries()) {
+  for (const _profile of profiles) {
     if (_profile === undefined || _profile === null) {
       return;
     }
@@ -3417,7 +3415,7 @@ export const getProfile = async (
 
   console.debug(`${options.debugId}: getProfile returned. (${Date.now() - timeStarted}ms)`);
   return { profile: profile, allProfiles: allSkyBlockProfiles, uuid: paramPlayer };
-};
+}
 
 async function updateLeaderboardPositions(db, uuid, allProfiles) {
   if (constants.BLOCKED_PLAYERS.includes(uuid)) {
@@ -3541,11 +3539,11 @@ async function updateLeaderboardPositions(db, uuid, allProfiles) {
         break;
       default:
         for (const floor of getAllKeys(memberProfiles, "data", "dungeons", "dungeon_types", "catacombs", stat)) {
-          const floor_id = `catacombs_${floor}`;
-          if (!constants.DUNGEONS.floors[floor_id] || !constants.DUNGEONS.floors[floor_id].name) continue;
+          const floorId = `catacombs_${floor}`;
+          if (!constants.DUNGEONS.floors[floorId] || !constants.DUNGEONS.floors[floorId].name) continue;
 
-          const floor_name = constants.DUNGEONS.floors[floor_id].name;
-          values[`dungeons_catacombs_${floor_name}_${stat}`] = getMax(
+          const floorName = constants.DUNGEONS.floors[floorId].name;
+          values[`dungeons_catacombs_${floorName}_${stat}`] = getMax(
             memberProfiles,
             "data",
             "dungeons",
@@ -3558,13 +3556,13 @@ async function updateLeaderboardPositions(db, uuid, allProfiles) {
     }
   }
 
-  for (const dungeon_class of getAllKeys(memberProfiles, "data", "dungeons", "player_classes")) {
-    values[`dungeons_class_${dungeon_class}_xp`] = getMax(
+  for (const dungeonClass of getAllKeys(memberProfiles, "data", "dungeons", "player_classes")) {
+    values[`dungeons_class_${dungeonClass}_xp`] = getMax(
       memberProfiles,
       "data",
       "dungeons",
       "player_classes",
-      dungeon_class,
+      dungeonClass,
       "experience"
     );
   }

--- a/src/lib.js
+++ b/src/lib.js
@@ -439,7 +439,7 @@ async function processItems(base64, customTextures = false, packs, cacheOnly = f
 
     // Set custom texture for colored potions
     if (item.id == 373) {
-      const color = constants.potionColors[item.Damage % 16];
+      const color = constants.POTION_COLORS[item.Damage % 16];
 
       const type = item.Damage & 16384 ? "splash" : "normal";
 
@@ -1094,7 +1094,7 @@ export const getItems = async (
 
   const itemSorter = (a, b) => {
     if (a.rarity !== b.rarity) {
-      return constants.rarities.indexOf(b.rarity) - constants.rarities.indexOf(a.rarity);
+      return constants.RARITIES.indexOf(b.rarity) - constants.RARITIES.indexOf(a.rarity);
     }
 
     if (b.inBackpack && !a.inBackpack) {
@@ -1249,7 +1249,7 @@ export const getItems = async (
     }
 
     output.armor_set = output_name;
-    output.armor_set_rarity = constants.rarities[Math.max(...armor.map((a) => helper.rarityNameToInt(a.rarity)))];
+    output.armor_set_rarity = constants.RARITIES[Math.max(...armor.map((a) => helper.rarityNameToInt(a.rarity)))];
   }
 
   console.debug(`${options.debugId}: getItems returned. (${Date.now() - timeStarted}ms)`);
@@ -1493,7 +1493,7 @@ export async function getStats(
   output.missingPets = await getMissingPets(output.pets, profile.game_mode);
   output.petScore = await getPetScore(output.pets);
 
-  const petScoreRequired = Object.keys(constants.pet_rewards).sort((a, b) => parseInt(b) - parseInt(a));
+  const petScoreRequired = Object.keys(constants.PET_REWARDS).sort((a, b) => parseInt(b) - parseInt(a));
 
   output.pet_bonus = {};
 
@@ -1503,7 +1503,7 @@ export async function getStats(
       continue;
     }
 
-    output.pet_score_bonus = Object.assign({}, constants.pet_rewards[score]);
+    output.pet_score_bonus = Object.assign({}, constants.PET_REWARDS[score]);
 
     break;
   }
@@ -2211,13 +2211,13 @@ export async function getPets(profile) {
     // Rarity upgrades
     if (pet.heldItem == "PET_ITEM_TIER_BOOST" && !pet.ignoresTierBoost) {
       pet.rarity =
-        constants.rarities[
-          Math.min(constants.rarities.indexOf(petData.maxTier), constants.rarities.indexOf(pet.rarity) + 1)
+        constants.RARITIES[
+          Math.min(constants.RARITIES.indexOf(petData.maxTier), constants.RARITIES.indexOf(pet.rarity) + 1)
         ];
     }
 
     if (pet.heldItem == "PET_ITEM_VAMPIRE_FANG" || pet.heldItem == "PET_ITEM_TOY_JERRY") {
-      if (constants.rarities.indexOf(pet.rarity) === constants.rarities.indexOf(petData.maxTier) - 1) {
+      if (constants.RARITIES.indexOf(pet.rarity) === constants.RARITIES.indexOf(petData.maxTier) - 1) {
         pet.rarity = petData.maxTier;
       }
     }
@@ -2268,7 +2268,7 @@ export async function getPets(profile) {
         ? petData.name[pet.rarity] ?? petData.name.default
         : helper.titleCase(pet.type.replaceAll("_", " "));
 
-    const rarity = constants.rarities.indexOf(pet.rarity);
+    const rarity = constants.RARITIES.indexOf(pet.rarity);
 
     const searchName = pet.type in constants.PET_STATS ? pet.type : "???";
     const petInstance = new constants.PET_STATS[searchName](rarity, pet.level.level, pet.extra);
@@ -2318,7 +2318,7 @@ export async function getPets(profile) {
       if (!heldItemObj) {
         heldItemObj = constants.PET_ITEMS[heldItem];
       }
-      lore.push("", `§6Held Item: §${constants.rarityColors[heldItemObj.tier.toLowerCase()]}${heldItemObj.name}`);
+      lore.push("", `§6Held Item: §${constants.RARITY_COLORS[heldItemObj.tier.toLowerCase()]}${heldItemObj.name}`);
 
       if (heldItem in constants.PET_ITEMS) {
         lore.push(constants.PET_ITEMS[heldItem].description);
@@ -2421,7 +2421,7 @@ export async function getPets(profile) {
           }
         }
       } else {
-        return constants.rarities.indexOf(a.rarity) < constants.rarities.indexOf(b.rarity) ? 1 : -1;
+        return constants.RARITIES.indexOf(a.rarity) < constants.RARITIES.indexOf(b.rarity) ? 1 : -1;
       }
     }
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -21,7 +21,7 @@ import { calculateSenitherWeight } from "./weight/senither-weight.js";
 
 const mcData = minecraftData("1.8.9");
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const Hypixel = axios.create({
+const hypixel = axios.create({
   baseURL: "https://api.hypixel.net/",
 });
 const parseNbt = util.promisify(nbt.parse);
@@ -64,15 +64,15 @@ function getAllKeys(profiles, ...path) {
 function getXpTable(type) {
   switch (type) {
     case "runecrafting":
-      return constants.runecrafting_xp;
+      return constants.RUNECRAFTING_XP;
     case "social":
-      return constants.social_xp;
+      return constants.SOCIAL_XP;
     case "dungeoneering":
-      return constants.dungeoneering_xp;
+      return constants.DUNGEONEERING_XP;
     case "hotm":
-      return constants.hotm_xp;
+      return constants.HOTM_XP;
     default:
-      return constants.leveling_xp;
+      return constants.LEVELING_XP;
   }
 }
 
@@ -93,10 +93,10 @@ function getXpByLevel(uncappedLevel, extra = {}) {
 
   /** the level that this player is caped at */
   const levelCap =
-    extra.cap ?? constants.default_skill_caps[extra.skill] ?? Math.max(...Object.keys(xpTable).map((a) => Number(a)));
+    extra.cap ?? constants.DEFAULT_SKILL_CAPS[extra.skill] ?? Math.max(...Object.keys(xpTable).map((a) => Number(a)));
 
   /** the maximum level that any player can achieve (used for gold progress bars) */
-  const maxLevel = constants.maxed_skill_caps[extra.skill] ?? levelCap;
+  const maxLevel = constants.MAXED_SKILL_CAPS[extra.skill] ?? levelCap;
 
   /** the amount of xp over the amount required for the level (used for calculation progress to next level) */
   const xpCurrent = 0;
@@ -150,10 +150,10 @@ export function getLevelByXp(xp, extra = {}) {
 
   /** the level that this player is caped at */
   const levelCap =
-    extra.cap ?? constants.default_skill_caps[extra.skill] ?? Math.max(...Object.keys(xpTable).map((a) => Number(a)));
+    extra.cap ?? constants.DEFAULT_SKILL_CAPS[extra.skill] ?? Math.max(...Object.keys(xpTable).map((a) => Number(a)));
 
   /** the maximum level that any player can achieve (used for gold progress bars) */
-  const maxLevel = constants.maxed_skill_caps[extra.skill] ?? levelCap;
+  const maxLevel = constants.MAXED_SKILL_CAPS[extra.skill] ?? levelCap;
 
   /** the level ignoring the cap and using only the table */
   let uncappedLevel = 0;
@@ -211,7 +211,7 @@ function getSlayerLevel(slayer, slayerName) {
   let progress = 0;
   let xpForNext = 0;
 
-  const maxLevel = Math.max(...Object.keys(constants.slayer_xp[slayerName]));
+  const maxLevel = Math.max(...Object.keys(constants.SLAYER_XP[slayerName]));
 
   for (const level_name in claimed_levels) {
     // Ignoring legacy levels for zombie
@@ -227,7 +227,7 @@ function getSlayerLevel(slayer, slayerName) {
   }
 
   if (currentLevel < maxLevel) {
-    const nextLevel = constants.slayer_xp[slayerName][currentLevel + 1];
+    const nextLevel = constants.SLAYER_XP[slayerName][currentLevel + 1];
 
     progress = xp / nextLevel;
     xpForNext = nextLevel;
@@ -239,8 +239,8 @@ function getSlayerLevel(slayer, slayerName) {
 }
 
 function getPetLevel(petExp, offsetRarity, maxLevel) {
-  const rarityOffset = constants.pet_rarity_offset[offsetRarity];
-  const levels = constants.pet_levels.slice(rarityOffset, rarityOffset + maxLevel - 1);
+  const rarityOffset = constants.PET_RARITY_OFFSET[offsetRarity];
+  const levels = constants.PET_LEVELS.slice(rarityOffset, rarityOffset + maxLevel - 1);
 
   const xpMaxLevel = levels.reduce((a, b) => a + b, 0);
   let xpTotal = 0;
@@ -475,8 +475,8 @@ async function processItems(base64, customTextures = false, packs, cacheOnly = f
     }
 
     // Uses animated skin texture
-    if (item?.extra?.skin != undefined && constants.animated_items?.[item.extra.skin]) {
-      item.texture_path = constants.animated_items[item.extra.skin].texture;
+    if (item?.extra?.skin != undefined && constants.ANIMATED_ITEMS?.[item.extra.skin]) {
+      item.texture_path = constants.ANIMATED_ITEMS[item.extra.skin].texture;
     }
 
     if (item.tag?.ExtraAttributes?.skin == undefined && customTextures) {
@@ -538,7 +538,7 @@ async function processItems(base64, customTextures = false, packs, cacheOnly = f
             itemLore.push(`§8MAXED OUT!`);
           } else {
             let toNextLevel = 0;
-            for (const e of constants.expertise_kills_ladder) {
+            for (const e of constants.EXPERTISE_KILLS_LADDER) {
               if (expertise_kills < e) {
                 toNextLevel = e - expertise_kills;
                 break;
@@ -558,7 +558,7 @@ async function processItems(base64, customTextures = false, packs, cacheOnly = f
             itemLore.push(`§8MAXED OUT!`);
           } else {
             let toNextLevel = 0;
-            for (const e of constants.prehistoric_egg_blocks_walked_ladder) {
+            for (const e of constants.PREHISTORIC_EGG_BLOCKS_WALKED_LADDER) {
               if (blocks_walked < e) {
                 toNextLevel = e - blocks_walked;
                 break;
@@ -648,16 +648,16 @@ function getMinions(coopMembers) {
 
     if (minion == undefined) {
       minions.push(
-        Object.assign({ id: minionName, maxLevel: 0, levels: [minionLevel] }, constants.minions[minionName])
+        Object.assign({ id: minionName, maxLevel: 0, levels: [minionLevel] }, constants.MINIONS[minionName])
       );
     } else {
       minion.levels.push(minionLevel);
     }
   }
 
-  for (const minion in constants.minions) {
+  for (const minion in constants.MINIONS) {
     if (minions.find((a) => a.id == minion) == undefined) {
-      minions.push(Object.assign({ id: minion, levels: [], maxLevel: 0 }, constants.minions[minion]));
+      minions.push(Object.assign({ id: minion, levels: [], maxLevel: 0 }, constants.MINIONS[minion]));
     }
   }
 
@@ -683,14 +683,14 @@ function getMinionSlots(minions) {
 
   const output = { currentSlots: 5, toNext: 5 };
 
-  const uniquesRequired = Object.keys(constants.minion_slots).sort((a, b) => parseInt(a) - parseInt(b));
+  const uniquesRequired = Object.keys(constants.MINION_SLOTS).sort((a, b) => parseInt(a) - parseInt(b));
 
   for (const [index, uniques] of uniquesRequired.entries()) {
     if (parseInt(uniques) <= uniqueMinions) {
       continue;
     }
 
-    output.currentSlots = constants.minion_slots[uniquesRequired[index - 1]];
+    output.currentSlots = constants.MINION_SLOTS[uniquesRequired[index - 1]];
     output.toNextSlot = uniquesRequired[index] - uniqueMinions;
     break;
   }
@@ -749,8 +749,8 @@ export const getItems = async (
 
   let storage = [];
   if (profile.backpack_contents) {
-    const storage_size = Math.max(18, Object.keys(profile.backpack_contents).length);
-    for (let slot = 0; slot < storage_size; slot++) {
+    const storageSize = Math.max(18, Object.keys(profile.backpack_contents).length);
+    for (let slot = 0; slot < storageSize; slot++) {
       storage.push({});
 
       if (profile.backpack_contents[slot] && profile.backpack_icons[slot]) {
@@ -768,9 +768,9 @@ export const getItems = async (
           item.item_index = index;
         }
 
-        const storage_unit = icon[0];
-        storage_unit.containsItems = items;
-        storage[slot] = storage_unit;
+        const storageUnit = icon[0];
+        storageUnit.containsItems = items;
+        storage[slot] = storageUnit;
       }
     }
   }
@@ -814,7 +814,7 @@ export const getItems = async (
   output.storage = storage;
   output.hotm = hotm;
 
-  const all_items = armor.concat(
+  const allItems = armor.concat(
     inventory,
     enderchest,
     accessory_bag,
@@ -827,7 +827,7 @@ export const getItems = async (
     hotm
   );
 
-  for (const [index, item] of all_items.entries()) {
+  for (const [index, item] of allItems.entries()) {
     item.item_index = index;
     item.itemId = v4("itemId");
 
@@ -845,15 +845,15 @@ export const getItems = async (
   hotm = hotm.map((a) => Object.assign({ isInactive: true }, a));
 
   // Add candy bag contents as backpack contents to candy bag
-  for (const item of all_items) {
+  for (const item of allItems) {
     if (helper.getId(item) == "TRICK_OR_TREAT_BAG") {
       item.containsItems = candy_bag;
     }
   }
 
   const accessories = [];
-  const accessory_ids = [];
-  const accessory_rarities = {
+  const accessoryIds = [];
+  const accessoryRarities = {
     common: 0,
     uncommon: 0,
     rare: 0,
@@ -884,7 +884,7 @@ export const getItems = async (
     }
 
     accessories.push(insertAccessory);
-    accessory_ids.push(id);
+    accessoryIds.push(id);
   }
 
   // Add accessories from inventory
@@ -906,7 +906,7 @@ export const getItems = async (
     }
 
     accessories.push(insertAccessory);
-    accessory_ids.push(id);
+    accessoryIds.push(id);
   }
 
   // Add accessories from accessory bag if not already in inventory
@@ -928,10 +928,10 @@ export const getItems = async (
     }
 
     accessories.push(insertAccessory);
-    accessory_ids.push(id);
-    accessory_rarities[insertAccessory.rarity]++;
+    accessoryIds.push(id);
+    accessoryRarities[insertAccessory.rarity]++;
     if (id == "HEGEMONY_ARTIFACT") {
-      accessory_rarities.hegemony = { rarity: insertAccessory.rarity };
+      accessoryRarities.hegemony = { rarity: insertAccessory.rarity };
     }
   }
 
@@ -958,7 +958,7 @@ export const getItems = async (
       }
 
       accessories.push(insertAccessory);
-      accessory_ids.push(id);
+      accessoryIds.push(id);
     }
   }
 
@@ -980,7 +980,7 @@ export const getItems = async (
         accessory.isInactive = true;
       }
 
-      accessory_ids.splice(accessory_ids.indexOf(id), 1, `CAMPFIRE_TALISMAN_${maxTier}`);
+      accessoryIds.splice(accessoryIds.indexOf(id), 1, `CAMPFIRE_TALISMAN_${maxTier}`);
     }
 
     if (id.startsWith("WEDDING_RING_")) {
@@ -997,11 +997,11 @@ export const getItems = async (
         accessory.isInactive = true;
       }
 
-      accessory_ids.splice(accessory_ids.indexOf(id), 1, `WEDDING_RING_${maxTier}`);
+      accessoryIds.splice(accessoryIds.indexOf(id), 1, `WEDDING_RING_${maxTier}`);
     }
 
-    if (id in constants.accessory_upgrades) {
-      const accessoryUpgrades = constants.accessory_upgrades[id];
+    if (id in constants.ACCESSORY_UPGRADES) {
+      const accessoryUpgrades = constants.ACCESSORY_UPGRADES[id];
 
       if (accessories.find((a) => !a.isInactive && accessoryUpgrades.includes(helper.getId(a))) != undefined) {
         accessory.isInactive = true;
@@ -1012,8 +1012,8 @@ export const getItems = async (
       }
     }
 
-    if (id in constants.accessory_duplicates) {
-      const accessoryDuplicates = constants.accessory_duplicates[id];
+    if (id in constants.ACCESSORY_DUPLICATES) {
+      const accessoryDuplicates = constants.ACCESSORY_DUPLICATES[id];
 
       if (accessories.find((a) => accessoryDuplicates.includes(helper.getId(a))) != undefined) {
         accessory.isUnique = false;
@@ -1035,15 +1035,15 @@ export const getItems = async (
   }
 
   output.accessories = accessories;
-  output.accessory_ids = accessory_ids;
-  output.accessory_rarities = accessory_rarities;
+  output.accessory_ids = accessoryIds;
+  output.accessory_rarities = accessoryRarities;
 
-  output.weapons = all_items.filter((a) => a.categories?.includes("weapon"));
-  output.farming_tools = all_items.filter((a) => a.categories?.includes("farming_tool"));
-  output.mining_tools = all_items.filter((a) => a.categories?.includes("mining_tool"));
-  output.fishing_tools = all_items.filter((a) => a.categories?.includes("fishing_tool"));
+  output.weapons = allItems.filter((a) => a.categories?.includes("weapon"));
+  output.farming_tools = allItems.filter((a) => a.categories?.includes("farming_tool"));
+  output.mining_tools = allItems.filter((a) => a.categories?.includes("mining_tool"));
+  output.fishing_tools = allItems.filter((a) => a.categories?.includes("fishing_tool"));
 
-  output.pets = all_items
+  output.pets = allItems
     .filter((a) => a.tag?.ExtraAttributes?.petInfo)
     .map((a) => ({
       uuid: a.tag.ExtraAttributes.uuid,
@@ -1056,7 +1056,7 @@ export const getItems = async (
       skin: a.tag.ExtraAttributes.petInfo.skin || null,
     }));
 
-  for (const item of all_items) {
+  for (const item of allItems) {
     if (!Array.isArray(item.containsItems)) {
       continue;
     }
@@ -1237,7 +1237,7 @@ export const getItems = async (
     }
 
     // Handling special sets of armor (where pieces aren't named the same)
-    constants.special_sets.forEach((set) => {
+    constants.SPECIAL_SETS.forEach((set) => {
       if (armor.filter((a) => set.pieces.includes(helper.getId(a))).length == 4) {
         output_name = set.name;
       }
@@ -1303,7 +1303,7 @@ async function getLevels(userProfile, hypixelProfile, levelCaps) {
     };
 
     for (const skill in skillLevels) {
-      if (!constants.cosmetic_skills.includes(skill)) {
+      if (!constants.COSMETIC_SKILLS.includes(skill)) {
         average_level += skillLevels[skill].level + skillLevels[skill].progress;
         average_level_no_progress += skillLevels[skill].level;
 
@@ -1312,9 +1312,9 @@ async function getLevels(userProfile, hypixelProfile, levelCaps) {
     }
 
     output.average_level =
-      average_level / (Object.keys(skillLevels).length - Object.keys(constants.cosmetic_skills).length);
+      average_level / (Object.keys(skillLevels).length - Object.keys(constants.COSMETIC_SKILLS).length);
     output.average_level_no_progress =
-      average_level_no_progress / (Object.keys(skillLevels).length - Object.keys(constants.cosmetic_skills).length);
+      average_level_no_progress / (Object.keys(skillLevels).length - Object.keys(constants.COSMETIC_SKILLS).length);
     output.total_skill_xp = totalSkillXp;
 
     output.levels = Object.assign({}, skillLevels);
@@ -1376,13 +1376,13 @@ async function getLevels(userProfile, hypixelProfile, levelCaps) {
   return output;
 }
 
-export const getStats = async (
+export async function getStats(
   db,
   profile,
   allProfiles,
   items,
   options = { cacheOnly: false, debugId: `${helper.getClusterId()}/unknown@getStats` }
-) => {
+) {
   const output = {};
 
   console.debug(`${options.debugId}: getStats called.`);
@@ -1391,7 +1391,7 @@ export const getStats = async (
   const userProfile = profile.members[profile.uuid];
   const hypixelProfile = await helper.getRank(profile.uuid, db, options.cacheOnly);
 
-  output.stats = Object.assign({}, constants.base_stats);
+  output.stats = Object.assign({}, constants.BASE_STATS);
 
   // fairy souls
   if (isNaN(userProfile.fairy_souls_collected)) {
@@ -1399,7 +1399,7 @@ export const getStats = async (
   }
 
   const totalSouls =
-    profile.game_mode === "island" ? constants.fairy_souls.max.stranded : constants.fairy_souls.max.normal;
+    profile.game_mode === "island" ? constants.FAIRY_SOULS.max.stranded : constants.FAIRY_SOULS.max.normal;
 
   output.fairy_souls = {
     collected: userProfile.fairy_souls_collected,
@@ -1410,7 +1410,7 @@ export const getStats = async (
 
   // levels
   const levelCaps = {
-    farming: constants.default_skill_caps.farming + (userProfile.jacob2?.perks?.farming_level_cap || 0),
+    farming: constants.DEFAULT_SKILL_CAPS.farming + (userProfile.jacob2?.perks?.farming_level_cap || 0),
   };
 
   const { levels, average_level, average_level_no_progress, total_skill_xp, average_level_rank } = await getLevels(
@@ -1454,7 +1454,7 @@ export const getStats = async (
             slayers[slayerName].kills[tier] = slayer[property];
 
             output.slayer_coins_spent[slayerName] =
-              (output.slayer_coins_spent[slayerName] || 0) + slayer[property] * constants.slayer_cost[tier];
+              (output.slayer_coins_spent[slayerName] || 0) + slayer[property] * constants.SLAYER_COST[tier];
           }
         }
       }
@@ -1542,8 +1542,8 @@ export const getStats = async (
   for (const stat of killsDeaths) {
     const { entityId } = stat;
 
-    if (entityId in constants.mob_names) {
-      stat.entityName = constants.mob_names[entityId];
+    if (entityId in constants.MOB_NAMES) {
+      stat.entityName = constants.MOB_NAMES[entityId];
       continue;
     }
 
@@ -1647,14 +1647,12 @@ export const getStats = async (
       continue;
     }
 
-    const last_updated = profile.members[member.uuid].last_save;
+    const lastUpdated = profile.members[member.uuid].last_save;
 
     member.last_updated = {
-      unix: last_updated,
+      unix: lastUpdated,
       text:
-        Date.now() - last_updated < 7 * 60 * 1000
-          ? "currently online"
-          : `last played ${moment(last_updated).fromNow()}`,
+        Date.now() - lastUpdated < 7 * 60 * 1000 ? "currently online" : `last played ${moment(lastUpdated).fromNow()}`,
     };
   }
 
@@ -1741,8 +1739,8 @@ export const getStats = async (
     // Things about individual crops
     farming.crops = {};
 
-    for (const crop in constants.farming_crops) {
-      farming.crops[crop] = constants.farming_crops[crop];
+    for (const crop in constants.FARMING_CROPS) {
+      farming.crops[crop] = constants.FARMING_CROPS[crop];
 
       Object.assign(farming.crops[crop], {
         attended: false,
@@ -1763,12 +1761,12 @@ export const getStats = async (
       all_contests: [],
     };
 
-    for (const contest_id in userProfile.jacob2.contests) {
-      const data = userProfile.jacob2.contests[contest_id];
+    for (const contestId in userProfile.jacob2.contests) {
+      const data = userProfile.jacob2.contests[contestId];
 
-      const contest_name = contest_id.split(":");
-      const date = `${contest_name[1]}_${contest_name[0]}`;
-      const crop = contest_name.slice(2).join(":");
+      const contestName = contestId.split(":");
+      const date = `${contestName[1]}_${contestName[0]}`;
+      const crop = contestName.slice(2).join(":");
 
       farming.crops[crop].contests++;
       farming.crops[crop].attended = true;
@@ -1831,56 +1829,56 @@ export const getStats = async (
   };
 
   if (enchanting.experimented) {
-    const enchanting_data = userProfile.experimentation;
+    const enchantingData = userProfile.experimentation;
 
-    for (const game in constants.experiments.games) {
-      if (enchanting_data[game] == null) continue;
-      if (!Object.keys(enchanting_data[game]).length >= 1) {
+    for (const game in constants.EXPERIMENTS.games) {
+      if (enchantingData[game] == null) continue;
+      if (!Object.keys(enchantingData[game]).length >= 1) {
         continue;
       }
 
-      const game_data = enchanting_data[game];
-      const game_constants = constants.experiments.games[game];
+      const gameData = enchantingData[game];
+      const gameConstants = constants.EXPERIMENTS.games[game];
 
-      const game_output = {
-        name: game_constants.name,
+      const gameOutput = {
+        name: gameConstants.name,
         stats: {},
         tiers: {},
       };
 
-      for (const key in game_data) {
+      for (const key in gameData) {
         if (key.startsWith("attempts") || key.startsWith("claims") || key.startsWith("best_score")) {
           let statKey = key.split("_");
           const tierValue = statKey.pop();
 
           statKey = statKey.join("_");
-          const tierInfo = _.cloneDeep(constants.experiments.tiers[tierValue]);
+          const tierInfo = _.cloneDeep(constants.EXPERIMENTS.tiers[tierValue]);
 
-          if (!game_output.tiers[tierValue]) {
-            game_output.tiers[tierValue] = tierInfo;
+          if (!gameOutput.tiers[tierValue]) {
+            gameOutput.tiers[tierValue] = tierInfo;
           }
 
-          Object.assign(game_output.tiers[tierValue], {
-            [statKey]: game_data[key],
+          Object.assign(gameOutput.tiers[tierValue], {
+            [statKey]: gameData[key],
           });
           continue;
         }
 
         if (key == "last_attempt" || key == "last_claimed") {
-          if (game_data[key] <= 0) continue;
-          const last_time = {
-            unix: game_data[key],
-            text: moment(game_data[key]).fromNow(),
+          if (gameData[key] <= 0) continue;
+          const lastTime = {
+            unix: gameData[key],
+            text: moment(gameData[key]).fromNow(),
           };
 
-          game_output.stats[key] = last_time;
+          gameOutput.stats[key] = lastTime;
           continue;
         }
 
-        game_output.stats[key] = game_data[key];
+        gameOutput.stats[key] = gameData[key];
       }
 
-      enchanting.experiments[game] = game_output;
+      enchanting.experiments[game] = gameOutput;
     }
 
     if (!Object.keys(enchanting.experiments).length >= 1) {
@@ -1900,9 +1898,9 @@ export const getStats = async (
 
   for (const key of userProfile.tutorial) {
     if (key.startsWith("commission_milestone_reward_mining_xp_tier_")) {
-      const milestone_tier = key.slice(43);
-      if (mining.commissions.milestone < milestone_tier) {
-        mining.commissions.milestone = milestone_tier;
+      const milestoneTier = key.slice(43);
+      if (mining.commissions.milestone < milestoneTier) {
+        mining.commissions.milestone = milestoneTier;
       }
     } else {
       continue;
@@ -1987,7 +1985,7 @@ export const getStats = async (
     if (key.includes("complete_the_")) {
       const isCompleted = userProfile.objectives[key].status == "COMPLETE";
       const tierNumber = parseInt("" + key.charAt(key.length - 1)) ?? 0;
-      const raceName = constants.raceObjectiveToStatName[key.substring(0, key.length - 2)];
+      const raceName = constants.RACE_OBJECTIVE_TO_STAT_NAME[key.substring(0, key.length - 2)];
 
       if (tierNumber == 1 && !isCompleted) {
         misc.objectives.completedRaces[raceName] = 0;
@@ -2108,13 +2106,13 @@ export const getStats = async (
   output.auctions_bought = auctions_bought;
   output.auctions_sold = auctions_sold;
 
-  const last_updated = userProfile.last_save;
-  const first_join = userProfile.first_join;
+  const lastUpdated = userProfile.last_save;
+  const firstJoin = userProfile.first_join;
 
-  const diff = (+new Date() - last_updated) / 1000;
+  const diff = (+new Date() - lastUpdated) / 1000;
 
-  let last_updated_text = moment(last_updated).fromNow();
-  const first_join_text = moment(first_join).fromNow();
+  let lastUpdatedText = moment(lastUpdated).fromNow();
+  const firstJoinText = moment(firstJoin).fromNow();
 
   if ("current_area" in userProfile) {
     output.current_area = userProfile.current_area;
@@ -2125,19 +2123,19 @@ export const getStats = async (
   }
 
   if (diff < 3) {
-    last_updated_text = `Right now`;
+    lastUpdatedText = `Right now`;
   } else if (diff < 60) {
-    last_updated_text = `${Math.floor(diff)} seconds ago`;
+    lastUpdatedText = `${Math.floor(diff)} seconds ago`;
   }
 
   output.last_updated = {
-    unix: last_updated,
-    text: last_updated_text,
+    unix: lastUpdated,
+    text: lastUpdatedText,
   };
 
   output.first_join = {
-    unix: first_join,
-    text: first_join_text,
+    unix: firstJoin,
+    text: firstJoinText,
   };
 
   /*
@@ -2156,29 +2154,29 @@ export const getStats = async (
     century cake effects
 
   */
-  const century_cakes = [];
+  const centuryCakes = [];
 
   if (userProfile.temp_stat_buffs) {
     for (const cake of userProfile.temp_stat_buffs) {
       if (!cake.key.startsWith("cake_")) continue;
       let stat = cake.key.replace("cake_", "");
-      if (Object.keys(constants.stat_mappings).includes(stat)) {
-        stat = constants.stat_mappings[stat];
+      if (Object.keys(constants.STAT_MAPPINGS).includes(stat)) {
+        stat = constants.STAT_MAPPINGS[stat];
       }
-      century_cakes.push({
+      centuryCakes.push({
         stat: stat == "walk_speed" ? "speed" : stat,
         amount: cake.amount,
       });
     }
   }
 
-  output.century_cakes = century_cakes;
+  output.century_cakes = centuryCakes;
 
   output.reaper_peppers_eaten = userProfile.reaper_peppers_eaten ?? 0;
 
   console.debug(`${options.debugId}: getStats returned. (${Date.now() - timeStarted}ms)`);
   return output;
-};
+}
 
 export async function getPets(profile) {
   let output = [];
@@ -2195,7 +2193,7 @@ export async function getPets(profile) {
       continue;
     }
 
-    const petData = constants.pet_data[pet.type] || {
+    const petData = constants.PET_DATA[pet.type] ?? {
       head: "/head/bc8ea1f51f253ff5142ca11ae45193a4ad8c3ab5e9c6eec8ba7a4fcb7bac40",
       type: "???",
       maxTier: "LEGENDARY",
@@ -2238,9 +2236,9 @@ export async function getPets(profile) {
     }
 
     let petSkin = null;
-    if (pet.skin && constants.pet_skins?.[`PET_SKIN_${pet.skin}`]) {
-      pet.texture_path = constants.pet_skins[`PET_SKIN_${pet.skin}`].texture;
-      petSkin = constants.pet_skins[`PET_SKIN_${pet.skin}`].name;
+    if (pet.skin && constants.PET_SKINS?.[`PET_SKIN_${pet.skin}`]) {
+      pet.texture_path = constants.PET_SKINS[`PET_SKIN_${pet.skin}`].texture;
+      petSkin = constants.PET_SKINS[`PET_SKIN_${pet.skin}`].name;
     }
 
     // Get first row of lore
@@ -2272,8 +2270,8 @@ export async function getPets(profile) {
 
     const rarity = constants.rarities.indexOf(pet.rarity);
 
-    const searchName = pet.type in constants.petStats ? pet.type : "???";
-    const petInstance = new constants.petStats[searchName](rarity, pet.level.level, pet.extra);
+    const searchName = pet.type in constants.PET_STATS ? pet.type : "???";
+    const petInstance = new constants.PET_STATS[searchName](rarity, pet.level.level, pet.extra);
     pet.stats = Object.assign({}, petInstance.stats);
     pet.ref = petInstance;
 
@@ -2281,22 +2279,22 @@ export async function getPets(profile) {
       const { heldItem } = pet;
       let heldItemObj = await db.collection("items").findOne({ id: heldItem });
 
-      if (heldItem in constants.pet_items) {
-        for (const stat in constants.pet_items[heldItem]?.stats) {
-          pet.stats[stat] = (pet.stats[stat] || 0) + constants.pet_items[heldItem].stats[stat];
+      if (heldItem in constants.PET_ITEMS) {
+        for (const stat in constants.PET_ITEMS[heldItem]?.stats) {
+          pet.stats[stat] = (pet.stats[stat] || 0) + constants.PET_ITEMS[heldItem].stats[stat];
         }
-        for (const stat in constants.pet_items[heldItem]?.statsPerLevel) {
+        for (const stat in constants.PET_ITEMS[heldItem]?.statsPerLevel) {
           pet.stats[stat] =
-            (pet.stats[stat] || 0) + constants.pet_items[heldItem].statsPerLevel[stat] * pet.level.level;
+            (pet.stats[stat] || 0) + constants.PET_ITEMS[heldItem].statsPerLevel[stat] * pet.level.level;
         }
-        for (const stat in constants.pet_items[heldItem]?.multStats) {
+        for (const stat in constants.PET_ITEMS[heldItem]?.multStats) {
           if (pet.stats[stat]) {
-            pet.stats[stat] = (pet.stats[stat] || 0) * constants.pet_items[heldItem].multStats[stat];
+            pet.stats[stat] = (pet.stats[stat] || 0) * constants.PET_ITEMS[heldItem].multStats[stat];
           }
         }
-        if ("multAllStats" in constants.pet_items[heldItem]) {
+        if ("multAllStats" in constants.PET_ITEMS[heldItem]) {
           for (const stat in pet.stats) {
-            pet.stats[stat] *= constants.pet_items[heldItem].multAllStats;
+            pet.stats[stat] *= constants.PET_ITEMS[heldItem].multAllStats;
           }
         }
       }
@@ -2318,12 +2316,12 @@ export async function getPets(profile) {
 
       // now we push the lore of the held items
       if (!heldItemObj) {
-        heldItemObj = constants.pet_items[heldItem];
+        heldItemObj = constants.PET_ITEMS[heldItem];
       }
       lore.push("", `§6Held Item: §${constants.rarityColors[heldItemObj.tier.toLowerCase()]}${heldItemObj.name}`);
 
-      if (heldItem in constants.pet_items) {
-        lore.push(constants.pet_items[heldItem].description);
+      if (heldItem in constants.PET_ITEMS) {
+        lore.push(constants.PET_ITEMS[heldItem].description);
       }
       // extra line
       lore.push(" ");
@@ -2440,9 +2438,9 @@ async function getMissingPets(pets, gameMode) {
 
   const missingPets = [];
 
-  const ownedPetTypes = pets.map((pet) => constants.pet_data[pet.type].typeGroup ?? pet.type);
+  const ownedPetTypes = pets.map((pet) => constants.PET_DATA[pet.type].typeGroup ?? pet.type);
 
-  for (const [petType, petData] of Object.entries(constants.pet_data)) {
+  for (const [petType, petData] of Object.entries(constants.PET_DATA)) {
     if (
       ownedPetTypes.includes(petData.typeGroup ?? petType) ||
       (petData.bingoExclusive === true && gameMode !== "bingo")
@@ -2456,8 +2454,8 @@ async function getMissingPets(pets, gameMode) {
     missingPets[key].push({
       type: petType,
       active: false,
-      exp: helper.getPetExp(constants.pet_data[petType].maxTier, constants.pet_data[petType].maxLevel),
-      tier: constants.pet_data[petType].maxTier,
+      exp: helper.getPetExp(constants.PET_DATA[petType].maxTier, constants.PET_DATA[petType].maxLevel),
+      tier: constants.PET_DATA[petType].maxTier,
       candyUsed: 0,
       heldItem: null,
       skin: null,
@@ -2482,8 +2480,8 @@ async function getPetScore(pets) {
   const highestRarity = {};
 
   for (const pet of pets) {
-    if (!(pet.type in highestRarity) || constants.pet_value[pet.rarity] > highestRarity[pet.type]) {
-      highestRarity[pet.type] = constants.pet_value[pet.rarity];
+    if (!(pet.type in highestRarity) || constants.PET_VALUE[pet.rarity] > highestRarity[pet.type]) {
+      highestRarity[pet.type] = constants.PET_VALUE[pet.rarity];
     }
   }
 
@@ -2491,10 +2489,10 @@ async function getPetScore(pets) {
 }
 
 async function getMissingAccessories(accessories) {
-  const unique = Object.keys(constants.accessories);
+  const unique = Object.keys(constants.ACCESSORIES);
   unique.forEach((name) => {
-    if (name in constants.accessory_duplicates) {
-      for (const duplicate of constants.accessory_duplicates[name]) {
+    if (name in constants.ACCESSORY_DUPLICATES) {
+      for (const duplicate of constants.ACCESSORY_DUPLICATES[name]) {
         if (accessories.includes(duplicate)) {
           accessories[accessories.indexOf(duplicate)] = name;
           break;
@@ -2505,9 +2503,9 @@ async function getMissingAccessories(accessories) {
 
   let missing = unique.filter((accessory) => !accessories.includes(accessory));
   missing.forEach((name) => {
-    if (name in constants.accessory_upgrades) {
+    if (name in constants.ACCESSORY_UPGRADES) {
       //if the name is in the upgrades list
-      for (const upgrade of constants.accessory_upgrades[name]) {
+      for (const upgrade of constants.ACCESSORY_UPGRADES[name]) {
         if (accessories.includes(upgrade)) {
           //if accessories list includes the upgrade
           missing = missing.filter((item) => item !== name);
@@ -2529,8 +2527,8 @@ async function getMissingAccessories(accessories) {
     object.name ??= accessory;
 
     // MAIN ACCESSORIES
-    if (constants.accessories[accessory] != null) {
-      const data = constants.accessories[accessory];
+    if (constants.ACCESSORIES[accessory] != null) {
+      const data = constants.ACCESSORIES[accessory];
 
       object.texture_path = data.texture || null;
       object.display_name = data.name || null;
@@ -2547,7 +2545,7 @@ async function getMissingAccessories(accessories) {
 
     let includes = false;
 
-    for (const array of Object.values(constants.accessory_upgrades)) {
+    for (const array of Object.values(constants.ACCESSORY_UPGRADES)) {
       if (array.includes(accessory)) {
         includes = true;
       }
@@ -2604,7 +2602,7 @@ export async function getCollections(uuid, profile, cacheOnly = false) {
       output[type] = { tier, amount, totalAmount, amounts };
     }
 
-    const collectionData = constants.collection_data.find((a) => a.skyblockId == type);
+    const collectionData = constants.COLLECTION_DATA.find((a) => a.skyblockId == type);
 
     for (const tier of collectionData?.tiers ?? []) {
       if (totalAmount >= tier.amountRequired) {
@@ -2622,7 +2620,7 @@ export async function getDungeons(userProfile, hypixelProfile) {
   const dungeons = userProfile.dungeons;
   if (dungeons == null || Object.keys(dungeons).length === 0) return output;
 
-  const dungeons_data = constants.dungeons;
+  const dungeons_data = constants.DUNGEONS;
   if (dungeons.dungeon_types == null || Object.keys(dungeons.dungeon_types).length === 0) return output;
 
   // Main Dungeons Data
@@ -2805,7 +2803,7 @@ export async function getDungeons(userProfile, hypixelProfile) {
   output.boss_collections = collections;
 
   // Journal Entries
-  const journal_constants = constants.dungeons.journals;
+  const journal_constants = constants.DUNGEONS.journals;
   const journal_entries = dungeons.dungeon_journal.journal_entries;
   const journals = {
     pages_collected: 0,
@@ -2843,8 +2841,8 @@ export async function getDungeons(userProfile, hypixelProfile) {
   output.journals = journals;
 
   // Level Bonuses (Only Catacombs Item Boost right now)
-  for (const name in constants.dungeons.level_bonuses) {
-    const level_stats = constants.dungeons.level_bonuses[name];
+  for (const name in constants.DUNGEONS.level_bonuses) {
+    const level_stats = constants.DUNGEONS.level_bonuses[name];
     const steps = Object.keys(level_stats)
       .sort((a, b) => Number(a) - Number(b))
       .map((a) => Number(a));
@@ -2888,7 +2886,7 @@ export async function getDungeons(userProfile, hypixelProfile) {
 async function getEssence(userProfile, hypixelProfile) {
   const output = {};
 
-  for (const essence in constants.essence) {
+  for (const essence in constants.ESSENCE) {
     output[essence] = userProfile?.[`essence_${essence}`] ?? 0;
   }
 
@@ -2919,16 +2917,16 @@ function getHotmItems(userProfile, packs) {
 
   // Check for missing node classes
   for (const nodeId in nodes) {
-    if (constants.hotm.nodes[nodeId] == undefined) {
+    if (constants.HOTM.nodes[nodeId] == undefined) {
       throw new Error(`Missing Heart of the Mountain node: ${nodeId}`);
     }
   }
 
   // Processing nodes
-  for (const nodeId in constants.hotm.nodes) {
+  for (const nodeId in constants.HOTM.nodes) {
     const enabled = toggles[`toggle_${nodeId}`] ?? true;
     const level = nodes[nodeId] ?? 0;
-    const node = new constants.hotm.nodes[nodeId]({
+    const node = new constants.HOTM.nodes[nodeId]({
       level,
       enabled,
       nodes,
@@ -2952,8 +2950,8 @@ function getHotmItems(userProfile, packs) {
   }
 
   // Processing HotM tiers
-  for (let tier = 1; tier <= constants.hotm.tiers; tier++) {
-    const hotm = new constants.hotm.hotm(tier, hotmLevelData);
+  for (let tier = 1; tier <= constants.HOTM.tiers; tier++) {
+    const hotm = new constants.HOTM.hotm(tier, hotmLevelData);
 
     output[hotm.position7x9 - 1] = helper.generateItem({
       display_name: `Tier ${tier}`,
@@ -2971,7 +2969,7 @@ function getHotmItems(userProfile, packs) {
   }
 
   // Processing HotM items (stats, hc crystals, reset)
-  for (const itemClass of constants.hotm.items) {
+  for (const itemClass of constants.HOTM.items) {
     const item = new itemClass({
       resources: {
         token_of_the_mountain: mcdata.tokens,
@@ -3032,7 +3030,7 @@ function getMiningCoreData(userProfile) {
   };
 
   output.selected_pickaxe_ability = data.selected_pickaxe_ability
-    ? constants.hotm.names[data.selected_pickaxe_ability]
+    ? constants.HOTM.names[data.selected_pickaxe_ability]
     : null;
 
   output.powder = {
@@ -3101,11 +3099,11 @@ async function getForge(userProfile) {
         timeFinishedText: "",
       };
 
-      if (item.id in constants.forge_times) {
-        let forgeTime = constants.forge_times[item.id] * 60 * 1000; // convert minutes to milliseconds
+      if (item.id in constants.FORGE_TIMES) {
+        let forgeTime = constants.FORGE_TIMES[item.id] * 60 * 1000; // convert minutes to milliseconds
         const quickForge = userProfile.mining_core?.nodes?.forge_time;
         if (quickForge != null) {
-          forgeTime *= constants.quick_forge_multiplier[quickForge];
+          forgeTime *= constants.QUICK_FORGE_MULTIPLIER[quickForge];
         }
         const dbObject = await db.collection("items").findOne({ id: item.id });
 
@@ -3126,7 +3124,7 @@ async function getForge(userProfile) {
 
 async function getProfileUpgrades(profile) {
   const output = {};
-  for (const upgrade in constants.profile_upgrades) {
+  for (const upgrade in constants.PROFILE_UPGRADES) {
     output[upgrade] = 0;
   }
   if (profile.community_upgrades?.upgrade_states != undefined) {
@@ -3202,7 +3200,7 @@ export const getProfile = async (
     try {
       response = await retry(
         async () => {
-          return await Hypixel.get("skyblock/profiles", {
+          return await hypixel.get("skyblock/profiles", {
             params,
           });
         },
@@ -3253,7 +3251,7 @@ export const getProfile = async (
         skyBlockProfiles = filteredProfiles;
       } else {
         const profileResponse = await retry(async () => {
-          const response = await Hypixel.get(
+          const response = await hypixel.get(
             "skyblock/profile",
             {
               params: { key: credentials.hypixel_api_key, profile: paramProfile },
@@ -3393,14 +3391,14 @@ export const getProfile = async (
 
     if (options.updateArea && Date.now() - userProfile.last_save < 5 * 60 * 1000) {
       try {
-        const statusResponse = await Hypixel.get("status", {
+        const statusResponse = await hypixel.get("status", {
           params: { uuid: paramPlayer, key: credentials.hypixel_api_key },
         });
 
         const areaData = statusResponse.data.session;
 
         if (areaData.online && areaData.gameType == "SKYBLOCK") {
-          const areaName = constants.area_names[areaData.mode] || helper.titleCase(areaData.mode.replaceAll("_", " "));
+          const areaName = constants.AREA_NAMES[areaData.mode] || helper.titleCase(areaData.mode.replaceAll("_", " "));
 
           userProfile.current_area = areaName;
           insertProfileStore.current_area = areaName;
@@ -3422,7 +3420,7 @@ export const getProfile = async (
 };
 
 async function updateLeaderboardPositions(db, uuid, allProfiles) {
-  if (constants.blocked_players.includes(uuid)) {
+  if (constants.BLOCKED_PLAYERS.includes(uuid)) {
     return;
   }
 
@@ -3450,8 +3448,8 @@ async function updateLeaderboardPositions(db, uuid, allProfiles) {
 
       userProfile.slayer_xp = totalSlayerXp;
 
-      for (const mountMob in constants.mob_mounts) {
-        const mounts = constants.mob_mounts[mountMob];
+      for (const mountMob in constants.MOB_MOUNTS) {
+        const mounts = constants.MOB_MOUNTS[mountMob];
 
         userProfile.stats[`kills_${mountMob}`] = 0;
         userProfile.stats[`deaths_${mountMob}`] = 0;
@@ -3475,7 +3473,7 @@ async function updateLeaderboardPositions(db, uuid, allProfiles) {
           continue;
         }
 
-        maxPetRarity[pet.type] = Math.max(maxPetRarity[pet.type] || 0, constants.pet_value[pet.tier.toLowerCase()]);
+        maxPetRarity[pet.type] = Math.max(maxPetRarity[pet.type] || 0, constants.PET_VALUE[pet.tier.toLowerCase()]);
       }
 
       for (const key in maxPetRarity) {
@@ -3544,9 +3542,9 @@ async function updateLeaderboardPositions(db, uuid, allProfiles) {
       default:
         for (const floor of getAllKeys(memberProfiles, "data", "dungeons", "dungeon_types", "catacombs", stat)) {
           const floor_id = `catacombs_${floor}`;
-          if (!constants.dungeons.floors[floor_id] || !constants.dungeons.floors[floor_id].name) continue;
+          if (!constants.DUNGEONS.floors[floor_id] || !constants.DUNGEONS.floors[floor_id].name) continue;
 
-          const floor_name = constants.dungeons.floors[floor_id].name;
+          const floor_name = constants.DUNGEONS.floors[floor_id].name;
           values[`dungeons_catacombs_${floor_name}_${stat}`] = getMax(
             memberProfiles,
             "data",
@@ -3620,7 +3618,7 @@ async function init() {
     for (const itemType in response.data.collections[type].items) {
       const item = response.data.collections[type].items[itemType];
       try {
-        const collectionData = constants.collection_data.find((a) => a.skyblockId == itemType);
+        const collectionData = constants.COLLECTION_DATA.find((a) => a.skyblockId == itemType);
 
         collectionData.maxTier = item.maxTiers;
         collectionData.tiers = item.tiers;

--- a/src/main.js
+++ b/src/main.js
@@ -17,7 +17,7 @@ if (cluster.isPrimary) {
       `${Date.now()}: Worker ${w.id} died with code ${c} ${s ? `and signal ${s}` : ""} (pid:${w.process.pid})`
     );
 
-    let fw = cluster.fork();
+    const fw = cluster.fork();
     console.log(`${Date.now()}: Worker respawned with id ${fw.id} (pid:${fw.process.pid})`);
   });
 

--- a/src/routes/api/collections.js
+++ b/src/routes/api/collections.js
@@ -4,7 +4,7 @@ import express from "express";
 
 import { tableify } from "../api.js";
 import { db } from "../../mongo.js";
-import { collection_data } from "../../constants.js";
+import { COLLECTION_DATA } from "../../constants.js";
 
 const router = express.Router();
 
@@ -20,7 +20,7 @@ router.use(async (req, res, next) => {
     const collections = await lib.getCollections(uuid, profile, req.options.cacheOnly);
 
     for (const collection in collections) {
-      collections[collection].name = collection_data.find((a) => a.skyblockId == collection).name;
+      collections[collection].name = COLLECTION_DATA.find((a) => a.skyblockId == collection).name;
     }
 
     res.send(

--- a/src/routes/apiv2/coins.js
+++ b/src/routes/apiv2/coins.js
@@ -20,9 +20,9 @@ router.get("/:player/:profile", async (req, res, next) => {
     };
 
     for (const singleProfile of allProfiles) {
-      const cute_name = singleProfile.cute_name;
+      const cuteName = singleProfile.cute_name;
 
-      if (cute_name.toLowerCase() != req.params.profile.toLowerCase()) {
+      if (cuteName.toLowerCase() != req.params.profile.toLowerCase()) {
         continue;
       }
 
@@ -31,7 +31,7 @@ router.get("/:player/:profile", async (req, res, next) => {
 
       output = {
         profile_id: singleProfile.profile_id,
-        cute_name: cute_name,
+        cute_name: cuteName,
         purse: data.purse,
         bank: data.bank,
       };
@@ -50,14 +50,14 @@ router.get("/:player", async (req, res, next) => {
     const output = { profiles: {} };
 
     for (const singleProfile of allProfiles) {
-      const cute_name = singleProfile.cute_name;
+      const cuteName = singleProfile.cute_name;
 
       const items = await lib.getItems(singleProfile.members[profile.uuid], false, "", req.options);
       const data = await lib.getStats(db, singleProfile, allProfiles, items, req.options);
 
       output.profiles[singleProfile.profile_id] = {
         profile_id: singleProfile.profile_id,
-        cute_name: cute_name,
+        cute_name: cuteName,
         purse: data.purse,
         bank: data.bank,
       };

--- a/src/routes/apiv2/dungeons.js
+++ b/src/routes/apiv2/dungeons.js
@@ -20,9 +20,9 @@ router.get("/:player/:profile", async (req, res, next) => {
     };
 
     for (const singleProfile of allProfiles) {
-      const cute_name = singleProfile.cute_name;
+      const cuteName = singleProfile.cute_name;
 
-      if (cute_name.toLowerCase() != req.params.profile.toLowerCase()) {
+      if (cuteName.toLowerCase() != req.params.profile.toLowerCase()) {
         continue;
       }
 

--- a/src/routes/apiv2/dungeons.js
+++ b/src/routes/apiv2/dungeons.js
@@ -29,7 +29,7 @@ router.get("/:player/:profile", async (req, res, next) => {
       const userProfile = singleProfile.members[profile.uuid];
       const hypixelProfile = await helper.getRank(profile.uuid, db, req.cacheOnly);
 
-      const dungeonData = await lib.getDungeons(userProfile, hypixelProfile);
+      const dungeonData = lib.getDungeons(userProfile, hypixelProfile);
 
       output = {
         profile_id: singleProfile.profile_id,
@@ -54,7 +54,7 @@ router.get("/:player", async (req, res, next) => {
       const userProfile = singleProfile.members[profile.uuid];
       const hypixelProfile = await helper.getRank(profile.uuid, db, req.cacheOnly);
 
-      const dungeonData = await lib.getDungeons(userProfile, hypixelProfile);
+      const dungeonData = lib.getDungeons(userProfile, hypixelProfile);
 
       output.profiles[singleProfile.profile_id] = {
         profile_id: singleProfile.profile_id,

--- a/src/routes/apiv2/slayers.js
+++ b/src/routes/apiv2/slayers.js
@@ -20,9 +20,9 @@ router.get("/:player/:profile", async (req, res, next) => {
     };
 
     for (const singleProfile of allProfiles) {
-      const cute_name = singleProfile.cute_name;
+      const cuteName = singleProfile.cute_name;
 
-      if (cute_name.toLowerCase() != req.params.profile.toLowerCase()) {
+      if (cuteName.toLowerCase() != req.params.profile.toLowerCase()) {
         continue;
       }
 

--- a/src/routes/apiv2/talismans.js
+++ b/src/routes/apiv2/talismans.js
@@ -18,9 +18,9 @@ router.get("/:player/:profile", async (req, res, next) => {
 
     let output;
     for (const singleProfile of allProfiles) {
-      const cute_name = singleProfile.cute_name;
+      const cuteName = singleProfile.cute_name;
 
-      if (cute_name.toLowerCase() != req.params.profile.toLowerCase()) {
+      if (cuteName.toLowerCase() != req.params.profile.toLowerCase()) {
         continue;
       }
 

--- a/src/scripts/init-collections.js
+++ b/src/scripts/init-collections.js
@@ -1,5 +1,5 @@
 import { db } from "../mongo.js";
-import { itemTags } from "../constants.js";
+import { ITEM_TAGS } from "../constants.js";
 
 await Promise.all([
   db.collection("apiKeys").createIndex({ key: 1 }, { unique: true }),
@@ -27,7 +27,7 @@ await Promise.all([
   db.collection("items").createIndex({ name: "text", tag: "text" }),
 
   Promise.all(
-    Object.entries(itemTags).map(([id, item]) => db.collection("items").updateOne({ id }, { $set: { tag: item } }))
+    Object.entries(ITEM_TAGS).map(([id, item]) => db.collection("items").updateOne({ id }, { $set: { tag: item } }))
   ),
 
   db.collection("bazaar").createIndex({ productId: 1 }, { unique: true }),

--- a/src/scripts/init-collections.js
+++ b/src/scripts/init-collections.js
@@ -1,5 +1,5 @@
 import { db } from "../mongo.js";
-import { item_tags } from "../constants.js";
+import { itemTags } from "../constants.js";
 
 await Promise.all([
   db.collection("apiKeys").createIndex({ key: 1 }, { unique: true }),
@@ -27,7 +27,7 @@ await Promise.all([
   db.collection("items").createIndex({ name: "text", tag: "text" }),
 
   Promise.all(
-    Object.entries(item_tags).map(([id, item]) => db.collection("items").updateOne({ id }, { $set: { tag: item } }))
+    Object.entries(itemTags).map(([id, item]) => db.collection("items").updateOne({ id }, { $set: { tag: item } }))
   ),
 
   db.collection("bazaar").createIndex({ productId: 1 }, { unique: true }),

--- a/src/scripts/update-bazaar.js
+++ b/src/scripts/update-bazaar.js
@@ -4,13 +4,13 @@ import "axios-debug-log";
 
 import { getPrices } from "../helper.js";
 
-const Hypixel = axios.create({
+const hypixel = axios.create({
   baseURL: "https://api.hypixel.net/",
 });
 
 async function updateBazaar() {
   try {
-    const response = await Hypixel.get("skyblock/bazaar" /*, { params: { key: credentials.hypixel_api_key }}*/);
+    const response = await hypixel.get("skyblock/bazaar" /*, { params: { key: credentials.hypixel_api_key }}*/);
 
     const { products } = response.data;
 

--- a/src/scripts/update-featured-profiles.js
+++ b/src/scripts/update-featured-profiles.js
@@ -3,7 +3,7 @@ import path from "path";
 import { db } from "../mongo.js";
 import * as helper from "../helper.js";
 
-const featuredProfiles = [
+const FEATURED_PROFILES = [
   {
     // metalcupcake5
     uuid: "b44d2d5272dc49c28185b2d6a158d80a",
@@ -62,15 +62,15 @@ const featuredProfiles = [
 
 {
   await Promise.all(
-    featuredProfiles.map(async (featuredProfile, index) => {
+    FEATURED_PROFILES.map(async (featuredProfile, index) => {
       const profile = await helper.resolveUsernameOrUuid(featuredProfile.uuid, db);
 
-      featuredProfiles[index].username = profile.display_name;
-      featuredProfiles[index].emoji = profile?.emoji;
+      FEATURED_PROFILES[index].username = profile.display_name;
+      FEATURED_PROFILES[index].emoji = profile?.emoji;
     })
   );
 
-  await fs.writeJson(path.resolve("./public/resources/js/featured-profiles.json"), featuredProfiles);
+  await fs.writeJson(path.resolve("./public/resources/js/featured-profiles.json"), FEATURED_PROFILES);
 
   console.log("Featured profiles updated!");
 }

--- a/src/weight/lily-weight.js
+++ b/src/weight/lily-weight.js
@@ -1,7 +1,7 @@
 import LilyWeight from "lilyweight";
 
-const skillOrder = ["enchanting", "taming", "alchemy", "mining", "farming", "foraging", "combat", "fishing"];
-const slayerOrder = ["zombie", "spider", "wolf", "enderman", "blaze"];
+const SKILL_ORDER = ["enchanting", "taming", "alchemy", "mining", "farming", "foraging", "combat", "fishing"];
+const SLAYER_ORDER = ["zombie", "spider", "wolf", "enderman", "blaze"];
 
 /**
  * converts a dungeon floor into a completion map
@@ -13,14 +13,14 @@ function getTierCompletions(floors = {}) {
 }
 
 export function calculateLilyWeight(profile) {
-  const skillLevels = skillOrder.map((key) => profile.levels[key].uncappedLevel);
-  const skillXP = skillOrder.map((key) => profile.levels[key].xp);
+  const skillLevels = SKILL_ORDER.map((key) => profile.levels[key].uncappedLevel);
+  const skillXP = SKILL_ORDER.map((key) => profile.levels[key].xp);
 
   const cataCompletions = getTierCompletions(profile.dungeons?.catacombs?.floors ?? {});
   const masterCataCompletions = getTierCompletions(profile.dungeons?.master_catacombs?.floors ?? {});
   const cataXP = profile.dungeons?.catacombs?.level?.xp ?? 0;
 
-  const slayerXP = slayerOrder.map((key) => profile.slayers?.[key]?.level?.xp ?? 0);
+  const slayerXP = SLAYER_ORDER.map((key) => profile.slayers?.[key]?.level?.xp ?? 0);
 
   return LilyWeight.getWeightRaw(skillLevels, skillXP, cataCompletions, masterCataCompletions, cataXP, slayerXP);
 }

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -2499,7 +2499,7 @@ const metaDescription = getMetaDescription()
     const calculated = JSON.parse(`<%- JSON.stringify(calculated).replaceAll('\\', '\\\\') %>`);
     <%
       const clientConstants = {
-        max_favorites: constants.max_favorites,
+        MAX_FAVORITES: constants.MAX_FAVORITES,
       }
     %>
     const constants = JSON.parse(`<%- JSON.stringify(clientConstants).replaceAll('\\', '\\\\') %>`);

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -980,29 +980,29 @@ const metaDescription = getMetaDescription()
           <% }else{ %>
             <p class="stat-raw-values">
               <%
-                const maxTalis = items.accessories.filter(a => a.isUnique).length >= constants.unique_accessories_count ? 'golden-text': ''
-                const maxRecombTalis = items.accessories.filter(a => a.isUnique && a.extra?.recombobulated).length >= constants.unique_accessories_count ? 'golden-text': ''
+                const maxTalis = items.accessories.filter(a => a.isUnique).length >= constants.UNIQUE_ACCESSORIES_COUNT ? 'golden-text': ''
+                const maxRecombTalis = items.accessories.filter(a => a.isUnique && a.extra?.recombobulated).length >= constants.UNIQUE_ACCESSORIES_COUNT ? 'golden-text': ''
               %>
 
               <span class="stat-name <%= maxTalis %>">Unique Accessories: </span>
-              <span class="stat-value <%= maxTalis %>"><%= items.accessories.filter(a => a.isUnique).length %> / <%= constants.unique_accessories_count %></span>
+              <span class="stat-value <%= maxTalis %>"><%= items.accessories.filter(a => a.isUnique).length %> / <%= constants.UNIQUE_ACCESSORIES_COUNT %></span>
               <br>
               <span class="stat-name <%= maxTalis %>">Completion: </span>
-              <span class="stat-value percent <%= maxTalis %>"><%= Math.round(items.accessories.filter(a => a.isUnique).length / constants.unique_accessories_count * 100) %></span>
+              <span class="stat-value percent <%= maxTalis %>"><%= Math.round(items.accessories.filter(a => a.isUnique).length / constants.UNIQUE_ACCESSORIES_COUNT * 100) %></span>
               <br>
               <span class="stat-name <%= maxRecombTalis %>">Recombobulated: </span>
-              <span class="stat-value <%= maxRecombTalis %>"><%= items.accessories.filter(a => a.isUnique && a.extra?.recombobulated).length %> / <%= constants.unique_accessories_count %></span>
+              <span class="stat-value <%= maxRecombTalis %>"><%= items.accessories.filter(a => a.isUnique && a.extra?.recombobulated).length %> / <%= constants.UNIQUE_ACCESSORIES_COUNT %></span>
               <br>
               <%
                 const rarities = items.accessory_rarities;
                 const player_magical_power = {}
 
-                for (const rarity in constants.magical_power) {
+                for (const rarity in constants.MAGICAL_POWER) {
                   player_magical_power[rarity] = 0
-                  player_magical_power[rarity] += rarities[rarity] * constants.magical_power[rarity];
+                  player_magical_power[rarity] += rarities[rarity] * constants.MAGICAL_POWER[rarity];
                 }
 
-                const mp_hegemony = rarities.hegemony ? constants.magical_power[rarities.hegemony.rarity] : 0
+                const mp_hegemony = rarities.hegemony ? constants.MAGICAL_POWER[rarities.hegemony.rarity] : 0
                 const mp_total = Object.values(player_magical_power).reduce((a, b) => a + b) + mp_hegemony;
               %>
               <span data-tippy-content="
@@ -1018,7 +1018,7 @@ const metaDescription = getMetaDescription()
               <span style='color: var(--§6);' class='grey-text'>5 MP</span> × <span style='color: var(--§c);' class='grey-text'><%= rarities.very_special %> Accs.</span> = <span style='color: var(--§6);' class='grey-text'><%= player_magical_power.very_special.toLocaleString() %> MP</span><br>
               <br>
               <% if(rarities.hegemony) { %>
-                <span style='color: var(--§<%= constants.rarityColors[rarities.hegemony.rarity] %>);' class='grey-text'>Hegemony Artifact</span> = <span style='color: var(--§6);' class='grey-text'>+<%= mp_hegemony.toLocaleString() %> MP</span><br><br>
+                <span style='color: var(--§<%= constants.RARITY_COLORS[rarities.hegemony.rarity] %>);' class='grey-text'>Hegemony Artifact</span> = <span style='color: var(--§6);' class='grey-text'>+<%= mp_hegemony.toLocaleString() %> MP</span><br><br>
               <% } %>
               Total: <span style='color: var(--§6);' class='grey-text'><%= mp_total.toLocaleString() %> Magical Power</span>
               ">
@@ -1091,13 +1091,13 @@ const metaDescription = getMetaDescription()
           <%
             const uniquePets = _.uniq(
               calculated.pets
-                .filter(pet => !constants.pet_data[pet.type].bingoExclusive === true || calculated.profile.game_mode === 'bingo')
-                .map((pet) => constants.pet_data[pet.type].typeGroup ?? pet.type)
+                .filter(pet => !constants.PET_DATA[pet.type].bingoExclusive === true || calculated.profile.game_mode === 'bingo')
+                .map((pet) => constants.PET_DATA[pet.type].typeGroup ?? pet.type)
             )
             const totalPets = _.uniq(
               Object.entries(
                 Object.fromEntries(
-                  Object.entries(constants.pet_data)
+                  Object.entries(constants.PET_DATA)
                     .filter(pet => !pet[1].bingoExclusive === true || calculated.profile.game_mode === 'bingo')
                 )
               )
@@ -1111,7 +1111,7 @@ const metaDescription = getMetaDescription()
 
             let totalSkins = {}
             let badSkins = {}
-            for (const [skin, skinData] of Object.entries(constants.pet_skins)) {
+            for (const [skin, skinData] of Object.entries(constants.PET_SKINS)) {
               if (skinData.release < Date.now()) {
                 totalSkins[skin] = calculated.pets.find((pet) => `PET_SKIN_${pet.skin}` === skin) != undefined;
               }
@@ -1128,7 +1128,7 @@ const metaDescription = getMetaDescription()
             <% max = userUniqueSkins >= totalUniqueSkins ? 'golden-text': '' %>
             <span class="stat-name <%= max %>">Unique Pet Skins: </span><span class="stat-value <%= max %>"><%= userUniqueSkins %> / <%= totalUniqueSkins %></span><br>
 
-            <% max = calculated.petScore >= Math.max(...Object.keys(constants.pet_rewards)) ? 'golden-text' : '' %>
+            <% max = calculated.petScore >= Math.max(...Object.keys(constants.PET_REWARDS)) ? 'golden-text' : '' %>
             <span data-tippy-content="
               Increase your pet score by collecting unique pets with a high rarity.<br><br>
               <table>
@@ -1355,7 +1355,7 @@ const metaDescription = getMetaDescription()
                 const delivered_parts = mining.core.crystal_nucleus?.precursor?.parts_delivered || []
                 const precursor_parts = {}
 
-                for (const [partId, partName] of Object.entries(constants.precursor_parts)) {
+                for (const [partId, partName] of Object.entries(constants.PRECURSOR_PARTS)) {
                   precursor_parts[partName] = delivered_parts.indexOf(partId) > -1
                 }
               %>
@@ -1402,7 +1402,7 @@ const metaDescription = getMetaDescription()
             <p class="stat-sub-header">Heart of the Mountain</p>
             <p class="stat-raw-values">
               <!-- Tier -->
-              <% max = mining.core.tier.level === constants.hotm.tiers ? 'golden-text' : '' %>
+              <% max = mining.core.tier.level === constants.HOTM.tiers ? 'golden-text' : '' %>
               <span class="stat-name <%= max %>">Tier:</span>
               <span class="stat-value <%= max %>"><%= mining.core.tier.level %></span>
               <br>
@@ -1412,7 +1412,7 @@ const metaDescription = getMetaDescription()
               <span class="stat-value <%= max %>"><%= mining.core.tokens.spent %>/<%= mining.core.tokens.total %></span>
               <br>
               <!-- Mithril Powder -->
-              <% max = mining.core.powder.mithril.total >= constants.hotm.powder_for_max_nodes.mithril_powder ? 'golden-text' : '' %>
+              <% max = mining.core.powder.mithril.total >= constants.HOTM.powder_for_max_nodes.mithril_powder ? 'golden-text' : '' %>
               <span class="stat-name <%= max %>">Mithril Powder:</span>
               <span class="stat-value <%= max %>" data-tippy-content="
                 <span class='stat-name'>Total:</span> <span class='stat-value'><%= mining.core.powder.mithril.total.toLocaleString() %></span><br>
@@ -1421,7 +1421,7 @@ const metaDescription = getMetaDescription()
               "><%= mining.core.powder.mithril.total.toLocaleString() %></span>
               <br>
               <!-- Gemstone Powder -->
-              <% max = mining.core.powder.gemstone.total >= constants.hotm.powder_for_max_nodes.gemstone_powder ? 'golden-text' : '' %>
+              <% max = mining.core.powder.gemstone.total >= constants.HOTM.powder_for_max_nodes.gemstone_powder ? 'golden-text' : '' %>
               <span class="stat-name <%= max %>">Gemstone Powder:</span>
               <span class="stat-value <%= max %>" data-tippy-content="
                 <span class='stat-name'>Total:</span> <span class='stat-value'><%= mining.core.powder.gemstone.total.toLocaleString() %></span><br>
@@ -2012,19 +2012,19 @@ const metaDescription = getMetaDescription()
           <div class="external-app-description">Check the next cheapest or fastest Minion upgrades and find out which Minions will earn you the most from Bazaar, for free.</div>
         </a>
         <p class="stat-raw-values">
-          <% max = uniqueMinions == constants.minions_max_uniques ? 'golden-text' : '' %><span class="stat-name <%= max %>">Unique Minions: </span><span class="stat-value <%= max %>"><%= uniqueMinions %> / <%= constants.minions_max_uniques %></span><span class="grey-text"> (<%= Math.floor(uniqueMinions / constants.minions_max_uniques * 100) %>%)</span><br>
-          <% max = calculated.minion_slots.currentSlots == constants.minions_max_slots ? 'golden-text' : '' %><span class="stat-name <%= max %>">Minion Slots: </span><span class="stat-value <%= max %>""><%= calculated.minion_slots.currentSlots %></span><span class="grey-text"> (<%= calculated.minion_slots.toNextSlot %> to next slot)</span><br>
-          <% max = calculated.misc.profile_upgrades.minion_slots == 5 ? 'golden-text' : '' %><span class="stat-name <%= max %>">Bonus Minion Slots: </span><span class="stat-value <%= max %>""><%= calculated.misc.profile_upgrades.minion_slots %> / <%= constants.profile_upgrades['minion_slots'] %></span><br>
-          <% max = maxedMinions == _.size(constants.minions) ? 'golden-text' : '' %><span class="stat-name <%= max %>">Maxed Minions: </span><span class="stat-value <%= max %>"><%= maxedMinions %> / <%= _.size(constants.minions) %></span><br>
+          <% max = uniqueMinions == constants.MINIONS_MAX_UNIQUES ? 'golden-text' : '' %><span class="stat-name <%= max %>">Unique Minions: </span><span class="stat-value <%= max %>"><%= uniqueMinions %> / <%= constants.MINIONS_MAX_UNIQUES %></span><span class="grey-text"> (<%= Math.floor(uniqueMinions / constants.MINIONS_MAX_UNIQUES * 100) %>%)</span><br>
+          <% max = calculated.minion_slots.currentSlots == constants.MINIONS_MAX_SLOTS ? 'golden-text' : '' %><span class="stat-name <%= max %>">Minion Slots: </span><span class="stat-value <%= max %>""><%= calculated.minion_slots.currentSlots %></span><span class="grey-text"> (<%= calculated.minion_slots.toNextSlot %> to next slot)</span><br>
+          <% max = calculated.misc.profile_upgrades.minion_slots == 5 ? 'golden-text' : '' %><span class="stat-name <%= max %>">Bonus Minion Slots: </span><span class="stat-value <%= max %>""><%= calculated.misc.profile_upgrades.minion_slots %> / <%= constants.PROFILE_UPGRADES['minion_slots'] %></span><br>
+          <% max = maxedMinions == _.size(constants.MINIONS) ? 'golden-text' : '' %><span class="stat-name <%= max %>">Maxed Minions: </span><span class="stat-value <%= max %>"><%= maxedMinions %> / <%= _.size(constants.MINIONS) %></span><br>
           <% if(skippedMinions > 0){ %>
           <span class="stat-name">Skipped Minion Tiers: </span><span class="stat-value"><%= skippedMinions %></span><br>
           <% } %>
         </p>
         <%
-        for(const type of constants.minion_types){
+        for(const type of constants.MINION_TYPES){
           const minions = calculated.minions.filter(a => a.type == type && a.maxLevel > 0).sort((a, b) => b.maxLevel - a.maxLevel);
 
-          const totalOfType = _.size(_.pickBy(constants.minions, a => a.type == type));
+          const totalOfType = _.size(_.pickBy(CONSTANTS.minions, a => a.type == type));
           const maxOfType = minions.filter(a => a.maxLevel == a.tiers).length;
 
           if(minions.length == 0)
@@ -2070,20 +2070,20 @@ const metaDescription = getMetaDescription()
           <p class="stat-raw-values">
             <%
             let maxCollections = 0;
-            for(const collection of constants.collection_data)
+            for(const collection of constants.COLLECTION_DATA)
               if(collection.skyblockId in calculated.collections
               && calculated.collections[collection.skyblockId].tier >= collection.maxTier)
                 maxCollections++;
             %>
-            <% max = maxCollections == constants.collection_data.length ? 'golden-text' : '' %><span class="stat-name <%= max %>">Maxed Collections: </span><span class="stat-value <%= max %>"><%= maxCollections %> / <%= constants.collection_data.length %></span>
+            <% max = maxCollections == constants.COLLECTION_DATA.length ? 'golden-text' : '' %><span class="stat-name <%= max %>">Maxed Collections: </span><span class="stat-value <%= max %>"><%= maxCollections %> / <%= constants.COLLECTION_DATA.length %></span>
           </p>
-          <% for(const type of constants.collection_types){
+          <% for(const type of constants.COLLECTION_TYPES){
             const collections = [];
 
-            const totalOfType = constants.collection_data.filter(a => a.type == type).length;
+            const totalOfType = constants.COLLECTION_DATA.filter(a => a.type == type).length;
             let maxOfType = 0;
 
-            for(const collection of constants.collection_data.filter(a => a.type == type))
+            for(const collection of constants.COLLECTION_DATA.filter(a => a.type == type))
               if(collection.skyblockId in calculated.collections)
                 collections.push(Object.assign(collection, calculated.collections[collection.skyblockId]));
 
@@ -2156,9 +2156,9 @@ const metaDescription = getMetaDescription()
           <div class="collections">
             <% for (const [key, value] of Object.entries(calculated.essence)) { %>
               <div class="chip" data-missing="<%= value === 0 %>">
-                <div class="chip-icon-wrapper"><div style="background-image:url('<%= constants.essence[key].head %>')" class="item-icon custom-icon"></div></div>
+                <div class="chip-icon-wrapper"><div style="background-image:url('<%= constants.ESSENCE[key].head %>')" class="item-icon custom-icon"></div></div>
                 <div class="chip-text">
-                  <div class="collection-name"><span class="stat-name"><%= constants.essence[key].name %></span></div>
+                  <div class="collection-name"><span class="stat-name"><%= constants.ESSENCE[key].name %></span></div>
                   <div class="collection-amount"><span class="stat-name">Amount: </span><span class="stat-value"><%= value.toLocaleString() %></span></div>
                 </div>
               </div>
@@ -2433,8 +2433,8 @@ const metaDescription = getMetaDescription()
           <% if('profile_upgrades' in calculated.misc){ %>
             <div class="category-header"><div class="category-icon"><div class="item-icon icon-154_0"></div></div><span>Profile upgrades</span></div>
             <p class="stat-raw-values">
-              <% for(const upgrade in constants.profile_upgrades){ %>
-              <% max = calculated.misc.profile_upgrades[upgrade] == constants.profile_upgrades[upgrade] ? 'golden-text' : '' %><span class="stat-name <%= max %>"><%= helper.capitalizeFirstLetter(upgrade.split("_").join(" ")); %>: </span><span class="stat-value <%= max %>""><%= calculated.misc.profile_upgrades[upgrade] %> / <%= constants.profile_upgrades[upgrade] %></span><br>
+              <% for(const upgrade in constants.PROFILE_UPGRADES){ %>
+              <% max = calculated.misc.profile_upgrades[upgrade] == constants.PROFILE_UPGRADES[upgrade] ? 'golden-text' : '' %><span class="stat-name <%= max %>"><%= helper.capitalizeFirstLetter(upgrade.split("_").join(" ")); %>: </span><span class="stat-value <%= max %>""><%= calculated.misc.profile_upgrades[upgrade] %> / <%= constants.PROFILE_UPGRADES[upgrade] %></span><br>
               <% } %>
             </p>
           <% } %>


### PR DESCRIPTION
related to #1205 

In this PR the following changes are made to eslint config:
- you will be warned if you have a `let` that should be a `const`
- you will be warned if you break a variable naming rule:
  - Variables must be camelCase
  - Constants that are exported must be UPPER_CASE
  - Classes and Types must be PascalCase

This PR also renames some variables to meet these new requirements

This PR also fixes some other linting errors

NOTE:
not all the variable case problems have been resolved. I am leaving some things to other developers/maintainers.