### PR TITLE
Fix for "CONSTANTS is not defined"

### DIFF
--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -2024,7 +2024,7 @@ const metaDescription = getMetaDescription()
         for(const type of constants.MINION_TYPES){
           const minions = calculated.minions.filter(a => a.type == type && a.maxLevel > 0).sort((a, b) => b.maxLevel - a.maxLevel);
 
-          const totalOfType = _.size(_.pickBy(CONSTANTS.minions, a => a.type == type));
+          const totalOfType = _.size(_.pickBy(constants.minions, a => a.type == type));
           const maxOfType = minions.filter(a => a.maxLevel == a.tiers).length;
 
           if(minions.length == 0)


### PR DESCRIPTION
Basically there was one reference to uppercase `CONSTANTS` instead of lowercase `constants` which broke the rendering of `stats.ejs`.