### PR TITLE
ensure enrichment is always lower case

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -1114,7 +1114,7 @@ export const getItems = async (
     }
 
     if (accessory.tag?.ExtraAttributes?.talisman_enrichment != undefined) {
-      accessory.enrichment = accessory.tag.ExtraAttributes.talisman_enrichment;
+      accessory.enrichment = accessory.tag.ExtraAttributes.talisman_enrichment.toLowerCase();
     }
   }
 

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -193,7 +193,7 @@ function formatEnrichment(string) {
 }
 
 function enrichmentToStatName(enrichment) {
-  switch (enrichment.toLowerCase()) {
+  switch (enrichment) {
     case 'walk_speed':
       return 'speed'
 
@@ -207,7 +207,7 @@ function enrichmentToStatName(enrichment) {
       return 'bonus_attack_speed'
 
     default:
-      return enrichment.toLowerCase()
+      return enrichment
   }
 }
 
@@ -233,7 +233,7 @@ function getEnrichments(accessories) {
       const stat = enrichmentToStatName(enrichment)
       %>
       <span class="stat-value color-<%= stat.replaceAll("_", "-") %>">
-        <%= amount %>× <%= formatEnrichment(enrichment.toLowerCase()) %>
+        <%= amount %>× <%= formatEnrichment(enrichment) %>
       </span>
       <%
       if (enrichment !== Object.keys(enrichmentCounts).pop()) {


### PR DESCRIPTION
fixes #1652 
ensures that enrichment is always lower case so the new and old enrichment values do not produce separate categories
tested on combatsheep4/Cucumber
![image](https://user-images.githubusercontent.com/43897385/189567777-42b97b9c-d17e-4eee-89c0-9ef0bf5417f6.png)
![image](https://user-images.githubusercontent.com/43897385/189567789-843e84ef-3275-4d3f-935d-293d8a53d105.png)
