### PR TITLE
tell the browser whether to use light or dark mode

### DIFF
--- a/public/resources/scss/shared.scss
+++ b/public/resources/scss/shared.scss
@@ -54,6 +54,8 @@
   /* Normal Background */
   --bg: url(/resources/img/bg.webp);
 
+  color-scheme: dark;
+
   &.light {
     --text-hex: black;
     --text-rgb: 0, 0, 0;
@@ -65,6 +67,8 @@
     --grey_background-rgb: 226, 226, 226;
     --lore_background-hex: #ffffffee;
     --bg-hex: white;
+
+    color-scheme: light;
   }
 
   .true-colors {


### PR DESCRIPTION
currently, we set everything to dark mode manually by making the background dark and the test light but by using the `color-scheme` CSS property we can tell the browser we are using dark mode and it will make the default be dark mode. 