### PR TITLE
ejs beautify

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
     "dbaeumer.vscode-eslint",
     "digitalbrainstem.javascript-ejs-support",
     "bierner.comment-tagged-templates",
-    "runem.lit-plugin"
+    "runem.lit-plugin",
+    "j69.ejs-beautify"
   ]
 }

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -227,21 +227,21 @@ function getEnrichments(accessories) {
     })
 
     %>
-    <span class="stat-name">Enrichments: </span>
-    <%
+<span class="stat-name">Enrichments: </span>
+<%
     for (const [enrichment, amount] of Object.entries(enrichmentCounts)) {
       const stat = enrichmentToStatName(enrichment)
       %>
-      <span class="stat-value color-<%= stat.replaceAll("_", "-") %>">
-        <%= amount %>× <%= formatEnrichment(enrichment.toLowerCase()) %>
-      </span>
-      <%
+<span class="stat-value color-<%= stat.replaceAll("_", "-") %>">
+  <%= amount %>× <%= formatEnrichment(enrichment.toLowerCase()) %>
+</span>
+<%
       if (enrichment !== Object.keys(enrichmentCounts).pop()) {
         %><span class="bonus-divider" role="separator"> // </span><%
       }
     }
     %>
-    <%
+<%
   }
 }
 
@@ -274,19 +274,16 @@ function isEnchanted(item) {
 
 function itemIcon(item, classes) {
   %>
-  <div
-    <% if(item.texture_path){ %> style='background-image: url("<%= item.texture_path %>")' <% } %>
-    class="
+<div <% if(item.texture_path){ %> style='background-image: url("<%= item.texture_path %>")' <% } %> class="
       <%= classes.join(" ") %>
       item-icon
       <% if(isEnchanted(item)){ %>is-enchanted <% } %>
       <% if(item.texture_path){ %>custom-icon<% } %>
       <% if(item.Damage != 0){ %>icon-<%= item.id %>_0<% } %>
       icon-<%= item.id %>_<%= item.Damage %>
-    "
-  >
-  </div>
-  <%
+    ">
+</div>
+<%
 }
 
 function jerriefy(rank) {
@@ -557,6 +554,7 @@ const metaDescription = getMetaDescription()
 %>
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <title><%= calculated.display_name %><% if(calculated.display_emoji){ %> <%= calculated.display_emoji %><% } %> | SkyCrypt</title>
   <meta name="description" content="<%= metaDescription %>">
@@ -569,6 +567,7 @@ const metaDescription = getMetaDescription()
   <meta name="twitter:card" content="summary">
   <%- include('../includes/resources') %>
 </head>
+
 <body class="page-stats">
   <svg xmlns="http://www.w3.org/2000/svg" height="0" width="0" style="position: fixed;">
     <filter id="enchanted-glint">
@@ -580,13 +579,17 @@ const metaDescription = getMetaDescription()
   <%- include('../includes/header') %>
   <div id="dimmer">
     <video preload="none" id="enable_api" loop>
-      <source type="video/webm" src="/resources/video/enable-api.webm"></source>
-      <source type="video/mp4" src="/resources/video/enable-api.mp4"></source>
+      <source type="video/webm" src="/resources/video/enable-api.webm">
+      </source>
+      <source type="video/mp4" src="/resources/video/enable-api.mp4">
+      </source>
     </video>
   </div>
   <div id="stats_content">
     <div class="item-name">
-      <div class="stats-piece-icon__wrapper"><div class="stats-piece-icon"></div></div>
+      <div class="stats-piece-icon__wrapper">
+        <div class="stats-piece-icon"></div>
+      </div>
       <p class="item-name__name"></p>
       <button class="close-lore" aria-label="Close"></button>
     </div>
@@ -598,38 +601,38 @@ const metaDescription = getMetaDescription()
   </div>
   <main id="wrapper" data-sticky-container>
     <% if(extra.cacheOnly) { %>
-      <figure class="banner error">
-        <figcaption>Cache Only Mode!</figcaption>
-        <p>
-          SkyCrypt is <strong>only</strong> showing the last known state of user's profiles which may be outdated due to API maintenance.<br>
-          <%# <i>If a profile wasn't viewed/cached before, it can't be viewed.</i><br> %>
-          <br>
-          For more info about Hypixel outages visit the official <a href="https://status.hypixel.net/" target="_blank" rel="noreferrer"> Hypixel Status</a>.
-        </p>
-      </figure>
+    <figure class="banner error">
+      <figcaption>Cache Only Mode!</figcaption>
+      <p>
+        SkyCrypt is <strong>only</strong> showing the last known state of user's profiles which may be outdated due to API maintenance.<br>
+        <%# <i>If a profile wasn't viewed/cached before, it can't be viewed.</i><br> %>
+        <br>
+        For more info about Hypixel outages visit the official <a href="https://status.hypixel.net/" target="_blank" rel="noreferrer"> Hypixel Status</a>.
+      </p>
+    </figure>
     <% } %>
     <div id="player_profile"><span class="text-stats-for">Stats for</span>
       <span tabindex="0" id="stats_for_player">
         <%- jerriefy(calculated.rank_prefix) %>
         <%= calculated.display_name %>
         <% if(calculated.display_emoji_img){ %>
-          <img class="emoji" draggable="false" src="<%= calculated.display_emoji_img %>">
+        <img class="emoji" draggable="false" src="<%= calculated.display_emoji_img %>">
         <% }else if(calculated.display_emoji){ %>
-          <%- extra.twemoji.parse(calculated.display_emoji) %>
+        <%- extra.twemoji.parse(calculated.display_emoji) %>
         <% } %>
         <ul id="other_players">
           <% calculated.members.forEach(member => { %>
-            <li>
-              <a class="goto" href="/stats/<%= member.uuid %>/<%= calculated.profile.profile_id %><%= Object.keys(req.query).length > 0 ? '?' + new URLSearchParams(req.query).toString() : '' %>">
-                <%= member.display_name %>
-                <% if(member.emojiImg){ %>
-                  <img class="emoji" draggable="false" src="<%= member.emojiImg %>">
-                <% }else if(member.emoji){ %>
-                  <%- extra.twemoji.parse(member.emoji) %>
-                <% } %>
-                <span class="goto-last-played"><%= 'last_updated' in member ? member.last_updated.text : '' %></span>
-              </a>
-            </li>
+          <li>
+            <a class="goto" href="/stats/<%= member.uuid %>/<%= calculated.profile.profile_id %><%= Object.keys(req.query).length > 0 ? '?' + new URLSearchParams(req.query).toString() : '' %>">
+              <%= member.display_name %>
+              <% if(member.emojiImg){ %>
+              <img class="emoji" draggable="false" src="<%= member.emojiImg %>">
+              <% }else if(member.emoji){ %>
+              <%- extra.twemoji.parse(member.emoji) %>
+              <% } %>
+              <span class="goto-last-played"><%= 'last_updated' in member ? member.last_updated.text : '' %></span>
+            </a>
+          </li>
           <% }); %>
         </ul>
       </span>
@@ -637,32 +640,32 @@ const metaDescription = getMetaDescription()
       <span tabindex="0" id="stats_for_profile">
         <%= calculated.profile.cute_name %>
         <% if (calculated.profile.game_mode == 'ironman') { %>
-          <img src="/resources/img/icons/ironman.png" class="emoji" alt="ironman">
+        <img src="/resources/img/icons/ironman.png" class="emoji" alt="ironman">
         <% } %>
         <% if (calculated.profile.game_mode == 'bingo') { %>
-          <%- extra.twemoji.parse("🎲") %>
+        <%- extra.twemoji.parse("🎲") %>
         <% } %>
         <% if (calculated.profile.game_mode == 'island') { %>
-          <%- extra.twemoji.parse("🌴") %>
+        <%- extra.twemoji.parse("🌴") %>
         <% } %>
         <ul id="other_profiles">
           <% for(let profile_id in calculated.profiles){ %>
-            <% let _profile = calculated.profiles[profile_id]; %>
-            <li>
-              <a class="goto" href="/stats/<%= calculated.uuid %>/<%= _profile.profile_id %><%= Object.keys(req.query).length > 0 ? '?' + new URLSearchParams(req.query).toString() : '' %>">
-                <%= _profile.cute_name %>
-                <% if (_profile.game_mode == 'ironman') { %>
-                  <img src="/resources/img/icons/ironman.png" class="emoji">
-                <% } %>
-                <% if (_profile.game_mode == 'bingo') { %>
-                  <%- extra.twemoji.parse("🎲") %>
-                <% } %>
-                <% if (_profile.game_mode == 'island') { %>
-                  <%- extra.twemoji.parse("🌴") %>
-                <% } %>
-                <span class="goto-last-played"><%= 'last_updated' in _profile ? _profile.last_updated.text : '' %></span>
-              </a>
-            </li>
+          <% let _profile = calculated.profiles[profile_id]; %>
+          <li>
+            <a class="goto" href="/stats/<%= calculated.uuid %>/<%= _profile.profile_id %><%= Object.keys(req.query).length > 0 ? '?' + new URLSearchParams(req.query).toString() : '' %>">
+              <%= _profile.cute_name %>
+              <% if (_profile.game_mode == 'ironman') { %>
+              <img src="/resources/img/icons/ironman.png" class="emoji">
+              <% } %>
+              <% if (_profile.game_mode == 'bingo') { %>
+              <%- extra.twemoji.parse("🎲") %>
+              <% } %>
+              <% if (_profile.game_mode == 'island') { %>
+              <%- extra.twemoji.parse("🌴") %>
+              <% } %>
+              <span class="goto-last-played"><%= 'last_updated' in _profile ? _profile.last_updated.text : '' %></span>
+            </a>
+          </li>
           <% } %>
         </ul>
       </span>
@@ -731,10 +734,10 @@ const metaDescription = getMetaDescription()
         <div class="additional-stat"><span data-tippy-content='Joined on <local-time timestamp="<%= calculated.first_join.unix %>"></local-time>'><span class="stat-name">Joined: </span><span class="stat-value"><%= calculated.first_join.text %></span></span></div>
         <div class="additional-stat"><span class="stat-name">Purse: </span><span class="stat-value"><%= helper.formatNumber(calculated.purse, true) %> Coin<%= Math.floor(calculated.purse) == 1 ? '': 's' %></span></div>
         <% if('bank' in calculated){ %>
-          <div class="additional-stat"><span class="stat-name">Bank Account: </span><span class="stat-value"><%= helper.formatNumber(calculated.bank, true) %> Coin<%= Math.floor(calculated.bank) == 1 ? '': 's' %></span></div>
+        <div class="additional-stat"><span class="stat-name">Bank Account: </span><span class="stat-value"><%= helper.formatNumber(calculated.bank, true) %> Coin<%= Math.floor(calculated.bank) == 1 ? '': 's' %></span></div>
         <% } %>
         <% if('levels' in calculated && 'runecrafting' in calculated.levels){ %>
-          <div class="additional-stat"><span data-tippy-content="
+        <div class="additional-stat"><span data-tippy-content="
           <span class='stat-name'>Total Skill XP: </span><span class='stat-value'><%= Math.round(calculated.total_skill_xp).toLocaleString() %></span>
           <div class='tippy-explanation'>Total XP gained in all skills except Carpentry and Runecrafting.</div>
           <span class='stat-name'>Average Level: </span><span class='stat-value'><%= calculated.average_level.toFixed(2) %></span>
@@ -768,8 +771,8 @@ const metaDescription = getMetaDescription()
 
           for (weight of weightSystems) {
             %>
-              <div class="additional-stat">
-                <span data-tippy-content="
+        <div class="additional-stat">
+          <span data-tippy-content="
                   <span class='stat-name'><%= weight.name %></span><br>
                   <span class='stat-info'>Weight calculations by <%= weight.author %></span>
                   <br/><br/>
@@ -790,36 +793,35 @@ const metaDescription = getMetaDescription()
                     <%= parseFloat(weight.total.toFixed(2)).toLocaleString() %>
                   </span>
                 ">
-                  <span class="stat-name"><%= weight.name %>: </span>
-                  <span class="stat-value"><%= parseFloat(Math.round(weight.total)).toLocaleString() %></span
-                ></span>
-              </div>
-            <%
+            <span class="stat-name"><%= weight.name %>: </span>
+            <span class="stat-value"><%= parseFloat(Math.round(weight.total)).toLocaleString() %></span></span>
+        </div>
+        <%
           }
         %>
       </div>
 
       <div id="skill_levels_container">
         <% if ('levels' in calculated) { %>
-          <div class="skill-bars" data-api-enabled="<%= 'runecrafting' in calculated.levels %>">
-            <skill-component skill="taming" type="skill" icon="<%= skillItems.taming %>"></skill-component>
-            <skill-component skill="farming" type="skill" icon="<%= skillItems.farming %>"></skill-component>
-            <skill-component skill="mining" type="skill" icon="<%= skillItems.mining %>"></skill-component>
-            <skill-component skill="combat" type="skill" icon="<%= skillItems.combat %>"></skill-component>
-            <skill-component skill="foraging" type="skill" icon="<%= skillItems.foraging %>"></skill-component>
-            <skill-component skill="fishing" type="skill" icon="<%= skillItems.fishing %>"></skill-component>
-            <skill-component skill="enchanting" type="skill" icon="<%= skillItems.enchanting %>"></skill-component>
-            <skill-component skill="alchemy" type="skill" icon="<%= skillItems.alchemy %>"></skill-component>
-            <% if ('runecrafting' in calculated.levels) { %>
-              <skill-component skill="carpentry" type="skill" icon="<%= skillItems.carpentry %>"></skill-component>
-              <skill-component skill="runecrafting" type="skill" icon="<%= skillItems.runecrafting %>"></skill-component>
-              <skill-component skill="social" type="skill" icon="<%= skillItems.social %>"></skill-component>
-            <% } else { %>
-              <div class="no-access">Skills from achievements across profiles. <a target="_blank" class="enable-api" href="/resources/video/enable-api.mp4">Enable Skills API</a> for more accurate data.</div>
-            <% } %>
-          </div>
+        <div class="skill-bars" data-api-enabled="<%= 'runecrafting' in calculated.levels %>">
+          <skill-component skill="taming" type="skill" icon="<%= skillItems.taming %>"></skill-component>
+          <skill-component skill="farming" type="skill" icon="<%= skillItems.farming %>"></skill-component>
+          <skill-component skill="mining" type="skill" icon="<%= skillItems.mining %>"></skill-component>
+          <skill-component skill="combat" type="skill" icon="<%= skillItems.combat %>"></skill-component>
+          <skill-component skill="foraging" type="skill" icon="<%= skillItems.foraging %>"></skill-component>
+          <skill-component skill="fishing" type="skill" icon="<%= skillItems.fishing %>"></skill-component>
+          <skill-component skill="enchanting" type="skill" icon="<%= skillItems.enchanting %>"></skill-component>
+          <skill-component skill="alchemy" type="skill" icon="<%= skillItems.alchemy %>"></skill-component>
+          <% if ('runecrafting' in calculated.levels) { %>
+          <skill-component skill="carpentry" type="skill" icon="<%= skillItems.carpentry %>"></skill-component>
+          <skill-component skill="runecrafting" type="skill" icon="<%= skillItems.runecrafting %>"></skill-component>
+          <skill-component skill="social" type="skill" icon="<%= skillItems.social %>"></skill-component>
+          <% } else { %>
+          <div class="no-access">Skills from achievements across profiles. <a target="_blank" class="enable-api" href="/resources/video/enable-api.mp4">Enable Skills API</a> for more accurate data.</div>
+          <% } %>
+        </div>
         <% } else { %>
-          <div class="no-access"><%= calculated.display_name %> doesn't have skills access via API enabled. <a target="_blank" class="enable-api" href="/resources/video/enable-api.mp4">See here</a> how to enable full API access.</div>
+        <div class="no-access"><%= calculated.display_name %> doesn't have skills access via API enabled. <a target="_blank" class="enable-api" href="/resources/video/enable-api.mp4">See here</a> how to enable full API access.</div>
         <% } %>
       </div>
     </div>
@@ -841,7 +843,7 @@ const metaDescription = getMetaDescription()
       </div>
     </div>
     <div class="stat-containers">
-    <%
+      <%
       const notAvailable = [];
 
       if(items.no_inventory)
@@ -853,119 +855,115 @@ const metaDescription = getMetaDescription()
       if(Object.keys(calculated.collections).length == 0)
         notAvailable.push('Collections');
     %>
-    <% if (notAvailable.length > 0 || ['ironman', 'bingo', 'island'].includes(calculated.profile.game_mode)) { %>
+      <% if (notAvailable.length > 0 || ['ironman', 'bingo', 'island'].includes(calculated.profile.game_mode)) { %>
       <div class="stat-container info-container-wrapper">
         <div class="info-container">
           <div class="info-header">Notice</div>
           <% if(notAvailable.length > 0){ %>
-            <%= notAvailable.join(', ') %> not available for <%= calculated.display_name %> due to limited API access.<br><span><a target="_blank" class="enable-api" href="/resources/video/enable-api.mp4">See here</a> how to enable full API access.</span>
+          <%= notAvailable.join(', ') %> not available for <%= calculated.display_name %> due to limited API access.<br><span><a target="_blank" class="enable-api" href="/resources/video/enable-api.mp4">See here</a> how to enable full API access.</span>
           <% } %>
           <% if(calculated.profile.game_mode == 'ironman'){ %>
-            <% if(notAvailable.length > 0){ %><br><br><% } %>
-            This is an <strong>Ironman</strong> profile. The player cannot use the auction house, bazaar, trade, or pick up drops from other players.
+          <% if(notAvailable.length > 0){ %><br><br><% } %>
+          This is an <strong>Ironman</strong> profile. The player cannot use the auction house, bazaar, trade, or pick up drops from other players.
           <% } %>
           <% if(calculated.profile.game_mode == 'bingo'){ %>
-            <% if(notAvailable.length > 0){ %><br><br><% } %>
-            This is a <strong>Bingo</strong> profile. The player cannot spend gems, use the auction house, bazaar, trade, or pick up drops from other players.
+          <% if(notAvailable.length > 0){ %><br><br><% } %>
+          This is a <strong>Bingo</strong> profile. The player cannot spend gems, use the auction house, bazaar, trade, or pick up drops from other players.
           <% } %>
           <% if(calculated.profile.game_mode == 'island'){ %>
-            <% if(notAvailable.length > 0){ %><br><br><% } %>
-            This is a <strong>Stranded</strong> profile. The player cannot leave their skyblock island or trade with other players.
+          <% if(notAvailable.length > 0){ %><br><br><% } %>
+          This is a <strong>Stranded</strong> profile. The player cannot leave their skyblock island or trade with other players.
           <% } %>
         </div>
       </div>
-    <% } %>
+      <% } %>
 
-    <div class="stat-container stat-armor">
-      <a class="stat-anchor" id="Armor"></a>
-      <h2 class="stat-header">Armor</h2>
-      <div class="stat-content">
-        <% if(items.armor.length == 0){ %>
+      <div class="stat-container stat-armor">
+        <a class="stat-anchor" id="Armor"></a>
+        <h2 class="stat-header">Armor</h2>
+        <div class="stat-content">
+          <% if(items.armor.length == 0){ %>
           <div class="no-access"><%= calculated.display_name %> doesn't have any armor equipped.</div>
-        <% }else{ %>
+          <% }else{ %>
           <% if(items.armor_set) { %>
-            <p class="stat-raw-values">
-              <span class="stat-name">Set: </span><span class="stat-value piece-<%= items.armor_set_rarity %>-fg"><%= items.armor_set %></span>
-            </p>
+          <p class="stat-raw-values">
+            <span class="stat-name">Set: </span><span class="stat-value piece-<%= items.armor_set_rarity %>-fg"><%= items.armor_set %></span>
+          </p>
           <% } %>
           <div class="pieces">
             <% for(const item of items.armor.slice().reverse()){ %>
-              <div tabindex="0" data-item-id="<%= item.itemId %>" class="rich-item piece piece-<%= item.rarity %>-bg <%= getRarityUpgradeClass(item) %>">
-                <% if(rarityOrder.indexOf(item.rarity) <= 4){ %>
-                  <div class="piece-shine"></div>
-                <% } %>
-                <% itemIcon(item, ['piece-icon']); %>
-              </div>
+            <div tabindex="0" data-item-id="<%= item.itemId %>" class="rich-item piece piece-<%= item.rarity %>-bg <%= getRarityUpgradeClass(item) %>">
+              <% if(rarityOrder.indexOf(item.rarity) <= 4){ %>
+              <div class="piece-shine"></div>
+              <% } %>
+              <% itemIcon(item, ['piece-icon']); %>
+            </div>
             <% } %>
           </div>
           <div data-bonus-stats="armor"></div>
-        <% } %>
-        <% if(items.wardrobe.length > 0){ %>
+          <% } %>
+          <% if(items.wardrobe.length > 0){ %>
           <p class="stat-sub-header">Wardrobe</p>
           <div class="pieces wardrobe">
-          <% for(const set of items.wardrobe){ %>
+            <% for(const set of items.wardrobe){ %>
             <div class="wardrobe-set">
               <% for(const [index, item] of set.entries()) { %>
-                <% if (item) { %>
-                  <div tabindex="0" data-item-id="<%= item.itemId %>" class="rich-item piece piece-<%= item.rarity %>-bg <%= getRarityUpgradeClass(item) %> index-<%= index %>">
-                    <% if(rarityOrder.indexOf(item.rarity) <= 4){ %>
-                      <div class="piece-shine"></div>
-                    <% } %>
-                    <% itemIcon(item, ['piece-icon']); %>
-                  </div>
-                <% } else { %>
-                  <div class="piece armor-placeholder index-<%= index %>">
-                    <div class="piece-icon item-icon custom-icon"></div>
-                  </div>
+              <% if (item) { %>
+              <div tabindex="0" data-item-id="<%= item.itemId %>" class="rich-item piece piece-<%= item.rarity %>-bg <%= getRarityUpgradeClass(item) %> index-<%= index %>">
+                <% if(rarityOrder.indexOf(item.rarity) <= 4){ %>
+                <div class="piece-shine"></div>
                 <% } %>
+                <% itemIcon(item, ['piece-icon']); %>
+              </div>
+              <% } else { %>
+              <div class="piece armor-placeholder index-<%= index %>">
+                <div class="piece-icon item-icon custom-icon"></div>
+              </div>
+              <% } %>
               <% } %>
             </div>
-          <% } %>
-        <% } %>
+            <% } %>
+            <% } %>
+          </div>
         </div>
       </div>
-    </div>
-    <% if(!items.no_inventory){ %>
+      <% if(!items.no_inventory){ %>
       <div class="stat-container stat-weapons">
         <a class="stat-anchor" id="Weapons"></a>
         <h2 class="stat-header">Weapons</h2>
         <div class="stat-content">
           <% if (items.weapons.length == 0) { %>
-            <div class="no-access"><%= calculated.display_name %> doesn't have any weapons.</div>
+          <div class="no-access"><%= calculated.display_name %> doesn't have any weapons.</div>
           <% } else { %>
-            <% if (items.highest_rarity_sword) { %>
-              <p class="stat-raw-values">
-                <span class="stat-name">Active Weapon: </span>
-                <span class="stat-active-weapon stat-value"><%- helper.renderLore(items.highest_rarity_sword.tag.display.Name) %></span>
-              </p>
-            <% } else if (items.weapons.length > 0) { %>
-              <p class="stat-raw-values">
-                <span class="stat-name">Active Weapon: </span><span class="stat-active-weapon stat-value piece-common-fg">None</span>
-              </p>
-            <% } %>
-            <div class="pieces">
-              <%
+          <% if (items.highest_rarity_sword) { %>
+          <p class="stat-raw-values">
+            <span class="stat-name">Active Weapon: </span>
+            <span class="stat-active-weapon stat-value"><%- helper.renderLore(items.highest_rarity_sword.tag.display.Name) %></span>
+          </p>
+          <% } else if (items.weapons.length > 0) { %>
+          <p class="stat-raw-values">
+            <span class="stat-name">Active Weapon: </span><span class="stat-active-weapon stat-value piece-common-fg">None</span>
+          </p>
+          <% } %>
+          <div class="pieces">
+            <%
                 items.weapons.filter(a => !a.hidden).forEach(item => {
               %>
-                  <div
-                    tabindex="0"
-                    data-item-id="<%= item.itemId %>"
-                    class="
+            <div tabindex="0" data-item-id="<%= item.itemId %>" class="
                       rich-item
                       piece
                       piece-<%= item.rarity %>-bg
                       <%= getRarityUpgradeClass(item) %>
-                    "
-                  >
-                    <% if (rarityOrder.indexOf(item.rarity) <= 4) { %>
-                      <div class="piece-shine"></div>
-                    <% } %>
-                    <% itemIcon(item, ['piece-icon']); %>
-                  </div>
-              <%
+                    ">
+              <% if (rarityOrder.indexOf(item.rarity) <= 4) { %>
+              <div class="piece-shine"></div>
+              <% } %>
+              <% itemIcon(item, ['piece-icon']); %>
+            </div>
+            <%
                 });
               %>
-            </div>
+          </div>
           <% } %>
         </div>
       </div>
@@ -974,26 +972,26 @@ const metaDescription = getMetaDescription()
         <h2 class="stat-header">Accessories</h2>
         <div class="stat-content">
           <% if(items.no_inventory){ %>
-            <div class="no-access"><%= calculated.display_name %> doesn't have inventory access via API enabled. <a target="_blank" class="enable-api" href="/resources/video/enable-api.mp4">See here</a> how to enable full API access.</div>
+          <div class="no-access"><%= calculated.display_name %> doesn't have inventory access via API enabled. <a target="_blank" class="enable-api" href="/resources/video/enable-api.mp4">See here</a> how to enable full API access.</div>
           <% }else if(items.accessories.length == 0){ %>
-            <div class="no-access"><%= calculated.display_name %> doesn't have any accessories.</div>
+          <div class="no-access"><%= calculated.display_name %> doesn't have any accessories.</div>
           <% }else{ %>
-            <p class="stat-raw-values">
-              <%
+          <p class="stat-raw-values">
+            <%
                 const maxTalis = items.accessories.filter(a => a.isUnique).length >= constants.UNIQUE_ACCESSORIES_COUNT ? 'golden-text': ''
                 const maxRecombTalis = items.accessories.filter(a => a.isUnique && a.extra?.recombobulated).length >= constants.UNIQUE_ACCESSORIES_COUNT ? 'golden-text': ''
               %>
 
-              <span class="stat-name <%= maxTalis %>">Unique Accessories: </span>
-              <span class="stat-value <%= maxTalis %>"><%= items.accessories.filter(a => a.isUnique).length %> / <%= constants.UNIQUE_ACCESSORIES_COUNT %></span>
-              <br>
-              <span class="stat-name <%= maxTalis %>">Completion: </span>
-              <span class="stat-value percent <%= maxTalis %>"><%= Math.round(items.accessories.filter(a => a.isUnique).length / constants.UNIQUE_ACCESSORIES_COUNT * 100) %></span>
-              <br>
-              <span class="stat-name <%= maxRecombTalis %>">Recombobulated: </span>
-              <span class="stat-value <%= maxRecombTalis %>"><%= items.accessories.filter(a => a.isUnique && a.extra?.recombobulated).length %> / <%= constants.UNIQUE_ACCESSORIES_COUNT %></span>
-              <br>
-              <%
+            <span class="stat-name <%= maxTalis %>">Unique Accessories: </span>
+            <span class="stat-value <%= maxTalis %>"><%= items.accessories.filter(a => a.isUnique).length %> / <%= constants.UNIQUE_ACCESSORIES_COUNT %></span>
+            <br>
+            <span class="stat-name <%= maxTalis %>">Completion: </span>
+            <span class="stat-value percent <%= maxTalis %>"><%= Math.round(items.accessories.filter(a => a.isUnique).length / constants.UNIQUE_ACCESSORIES_COUNT * 100) %></span>
+            <br>
+            <span class="stat-name <%= maxRecombTalis %>">Recombobulated: </span>
+            <span class="stat-value <%= maxRecombTalis %>"><%= items.accessories.filter(a => a.isUnique && a.extra?.recombobulated).length %> / <%= constants.UNIQUE_ACCESSORIES_COUNT %></span>
+            <br>
+            <%
                 const rarities = items.accessory_rarities;
                 const player_magical_power = {}
 
@@ -1005,7 +1003,7 @@ const metaDescription = getMetaDescription()
                 const mp_hegemony = rarities.hegemony ? constants.MAGICAL_POWER[rarities.hegemony.rarity] : 0
                 const mp_total = Object.values(player_magical_power).reduce((a, b) => a + b) + mp_hegemony;
               %>
-              <span data-tippy-content="
+            <span data-tippy-content="
               Accessories Breakdown<br>
               <span style='color: var(--§8);' class='grey-text'>From your accessory bag</span><br><br>
               <span style='color: var(--§6);' class='grey-text'>22 MP</span> × <span style='color: var(--§d);' class='grey-text'><%= rarities.mythic %> Accs.</span> = <span style='color: var(--§6);' class='grey-text'><%= player_magical_power.mythic.toLocaleString() %> MP</span><br>
@@ -1022,68 +1020,66 @@ const metaDescription = getMetaDescription()
               <% } %>
               Total: <span style='color: var(--§6);' class='grey-text'><%= mp_total.toLocaleString() %> Magical Power</span>
               ">
-                <span class="stat-name">Magical Power: </span><span class="stat-value"><%= mp_total.toLocaleString() %></span>
-              </span>
-            </p>
-            <% if(items.accessories.find(a => !a.isInactive) != undefined){ %>
-              <div class="accessory-list">
-                <p class="stat-sub-header" style="margin-bottom: 5px">Active Accessories</p>
-                <% items.accessories.filter(a => !a.isInactive).forEach(item => {
+              <span class="stat-name">Magical Power: </span><span class="stat-value"><%= mp_total.toLocaleString() %></span>
+            </span>
+          </p>
+          <% if(items.accessories.find(a => !a.isInactive) != undefined){ %>
+          <div class="accessory-list">
+            <p class="stat-sub-header" style="margin-bottom: 5px">Active Accessories</p>
+            <% items.accessories.filter(a => !a.isInactive).forEach(item => {
                   %>
-                  <div tabindex="0" data-item-id="<%= item.itemId %>"
-                  class="rich-item piece piece-<%= item.rarity %>-bg <%= getRarityUpgradeClass(item) %>">
-                    <% if(rarityOrder.indexOf(item.rarity) <= 4){ %>
-                      <div class="piece-shine"></div>
-                    <% } %>
-                    <% itemIcon(item, ['piece-icon']); %>
-                  </div>
-                <% }) %>
-                <div class="accessories-extras">
-                  <div><%- getEnrichments(items.accessories.filter(a => a.isUnique && !a.isInactive)) %></div>
-                  <div data-bonus-stats="accessories,new_year_cake_bag"></div>
-                </div>
-              </div>
-            <% } %>
-            <% if(items.accessories.find(a => a.isUnique && a.isInactive) != undefined){ %>
-              <div class="accessory-list">
-                <p class="stat-sub-header">Inactive Accessories</p>
-                <% items.accessories.filter(a => a.isUnique && a.isInactive).forEach(item => { %>
-                  <div tabindex="0" data-item-id="<%= item.itemId %>"
-                  class="rich-item piece piece-<%= item.rarity %>-bg <%= getRarityUpgradeClass(item) %>">
-                    <% if(rarityOrder.indexOf(item.rarity) <= 4){ %>
-                      <div class="piece-shine"></div>
-                    <% } %>
-                    <% itemIcon(item, ['piece-icon']); %>
-                  </div>
-                <% }) %>
-              </div>
-            <% } %>
-            <% if(calculated.missingAccessories.missing.length > 0 || calculated.missingAccessories.upgrades.length > 0){ %>
-              <% if(items.accessories.length == 1){ %>
-                <br>
+            <div tabindex="0" data-item-id="<%= item.itemId %>" class="rich-item piece piece-<%= item.rarity %>-bg <%= getRarityUpgradeClass(item) %>">
+              <% if(rarityOrder.indexOf(item.rarity) <= 4){ %>
+              <div class="piece-shine"></div>
               <% } %>
-              <button class="stat-sub-header extender" aria-controls="missing-accessories" aria-expanded="false">Missing Accessories</button>
-              <div class="pieces extendable" id="missing-accessories">
-                <br>
-                <p class="stat-sub-header">Missing Accessories<span data-tippy-content='Missing accessories that are <strong>not</strong> upgrades of another accessory.'></span></p>
-                <% for(const [index, accessory] of calculated.missingAccessories.missing.entries()){ %>
-                  <div tabindex="0" data-missing-accessory-index="<%= index %>" class="rich-item piece piece-<%= accessory.rarity %>-bg missing-accessory">
-                    <div style='background-image: url("<%= accessory.texture_path %>")' class="piece-icon item-icon custom-icon"></div>
-                  </div>
-                <% } %>
-                <p class="stat-sub-header">Missing Accessory Upgrades<span data-tippy-content='Missing accessories that are upgrades of a lower tier accessory.'></span></p>
-                <% for(const [index, accessory] of calculated.missingAccessories.upgrades.entries()){ %>
-                  <div tabindex="0" data-upgrade-accessory-index="<%= index %>" class="rich-item piece piece-<%= accessory.rarity %>-bg missing-accessory">
-                    <div style='background-image: url("<%= accessory.texture_path %>")' class="piece-icon item-icon custom-icon"></div>
-                  </div>
-                <% } %>
-              </div>
+              <% itemIcon(item, ['piece-icon']); %>
+            </div>
+            <% }) %>
+            <div class="accessories-extras">
+              <div><%- getEnrichments(items.accessories.filter(a => a.isUnique && !a.isInactive)) %></div>
+              <div data-bonus-stats="accessories,new_year_cake_bag"></div>
+            </div>
+          </div>
+          <% } %>
+          <% if(items.accessories.find(a => a.isUnique && a.isInactive) != undefined){ %>
+          <div class="accessory-list">
+            <p class="stat-sub-header">Inactive Accessories</p>
+            <% items.accessories.filter(a => a.isUnique && a.isInactive).forEach(item => { %>
+            <div tabindex="0" data-item-id="<%= item.itemId %>" class="rich-item piece piece-<%= item.rarity %>-bg <%= getRarityUpgradeClass(item) %>">
+              <% if(rarityOrder.indexOf(item.rarity) <= 4){ %>
+              <div class="piece-shine"></div>
+              <% } %>
+              <% itemIcon(item, ['piece-icon']); %>
+            </div>
+            <% }) %>
+          </div>
+          <% } %>
+          <% if(calculated.missingAccessories.missing.length > 0 || calculated.missingAccessories.upgrades.length > 0){ %>
+          <% if(items.accessories.length == 1){ %>
+          <br>
+          <% } %>
+          <button class="stat-sub-header extender" aria-controls="missing-accessories" aria-expanded="false">Missing Accessories</button>
+          <div class="pieces extendable" id="missing-accessories">
+            <br>
+            <p class="stat-sub-header">Missing Accessories<span data-tippy-content='Missing accessories that are <strong>not</strong> upgrades of another accessory.'></span></p>
+            <% for(const [index, accessory] of calculated.missingAccessories.missing.entries()){ %>
+            <div tabindex="0" data-missing-accessory-index="<%= index %>" class="rich-item piece piece-<%= accessory.rarity %>-bg missing-accessory">
+              <div style='background-image: url("<%= accessory.texture_path %>")' class="piece-icon item-icon custom-icon"></div>
+            </div>
             <% } %>
+            <p class="stat-sub-header">Missing Accessory Upgrades<span data-tippy-content='Missing accessories that are upgrades of a lower tier accessory.'></span></p>
+            <% for(const [index, accessory] of calculated.missingAccessories.upgrades.entries()){ %>
+            <div tabindex="0" data-upgrade-accessory-index="<%= index %>" class="rich-item piece piece-<%= accessory.rarity %>-bg missing-accessory">
+              <div style='background-image: url("<%= accessory.texture_path %>")' class="piece-icon item-icon custom-icon"></div>
+            </div>
+            <% } %>
+          </div>
+          <% } %>
           <% } %>
         </div>
       </div>
-    <% } %>
-    <% if(calculated.pets.length > 0){ %>
+      <% } %>
+      <% if(calculated.pets.length > 0){ %>
       <div class="stat-container stat-pets">
         <a class="stat-anchor" id="Pets"></a>
         <h2 class="stat-header">Pets</h2>
@@ -1154,180 +1150,179 @@ const metaDescription = getMetaDescription()
             const otherPets = calculated.pets.filter(pet => !pet.active).slice(0, petsToShowLimit)
           %>
           <% if (activePet) { %>
-            <p class="stat-sub-header">Active Pet</p>
-            <div class="pieces">
-              <div tabindex="0" data-pet-index="0" class="active-pet rich-item piece piece-<%= activePet.rarity %>-bg <%= getRarityUpgradeClass(activePet) %>">
-                <% if (rarityOrder.indexOf(activePet.rarity) <= 4) { %>
-                  <div class="piece-shine"></div>
-                <% } %>
-                <div style='background-image: url("<%= activePet.texture_path %>")' class="piece-icon item-icon custom-icon"></div>
-              </div>
-              <div class="active-pet-info">
-                <div class="pet-name piece-<%= activePet.rarity %>-fg"><%= activePet.rarity %> <%- activePet.display_name %></div>
-                <div class="pet-level">Level <%= activePet.level.level %></div>
-              </div>
+          <p class="stat-sub-header">Active Pet</p>
+          <div class="pieces">
+            <div tabindex="0" data-pet-index="0" class="active-pet rich-item piece piece-<%= activePet.rarity %>-bg <%= getRarityUpgradeClass(activePet) %>">
+              <% if (rarityOrder.indexOf(activePet.rarity) <= 4) { %>
+              <div class="piece-shine"></div>
+              <% } %>
+              <div style='background-image: url("<%= activePet.texture_path %>")' class="piece-icon item-icon custom-icon"></div>
             </div>
-            <div data-bonus-stats="pet"></div>
+            <div class="active-pet-info">
+              <div class="pet-name piece-<%= activePet.rarity %>-fg"><%= activePet.rarity %> <%- activePet.display_name %></div>
+              <div class="pet-level">Level <%= activePet.level.level %></div>
+            </div>
+          </div>
+          <div data-bonus-stats="pet"></div>
           <% } %>
           <% if (otherPets) { %>
-            <p class="stat-sub-header"><%= activePet ? 'Other Pets' : '' %></p>
-            <div class="pieces">
-              <% for(const [index, pet] of otherPets.entries()) { %>
+          <p class="stat-sub-header"><%= activePet ? 'Other Pets' : '' %></p>
+          <div class="pieces">
+            <% for(const [index, pet] of otherPets.entries()) { %>
 
-                <% if (
+            <% if (
                   (activePet && index === petsToShow - 1) ||
                   (!activePet && index === petsToShow)
                 ) { %>
-                  </div>
-                  <button class="stat-sub-header extender" aria-controls="showmore-pets" aria-expanded="false">Show More Pets</button>
-                  <div class="pieces extendable" id="showmore-pets">
-                <% } %>
+          </div>
+          <button class="stat-sub-header extender" aria-controls="showmore-pets" aria-expanded="false">Show More Pets</button>
+          <div class="pieces extendable" id="showmore-pets">
+            <% } %>
 
-                <div tabindex="0" data-pet-index="<%= activePet ? index + 1 : index %>" class="other-pet rich-item piece piece-<%= pet.rarity %>-bg <%= getRarityUpgradeClass(pet) %>">
-                  <% if(rarityOrder.indexOf(pet.rarity) <= 4) { %>
-                    <div class="piece-shine"></div>
-                  <% } %>
-                  <div style='background-image: url("<%= pet.texture_path %>")' class="piece-icon item-icon custom-icon"></div>
-                  <div class="other-pet-level"><abbr title="Level">Lvl</abbr> <%= pet.level.level %></div>
-                </div>
+            <div tabindex="0" data-pet-index="<%= activePet ? index + 1 : index %>" class="other-pet rich-item piece piece-<%= pet.rarity %>-bg <%= getRarityUpgradeClass(pet) %>">
+              <% if(rarityOrder.indexOf(pet.rarity) <= 4) { %>
+              <div class="piece-shine"></div>
               <% } %>
+              <div style='background-image: url("<%= pet.texture_path %>")' class="piece-icon item-icon custom-icon"></div>
+              <div class="other-pet-level"><abbr title="Level">Lvl</abbr> <%= pet.level.level %></div>
             </div>
+            <% } %>
+          </div>
           <% } %>
           <% if(calculated.missingPets.length > 0) { %>
-            <% if(calculated.pets.length == 1) { %>
-              <br>
-            <% } %>
-            <button class="stat-sub-header extender" aria-controls="missing-pets" aria-expanded="false">Missing Pets</button>
-            <div class="pieces extendable" id="missing-pets">
-              <% for(const [index, pet] of calculated.missingPets.entries()) { %>
-                <div tabindex="0" data-missing-pet-index="<%= index %>" class="rich-item piece piece-<%= pet.rarity %>-bg missing-pet">
-                  <div style='background-image: url("<%= pet.texture_path %>")' class="piece-icon item-icon custom-icon"></div>
-                </div>
-              <% } %>
+          <% if(calculated.pets.length == 1) { %>
+          <br>
+          <% } %>
+          <button class="stat-sub-header extender" aria-controls="missing-pets" aria-expanded="false">Missing Pets</button>
+          <div class="pieces extendable" id="missing-pets">
+            <% for(const [index, pet] of calculated.missingPets.entries()) { %>
+            <div tabindex="0" data-missing-pet-index="<%= index %>" class="rich-item piece piece-<%= pet.rarity %>-bg missing-pet">
+              <div style='background-image: url("<%= pet.texture_path %>")' class="piece-icon item-icon custom-icon"></div>
             </div>
+            <% } %>
+          </div>
           <% } %>
         </div>
       </div>
-    <% } %>
-    <% if(!items.no_inventory){ %>
+      <% } %>
+      <% if(!items.no_inventory){ %>
       <div class="stat-container stat-inventory">
         <a class="stat-anchor" id="Inventory"></a>
         <h2 class="stat-header">Inventory</h2>
         <div class="stat-content">
           <% if(items.no_inventory){ %>
-            <div class="no-access"><%= calculated.display_name %> doesn't have inventory access via API enabled. <a target="_blank" class="enable-api" href="/resources/video/enable-api.mp4">See here</a> how to enable full API access.</div>
+          <div class="no-access"><%= calculated.display_name %> doesn't have inventory access via API enabled. <a target="_blank" class="enable-api" href="/resources/video/enable-api.mp4">See here</a> how to enable full API access.</div>
           <% }else{ %>
-            <div id="inventory_container">
-              <div id="inventory_header">
-                <div class="inventory-header-line"></div>
-                <div class="inventory-tabs-container">
-                  <%
+          <div id="inventory_container">
+            <div id="inventory_header">
+              <div class="inventory-header-line"></div>
+              <div class="inventory-tabs-container">
+                <%
                     const inventoryIconUrl = `https://crafatar.com/renders/head/${extra.isFoolsDay ? 'bd482739767c45dca1f8c33c40530952' : calculated.uuid }?size=32&overlay`
                   %>
-                  <button class="inventory-tab active-inventory" data-inventory-type="inventory">
-                    <div
-                      class="inventory-tab-icon item-icon custom-icon"
-                      style="background-image: url('<%= inventoryIconUrl %>')"
-                    ></div>
-                    <div class="inventory-tab-name"><abbr title="Inventory">Inv</abbr></div>
-                  </button>
+                <button class="inventory-tab active-inventory" data-inventory-type="inventory">
+                  <div class="inventory-tab-icon item-icon custom-icon" style="background-image: url('<%= inventoryIconUrl %>')"></div>
+                  <div class="inventory-tab-name"><abbr title="Inventory">Inv</abbr></div>
+                </button>
 
-                  <% if(items.storage.length > 0){ %>
-                    <button class="inventory-tab" data-inventory-type="storage">
-                      <div class="inventory-tab-icon item-icon icon-54_0"></div>
-                      <div class="inventory-tab-name">Storage</div>
-                    </button>
-                  <% } %>
+                <% if(items.storage.length > 0){ %>
+                <button class="inventory-tab" data-inventory-type="storage">
+                  <div class="inventory-tab-icon item-icon icon-54_0"></div>
+                  <div class="inventory-tab-name">Storage</div>
+                </button>
+                <% } %>
 
-                  <% if(items.enderchest.length > 0){ %>
-                    <button class="inventory-tab" data-inventory-type="enderchest">
-                      <div class="inventory-tab-icon item-icon icon-130_0"></div>
-                      <div class="inventory-tab-name"><abbr title="Enderchest">Ender</abbr></div>
-                    </button>
-                  <% } %>
+                <% if(items.enderchest.length > 0){ %>
+                <button class="inventory-tab" data-inventory-type="enderchest">
+                  <div class="inventory-tab-icon item-icon icon-130_0"></div>
+                  <div class="inventory-tab-name"><abbr title="Enderchest">Ender</abbr></div>
+                </button>
+                <% } %>
 
-                  <% if(items.personal_vault.length > 0){ %>
-                    <button class="inventory-tab" data-inventory-type="personal_vault">
-                      <div class="inventory-tab-icon item-icon custom-icon" style="background-image: url(/head/f7aadff9ddc546fdcec6ed5919cc39dfa8d0c07ff4bc613a19f2e6d7f2593)"></div>
-                      <div class="inventory-tab-name"><abbr title="Personal Vault">Vault</abbr></div>
-                    </button>
-                  <% } %>
+                <% if(items.personal_vault.length > 0){ %>
+                <button class="inventory-tab" data-inventory-type="personal_vault">
+                  <div class="inventory-tab-icon item-icon custom-icon" style="background-image: url(/head/f7aadff9ddc546fdcec6ed5919cc39dfa8d0c07ff4bc613a19f2e6d7f2593)"></div>
+                  <div class="inventory-tab-name"><abbr title="Personal Vault">Vault</abbr></div>
+                </button>
+                <% } %>
 
-                  <% if(items.accessory_bag.length > 0){ %>
-                    <button class="inventory-tab" data-inventory-type="accessory_bag">
-                      <div class="inventory-tab-icon item-icon custom-icon" style="background-image: url(/head/961a918c0c49ba8d053e522cb91abc74689367b4d8aa06bfc1ba9154730985ff)"></div>
-                      <div class="inventory-tab-name"><abbr title="Accessory Bag">Accs</abbr></div>
-                    </button>
-                  <% } %>
+                <% if(items.accessory_bag.length > 0){ %>
+                <button class="inventory-tab" data-inventory-type="accessory_bag">
+                  <div class="inventory-tab-icon item-icon custom-icon" style="background-image: url(/head/961a918c0c49ba8d053e522cb91abc74689367b4d8aa06bfc1ba9154730985ff)"></div>
+                  <div class="inventory-tab-name"><abbr title="Accessory Bag">Accs</abbr></div>
+                </button>
+                <% } %>
 
-                  <% if(items.potion_bag.length > 0){ %>
-                    <button class="inventory-tab" data-inventory-type="potion_bag">
-                      <div class="inventory-tab-icon item-icon custom-icon" style="background-image: url(/head/9f8b82427b260d0a61e6483fc3b2c35a585851e08a9a9df372548b4168cc817c)"></div>
-                      <div class="inventory-tab-name"><abbr title="Potion Bag">Pots</abbr></div>
-                    </button>
-                  <% } %>
+                <% if(items.potion_bag.length > 0){ %>
+                <button class="inventory-tab" data-inventory-type="potion_bag">
+                  <div class="inventory-tab-icon item-icon custom-icon" style="background-image: url(/head/9f8b82427b260d0a61e6483fc3b2c35a585851e08a9a9df372548b4168cc817c)"></div>
+                  <div class="inventory-tab-name"><abbr title="Potion Bag">Pots</abbr></div>
+                </button>
+                <% } %>
 
-                  <% if(items.fishing_bag.length > 0){ %>
-                    <button class="inventory-tab" data-inventory-type="fishing_bag">
-                      <div class="inventory-tab-icon item-icon custom-icon" style="background-image: url(/head/eb8e297df6b8dffcf135dba84ec792d420ad8ecb458d144288572a84603b1631)"></div>
-                      <div class="inventory-tab-name"><abbr title="Fishing Bag">Fish</abbr></div>
-                    </button>
-                  <% } %>
+                <% if(items.fishing_bag.length > 0){ %>
+                <button class="inventory-tab" data-inventory-type="fishing_bag">
+                  <div class="inventory-tab-icon item-icon custom-icon" style="background-image: url(/head/eb8e297df6b8dffcf135dba84ec792d420ad8ecb458d144288572a84603b1631)"></div>
+                  <div class="inventory-tab-name"><abbr title="Fishing Bag">Fish</abbr></div>
+                </button>
+                <% } %>
 
-                  <% if(items.quiver.length > 0){ %>
-                    <button class="inventory-tab" data-inventory-type="quiver">
-                      <div class="inventory-tab-icon item-icon custom-icon" style="background-image: url(/head/4cb3acdc11ca747bf710e59f4c8e9b3d949fdd364c6869831ca878f0763d1787)"></div>
-                      <div class="inventory-tab-name">Quiver</div>
-                    </button>
-                  <% } %>
-                </div>
+                <% if(items.quiver.length > 0){ %>
+                <button class="inventory-tab" data-inventory-type="quiver">
+                  <div class="inventory-tab-icon item-icon custom-icon" style="background-image: url(/head/4cb3acdc11ca747bf710e59f4c8e9b3d949fdd364c6869831ca878f0763d1787)"></div>
+                  <div class="inventory-tab-name">Quiver</div>
+                </button>
+                <% } %>
               </div>
-              <inventory-view></inventory-view>
             </div>
+            <inventory-view></inventory-view>
+          </div>
           <% } %>
         </div>
       </div>
-    <% } %>
-    <div class="stat-container stat-skills">
-      <a class="stat-anchor" id="Skills"></a>
-      <h2 class="stat-header">Skills</h2>
-      <div class="stat-content">
+      <% } %>
+      <div class="stat-container stat-skills">
+        <a class="stat-anchor" id="Skills"></a>
+        <h2 class="stat-header">Skills</h2>
+        <div class="stat-content">
 
-        <div class="stat-mining">
-          <div class="category-header">
-            <div class="category-icon"><div class="item-icon icon-274_0"></div></div>
-            <span>mining</span>
-          </div>
+          <div class="stat-mining">
+            <div class="category-header">
+              <div class="category-icon">
+                <div class="item-icon icon-274_0"></div>
+              </div>
+              <span>mining</span>
+            </div>
 
-          <% const mining = calculated.mining; %>
+            <% const mining = calculated.mining; %>
 
-          <% if(items.mining_tools.length > 0){ %>
+            <% if(items.mining_tools.length > 0){ %>
             <p class="stat-sub-header">Mining Tools</p>
             <% if(items.highest_rarity_mining_tool){ %>
-              <p class="stat-raw-values">
-                <span class="stat-name">Active Tool: </span>
-                <span class="stat-active-pickaxe stat-value"><%- helper.renderLore(items.highest_rarity_mining_tool.tag.display.Name) %></span>
-              </p>
+            <p class="stat-raw-values">
+              <span class="stat-name">Active Tool: </span>
+              <span class="stat-active-pickaxe stat-value"><%- helper.renderLore(items.highest_rarity_mining_tool.tag.display.Name) %></span>
+            </p>
             <% }else{ %>
-              <p class="stat-raw-values">
-                <span class="stat-name">Active Tool: </span><span class="stat-active-pickaxe stat-value piece-common-fg">None</span>
-              </p>
+            <p class="stat-raw-values">
+              <span class="stat-name">Active Tool: </span><span class="stat-active-pickaxe stat-value piece-common-fg">None</span>
+            </p>
             <% } %>
             <div class="pieces">
               <%  items.mining_tools.filter(a => !a.hidden).forEach(item => { %>
-                  <div tabindex="0" data-item-id="<%= item.itemId %>" class="rich-item piece piece-<%= item.rarity %>-bg <%= getRarityUpgradeClass(item) %>">
-                    <% if(rarityOrder.indexOf(item.rarity) <= 4){ %>
-                      <div class="piece-shine"></div>
-                    <% } %>
-                    <% itemIcon(item, ['piece-icon']); %>
-                  </div>
+              <div tabindex="0" data-item-id="<%= item.itemId %>" class="rich-item piece piece-<%= item.rarity %>-bg <%= getRarityUpgradeClass(item) %>">
+                <% if(rarityOrder.indexOf(item.rarity) <= 4){ %>
+                <div class="piece-shine"></div>
+                <% } %>
+                <% itemIcon(item, ['piece-icon']); %>
+              </div>
               <% }); %>
             </div>
-          <% } %>
+            <% } %>
 
-          <% if (!mining.core) { %>
+            <% if (!mining.core) { %>
             <p class="no-access"><%= calculated.display_name %> hasn't visited Dwarven Mines or Crystal Hollows yet.</p>
-          <% } else { %>
+            <% } else { %>
             <p class="stat-sub-header">Dwarven Mines & Crystal Hollows</p>
             <p class="stat-raw-values">
               <!-- Commissions Milestone -->
@@ -1437,38 +1432,42 @@ const metaDescription = getMetaDescription()
             <div id="inventory_container">
               <inventory-view inventory-type="hotm"></inventory-view>
             </div>
-          <% } %>
+            <% } %>
 
-          <p class="stat-sub-header">Forge</p>
-          <%
+            <p class="stat-sub-header">Forge</p>
+            <%
             if (mining.forge?.processes?.length > 0) {
               mining.forge.processes.forEach(process => {
           %>
             <div class="forge-item">
               <p class="stat-name forge-slot">Slot <%= process.slot %>:</p>
               <% if (!process.id.startsWith("UNKNOWN-")) { %>
-                <span data-tippy-content="<local-time timestamp='<%= process.timeFinished %>'></local-time>" class="stat-value"><%= process.name %> - <%= process.timeFinished < Date.now() ? "ended" : `ending ${process.timeFinishedText}`%></span>
+              <span data-tippy-content="<local-time timestamp='<%= process.timeFinished %>'></local-time>" class="stat-value"><%= process.name %> - <%= process.timeFinished < Date.now() ? "ended" : `ending ${process.timeFinishedText}`%></span>
               <% } else { %>
-                <span class="stat-value">Unknown item</span>
-                <script>console.error("Unknown forge item id: <%= process.id.split('UNKNOWN-')[1] %>")</script>
+              <span class="stat-value">Unknown item</span>
+              <script>
+                console.error("Unknown forge item id: <%= process.id.split('UNKNOWN-')[1] %>")
+              </script>
               <% } %>
             </div>
-          <%
+            <%
               });
             } else {
           %>
             <p class="stat-raw-values">No items currently forging!</p>
-          <% } %>
-        </div>
-
-        <% if(calculated.farming.talked){ %>
-        <div class="stat-farming">
-          <div class="category-header">
-            <div class="category-icon" onclick="window.open('https://www.youtube.com/watch?v=pZaY1jV96jI')"><div class="item-icon icon-294_0"></div></div>
-            <span>farming</span>
+            <% } %>
           </div>
 
-          <% const farming = calculated.farming;
+          <% if(calculated.farming.talked){ %>
+          <div class="stat-farming">
+            <div class="category-header">
+              <div class="category-icon" onclick="window.open('https://www.youtube.com/watch?v=pZaY1jV96jI')">
+                <div class="item-icon icon-294_0"></div>
+              </div>
+              <span>farming</span>
+            </div>
+
+            <% const farming = calculated.farming;
           if (farming.contests.attended_contests > 0) {%>
             <p class="stat-raw-values">
               <span class="stat-name">Contests attended: </span><span class="stat-value"><%= farming.contests.attended_contests.toLocaleString() %></span><br>
@@ -1477,7 +1476,7 @@ const metaDescription = getMetaDescription()
 
             <p class="stat-raw-values">
               <% for(let badge of badgeOrder){ %>
-                <span data-tippy-content='
+              <span data-tippy-content='
                   <span class="stat-name">Current: </span><span class="stat-value"><%= farming.current_badges[badge].toLocaleString() %> Badges</span><br>
                   <span class="stat-name">Total: </span><span class="stat-value"><%= farming.total_badges[badge].toLocaleString() %> Badges</span>
                 '>
@@ -1485,37 +1484,37 @@ const metaDescription = getMetaDescription()
                 <span class="stat-value"><%= farming.total_badges[badge].toLocaleString() %></span></span><br>
               <% } %>
             </p>
-          <% }else{ %>
+            <% }else{ %>
             <p class="stat-raw-values">
               <%= calculated.display_name %> hasn't attended any contests yet.
             </p>
-          <% } %>
+            <% } %>
 
-          <% if(items.farming_tools.length > 0){ %>
+            <% if(items.farming_tools.length > 0){ %>
             <p class="stat-sub-header">Farming Tools</p>
             <% if(items.highest_rarity_farming_tool){ %>
-              <p class="stat-raw-values">
-                <span class="stat-name">Active Tool: </span>
-                <span class="stat-active-hoe stat-value"><%- helper.renderLore(items.highest_rarity_farming_tool.tag.display.Name) %></span>
-              </p>
+            <p class="stat-raw-values">
+              <span class="stat-name">Active Tool: </span>
+              <span class="stat-active-hoe stat-value"><%- helper.renderLore(items.highest_rarity_farming_tool.tag.display.Name) %></span>
+            </p>
             <% }else{ %>
-              <p class="stat-raw-values">
-                <span class="stat-name">Active Tool: </span><span class="stat-active-hoe stat-value piece-common-fg">None</span>
-              </p>
+            <p class="stat-raw-values">
+              <span class="stat-name">Active Tool: </span><span class="stat-active-hoe stat-value piece-common-fg">None</span>
+            </p>
             <% } %>
             <div class="pieces">
               <%  items.farming_tools.filter(a => !a.hidden).forEach(item => { %>
-                  <div tabindex="0" data-item-id="<%= item.itemId %>" class="rich-item piece piece-<%= item.rarity %>-bg <%= getRarityUpgradeClass(item) %>">
-                    <% if(rarityOrder.indexOf(item.rarity) <= 4){ %>
-                      <div class="piece-shine"></div>
-                    <% } %>
-                    <% itemIcon(item, ['piece-icon']); %>
-                  </div>
+              <div tabindex="0" data-item-id="<%= item.itemId %>" class="rich-item piece piece-<%= item.rarity %>-bg <%= getRarityUpgradeClass(item) %>">
+                <% if(rarityOrder.indexOf(item.rarity) <= 4){ %>
+                <div class="piece-shine"></div>
+                <% } %>
+                <% itemIcon(item, ['piece-icon']); %>
+              </div>
               <% }); %>
             </div>
-          <% } %>
+            <% } %>
 
-          <% if(Object.keys(calculated.farming.crops).length > 0){ %>
+            <% if(Object.keys(calculated.farming.crops).length > 0){ %>
             <button class="stat-sub-header extender" aria-controls="farming-crops" aria-expanded="false">Farming Crops</button>
             <div class="stat-farming-crops extendable" id="farming-crops">
               <%
@@ -1535,7 +1534,9 @@ const metaDescription = getMetaDescription()
                   `;
               %>
               <div class="chip" data-tippy-content="<%= amountsTooltip %>">
-                <div class="chip-icon-wrapper"><div class="item-icon icon-<%= crop.icon %>"></div></div>
+                <div class="chip-icon-wrapper">
+                  <div class="item-icon icon-<%= crop.icon %>"></div>
+                </div>
                 <div class="chip-text">
                   <div class="collection-name <%= crop.unique_gold ? 'max-minion' : '' %>"><span class="stat-name"><%= crop.name %></span></div>
                   <div class="collection-amount">
@@ -1546,17 +1547,19 @@ const metaDescription = getMetaDescription()
               </div>
               <% } %>
             </div>
-          <% } %>
-        </div>
-        <% } %>
-
-        <div class="stat-fishing">
-          <div class="category-header">
-            <div class="category-icon"><div class="item-icon icon-346_0"></div></div>
-            <span>fishing</span>
+            <% } %>
           </div>
+          <% } %>
 
-          <%
+          <div class="stat-fishing">
+            <div class="category-header">
+              <div class="category-icon">
+                <div class="item-icon icon-346_0"></div>
+              </div>
+              <span>fishing</span>
+            </div>
+
+            <%
           let totalSeaCreatureKills = 0;
 
           for(const creature of calculated.kills){
@@ -1566,23 +1569,23 @@ const metaDescription = getMetaDescription()
           }
           %>
 
-          <p class="stat-raw-values">
-            <span class="stat-name">Items fished: </span><span class="stat-value"><%= calculated.fishing.total.toLocaleString() %></span><br>
-            <span class="stat-name">Treasures fished: </span><span class="stat-value"><%= calculated.fishing.treasure.toLocaleString() %></span><br>
-            <span class="stat-name">Large treasures fished: </span><span class="stat-value"><%= calculated.fishing.treasure_large.toLocaleString() %></span><br>
-            <span class="stat-name">Sea Creatures killed: </span><span class="stat-value"><%= totalSeaCreatureKills.toLocaleString() %></span><br>
-            <%
+            <p class="stat-raw-values">
+              <span class="stat-name">Items fished: </span><span class="stat-value"><%= calculated.fishing.total.toLocaleString() %></span><br>
+              <span class="stat-name">Treasures fished: </span><span class="stat-value"><%= calculated.fishing.treasure.toLocaleString() %></span><br>
+              <span class="stat-name">Large treasures fished: </span><span class="stat-value"><%= calculated.fishing.treasure_large.toLocaleString() %></span><br>
+              <span class="stat-name">Sea Creatures killed: </span><span class="stat-value"><%= totalSeaCreatureKills.toLocaleString() %></span><br>
+              <%
             if(calculated.fishing.shredder_fished > 0 && calculated.fishing.shredder_bait > 0){
 
               %>
-            <span data-tippy-content='
+              <span data-tippy-content='
             <span class="stat-name">Fished with Shredder: </span><span class="stat-value"><%= calculated.fishing.shredder_fished.toLocaleString() %></span><br>
             <span class="stat-name">Bait used with Shredder: </span><span class="stat-value"><%= calculated.fishing.shredder_bait.toLocaleString() %></span><br>
             '><span class="stat-name">Fished with Shredder: </span><span class="stat-value"><%= calculated.fishing.shredder_fished.toLocaleString() %></span></span><br>
-            <% } %>
-          </p>
+              <% } %>
+            </p>
 
-          <% if(items.fishing_tools.length > 0){ %>
+            <% if(items.fishing_tools.length > 0){ %>
             <p class="stat-sub-header">Fishing Rods</p>
             <% if(items.highest_rarity_fishing_tool){ %>
             <p class="stat-raw-values">
@@ -1598,27 +1601,23 @@ const metaDescription = getMetaDescription()
               <%
                 items.fishing_tools.filter(a => !a.hidden).forEach(item => {
               %>
-                  <div
-                    tabindex="0"
-                    data-item-id="<%= item.itemId %>"
-                    class="
+              <div tabindex="0" data-item-id="<%= item.itemId %>" class="
                       rich-item
                       piece
                       piece-<%= item.rarity %>-bg <%= getRarityUpgradeClass(item) %>
-                    "
-                  >
-                    <% if(rarityOrder.indexOf(item.rarity) <= 4){ %>
-                      <div class="piece-shine"></div>
-                    <% } %>
-                    <% itemIcon(item, ['piece-icon']); %>
-                  </div>
+                    ">
+                <% if(rarityOrder.indexOf(item.rarity) <= 4){ %>
+                <div class="piece-shine"></div>
+                <% } %>
+                <% itemIcon(item, ['piece-icon']); %>
+              </div>
               <%
                 });
               %>
             </div>
-          <% } %>
+            <% } %>
 
-          <% if(totalSeaCreatureKills > 0){ %>
+            <% if(totalSeaCreatureKills > 0){ %>
             <button class="stat-sub-header extender" aria-controls="missing-seacreatures" aria-expanded="false">Sea Creatures</button>
             <div class="sea-creatures extendable" id="missing-seacreatures">
               <% for(const creatureId of seaCreatures) {
@@ -1626,87 +1625,91 @@ const metaDescription = getMetaDescription()
 
                 if(creature?.amount > 0 ) {
                   %>
-                  <div class="sea-creature">
-                    <div class="sea-creature-name"><span><%= creature.entityName %></span></div>
-                    <div class="sea-creature-image" style="background-image: url(/resources/img/sea_creatures/<%= creature.entityId %>.webp)"></div>
-                    <div class="sea-creature-kills"><span class="stat-value"><%= creature.amount.toLocaleString() %></span><span class="stat-name"> Kill<%= creature.amount != 1 ? 's' : '' %></span></div>
-                  </div>
-                  <%
+              <div class="sea-creature">
+                <div class="sea-creature-name"><span><%= creature.entityName %></span></div>
+                <div class="sea-creature-image" style="background-image: url(/resources/img/sea_creatures/<%= creature.entityId %>.webp)"></div>
+                <div class="sea-creature-kills"><span class="stat-value"><%= creature.amount.toLocaleString() %></span><span class="stat-name"> Kill<%= creature.amount != 1 ? 's' : '' %></span></div>
+              </div>
+              <%
                 }
               } %>
             </div>
-          <% } %>
-        </div>
-
-        <% if(calculated.enchanting.experimented){ %>
-        <div class="stat-enchanting">
-          <div class="category-header">
-            <div class="category-icon"><div class="item-icon icon-116_0"></div></div>
-            <span>enchanting</span>
+            <% } %>
           </div>
 
-          <% const enchanting = calculated.enchanting; %>
-          <button class="stat-sub-header extender" aria-controls="Experiments" aria-expanded="false">Experiments</button>
-          <div class="stat-experiments extendable narrow-info-container-wrapper" id="Experiments">
-            <% for(let game in enchanting.experiments){
-            const game_data = enchanting.experiments[game]; %>
-            <div class="narrow-info-container">
-              <div class="narrow-info-header">
-                <span><%= game_data.name %></span>
+          <% if(calculated.enchanting.experimented){ %>
+          <div class="stat-enchanting">
+            <div class="category-header">
+              <div class="category-icon">
+                <div class="item-icon icon-116_0"></div>
               </div>
-              <span>
-                <p class="stat-raw-values">
-                  <%
+              <span>enchanting</span>
+            </div>
+
+            <% const enchanting = calculated.enchanting; %>
+            <button class="stat-sub-header extender" aria-controls="Experiments" aria-expanded="false">Experiments</button>
+            <div class="stat-experiments extendable narrow-info-container-wrapper" id="Experiments">
+              <% for(let game in enchanting.experiments){
+            const game_data = enchanting.experiments[game]; %>
+              <div class="narrow-info-container">
+                <div class="narrow-info-header">
+                  <span><%= game_data.name %></span>
+                </div>
+                <span>
+                  <p class="stat-raw-values">
+                    <%
                     const game_stats = helper.sortObject(game_data.stats);
                     for(let stat in game_stats){
                   %>
                     <span class="stat-name"><%= helper.titleCase(stat.replace('_', ' ')) %>: </span>
                     <span class="stat-value"><%= (stat == 'last_attempt' || stat == 'last_claimed') ? game_stats[stat].text : game_stats[stat] %></span><br>
-                  <% } %>
-                </p>
-                <%
+                    <% } %>
+                  </p>
+                  <%
                 for(let tier in game_data.tiers) {
                   const tier_data = game_data.tiers[tier];
                 %>
-                <hr>
-                <div class="chip">
-                  <div class="chip-icon-wrapper"><div class="item-icon icon-<%= tier_data.icon.replace(':', '_'); %>"></div></div>
-                  <div class="chip-text">
-                    <div class="collection-name"><span class="stat-name"><%= tier_data.name %></span></div>
-                    <div class="collection-amount">
-                      <%
+                  <hr>
+                  <div class="chip">
+                    <div class="chip-icon-wrapper">
+                      <div class="item-icon icon-<%= tier_data.icon.replace(':', '_'); %>"></div>
+                    </div>
+                    <div class="chip-text">
+                      <div class="collection-name"><span class="stat-name"><%= tier_data.name %></span></div>
+                      <div class="collection-amount">
+                        <%
                       for(let info in tier_data) {
                         if(info == 'name' || info == 'icon') continue;
                       %>
-                      <small class="stat-name"><%= helper.titleCase(info.replace('_', ' ')) %>: </small><small class="stat-value"><%= tier_data[info] %></small><br>
-                      <% } %>
+                        <small class="stat-name"><%= helper.titleCase(info.replace('_', ' ')) %>: </small><small class="stat-value"><%= tier_data[info] %></small><br>
+                        <% } %>
+                      </div>
                     </div>
                   </div>
-                </div>
-                <% } %>
-              </span>
+                  <% } %>
+                </span>
+              </div>
+              <% } %>
             </div>
-            <% } %>
           </div>
+          <% } %>
         </div>
-        <% } %>
       </div>
-    </div>
-    <div class="stat-container stat-dungeons">
-      <a class="stat-anchor" id="Dungeons"></a>
-      <h2 class="stat-header">Dungeons</h2>
-      <div class="stat-content">
-      <% if (
+      <div class="stat-container stat-dungeons">
+        <a class="stat-anchor" id="Dungeons"></a>
+        <h2 class="stat-header">Dungeons</h2>
+        <div class="stat-content">
+          <% if (
         Object.keys(calculated.dungeons).length === 0 ||
         !calculated.dungeons.catacombs?.visited ||
         Object.keys(calculated.dungeons.catacombs.floors).length === 0
       ) { %>
-        <p class="stat-raw-values">
-          <%= calculated.display_name %> hasn't entered any dungeon yet.
-        </p>
-      <% } else { %>
+          <p class="stat-raw-values">
+            <%= calculated.display_name %> hasn't entered any dungeon yet.
+          </p>
+          <% } else { %>
 
-        <% if (calculated.dungeons.used_classes) { %>
+          <% if (calculated.dungeons.used_classes) { %>
           <div class="skill-bars">
             <skill-component skill="catacombs" type="dungeon" icon="<%= skillItems.catacombs %>"></skill-component>
 
@@ -1716,69 +1719,69 @@ const metaDescription = getMetaDescription()
             <skill-component skill="archer" type="dungeon_class" icon="<%= skillItems.archer %>"></skill-component>
             <skill-component skill="tank" type="dungeon_class" icon="<%= skillItems.tank %>"></skill-component>
           </div>
-        <% } %>
+          <% } %>
 
-        <p class="stat-raw-values" style="margin: 20px 0;">
-          <span class="stat-name">Selected Class: </span>
-          <span class="stat-value"><%= helper.titleCase(calculated.dungeons.selected_class) %></span>
-          <br>
-          <% max = calculated.dungeons.catacombs.bonuses.item_boost === 465 ? "golden-text" : "" %>
-          <span class="stat-name <%= max %>">Dungeon Item Boost: </span>
-          <span class="stat-value percent <%= max %>"><%= calculated.dungeons.catacombs.bonuses.item_boost.toLocaleString() %></span>
-          <br>
-          <% max = calculated.dungeons.catacombs.highest_floor === "floor_7" ? "golden-text" : "" %>
-          <span class="stat-name <%= max %>">Highest Floor Beaten (normal): </span>
-          <span class="stat-value <%= max %>"><%= helper.titleCase(calculated.dungeons.catacombs.highest_floor.replace("_", " ")) %></span>
-          <br>
-          <% if (calculated.dungeons.master_catacombs?.visited && Object.keys(calculated.dungeons.master_catacombs.floors).length > 0) { %>
+          <p class="stat-raw-values" style="margin: 20px 0;">
+            <span class="stat-name">Selected Class: </span>
+            <span class="stat-value"><%= helper.titleCase(calculated.dungeons.selected_class) %></span>
+            <br>
+            <% max = calculated.dungeons.catacombs.bonuses.item_boost === 465 ? "golden-text" : "" %>
+            <span class="stat-name <%= max %>">Dungeon Item Boost: </span>
+            <span class="stat-value percent <%= max %>"><%= calculated.dungeons.catacombs.bonuses.item_boost.toLocaleString() %></span>
+            <br>
+            <% max = calculated.dungeons.catacombs.highest_floor === "floor_7" ? "golden-text" : "" %>
+            <span class="stat-name <%= max %>">Highest Floor Beaten (normal): </span>
+            <span class="stat-value <%= max %>"><%= helper.titleCase(calculated.dungeons.catacombs.highest_floor.replace("_", " ")) %></span>
+            <br>
+            <% if (calculated.dungeons.master_catacombs?.visited && Object.keys(calculated.dungeons.master_catacombs.floors).length > 0) { %>
             <% max = calculated.dungeons.master_catacombs.highest_floor === "floor_7" ? "golden-text" : "" %>
             <span class="stat-name <%= max %>">Highest Floor Beaten (master): </span>
             <span class="stat-value <%= max %>"><%= helper.titleCase(calculated.dungeons.master_catacombs.highest_floor.replace("_", " ")) %></span>
             <br>
-          <% } %>
-          <% max = calculated.dungeons.journals.maxed ? "golden-text" : "" %>
-          <span class="stat-name <%= max %>">Journals Completed: </span>
-          <span class="stat-value <%= max %>"><%= calculated.dungeons.journals.journals_completed %></span>
-          <span class="grey-text"> (<%= calculated.dungeons.journals.pages_collected %>/<%= calculated.dungeons.journals.total_pages %>)</span>
-          <br>
-          <span class="stat-name">Secrets Found: </span>
-          <span class="stat-value" data-tippy-content="Secrets from achievements across profiles"><%= calculated.dungeons.secrets_found.toLocaleString() %></span>
-        </p>
+            <% } %>
+            <% max = calculated.dungeons.journals.maxed ? "golden-text" : "" %>
+            <span class="stat-name <%= max %>">Journals Completed: </span>
+            <span class="stat-value <%= max %>"><%= calculated.dungeons.journals.journals_completed %></span>
+            <span class="grey-text"> (<%= calculated.dungeons.journals.pages_collected %>/<%= calculated.dungeons.journals.total_pages %>)</span>
+            <br>
+            <span class="stat-name">Secrets Found: </span>
+            <span class="stat-value" data-tippy-content="Secrets from achievements across profiles"><%= calculated.dungeons.secrets_found.toLocaleString() %></span>
+          </p>
 
-        <p class="stat-sub-header">Catacombs</p>
-        <div class="floor-containers narrow-info-container-wrapper">
-          <% for (let [id, floor] of Object.entries(calculated.dungeons.catacombs.floors)) { %>
-          <div class="narrow-info-container">
-            <div class="narrow-info-header">
-              <div class="floor-icon" style="background-image: url(/head/<%= floor.icon_texture %>)"></div>
-              <span><%= floor.name.replace("_", " ") %></span>
-            </div>
-            <span>
-              <button class="stat-sub-header extender" aria-controls="floor-<%= id %>" aria-expanded="false">Floor Stats</button>
-              <div class="pieces extendable" id="floor-<%= id %>">
-              <% for (let [stat, value] of Object.entries(floor.stats)) { %>
-                <span class="stat-name"><%= helper.capitalizeFirstLetter(stat.split("_").join(" ")) %>: </span>
-                <span class="stat-value">
-                <% if(stat.startsWith("fastest_time")) { %>
-                  <%= moment.duration(value, "milliseconds").format("m:ss.SSS") %>
-                <% } else { %>
-                  <%= helper.formatNumber(value) %>
-                <% } %>
-                </span><br>
-              <% } %>
-              <% if(floor.most_damage) { %>
-                <span class="stat-name">Most Damage: </span>
-                <span class="stat-value"><%= helper.formatNumber(floor.most_damage.value) %></span>
-                <span class="stat-name">(<%= helper.titleCase(floor.most_damage.class) %>)</span>
-              <% } %>
+          <p class="stat-sub-header">Catacombs</p>
+          <div class="floor-containers narrow-info-container-wrapper">
+            <% for (let [id, floor] of Object.entries(calculated.dungeons.catacombs.floors)) { %>
+            <div class="narrow-info-container">
+              <div class="narrow-info-header">
+                <div class="floor-icon" style="background-image: url(/head/<%= floor.icon_texture %>)"></div>
+                <span><%= floor.name.replace("_", " ") %></span>
               </div>
-              <% if(floor.best_runs) { %>
+              <span>
+                <button class="stat-sub-header extender" aria-controls="floor-<%= id %>" aria-expanded="false">Floor Stats</button>
+                <div class="pieces extendable" id="floor-<%= id %>">
+                  <% for (let [stat, value] of Object.entries(floor.stats)) { %>
+                  <span class="stat-name"><%= helper.capitalizeFirstLetter(stat.split("_").join(" ")) %>: </span>
+                  <span class="stat-value">
+                    <% if(stat.startsWith("fastest_time")) { %>
+                    <%= moment.duration(value, "milliseconds").format("m:ss.SSS") %>
+                    <% } else { %>
+                    <%= helper.formatNumber(value) %>
+                    <% } %>
+                  </span><br>
+                  <% } %>
+                  <% if(floor.most_damage) { %>
+                  <span class="stat-name">Most Damage: </span>
+                  <span class="stat-value"><%= helper.formatNumber(floor.most_damage.value) %></span>
+                  <span class="stat-name">(<%= helper.titleCase(floor.most_damage.class) %>)</span>
+                  <% } %>
+                </div>
+                <% if(floor.best_runs) { %>
                 <button class="stat-sub-header extender" aria-controls="runs-<%= id %>" aria-expanded="false">Best Run</button>
                 <div class="pieces extendable" id="runs-<%= id %>">
                   <span class="stat-name">Grade:</span>
                   <span class="stat-value"><%= helper.calcDungeonGrade(floor.best_runs[floor.best_runs.length - 1]) %></span>
                   <br>
-                <% for (let [stat, value] of Object.entries(floor.best_runs[floor.best_runs.length - 1])) {
+                  <% for (let [stat, value] of Object.entries(floor.best_runs[floor.best_runs.length - 1])) {
                   if(stat == "teammates") continue; %>
                   <span class="stat-name"><%= helper.capitalizeFirstLetter(stat.split("_").join(" ")) %>: </span>
                   <span class="stat-value" <%- stat == "timestamp" ? `data-tippy-content='<local-time timestamp="${value}"></local-time>'` : ""%>><%=
@@ -1795,56 +1798,56 @@ const metaDescription = getMetaDescription()
                       }
                     })()
                   %></span><br>
-                <% } %>
+                  <% } %>
                 </div>
-              <% } %>
-            </span>
+                <% } %>
+              </span>
+            </div>
+            <% } %>
           </div>
-          <% } %>
-        </div>
 
-        <% if (calculated.dungeons.master_catacombs?.visited) { %>
+          <% if (calculated.dungeons.master_catacombs?.visited) { %>
           <p class="stat-sub-header">Master Catacombs</p>
 
           <% if (Object.keys(calculated.dungeons.master_catacombs.floors).length === 0) { %>
-            <p class="stat-raw-values"><%= calculated.display_name %> hasn't completed any Master Catacombs floor yet.</p>
+          <p class="stat-raw-values"><%= calculated.display_name %> hasn't completed any Master Catacombs floor yet.</p>
           <% } else { %>
-            <div class="floor-containers narrow-info-container-wrapper">
-              <% for (let [id, floor] of Object.entries(calculated.dungeons.master_catacombs.floors)) { %>
-              <div class="narrow-info-container">
-                <div class="narrow-info-header">
-                  <div class="floor-icon" style="background-image: url(/head/<%= floor.icon_texture %>)"></div>
-                  <span><%= floor.name.replace("_", " ") %></span>
-                </div>
-                <span>
-                  <button class="stat-sub-header extender" aria-controls="floor-<%= id %>" aria-expanded="false">Floor Stats</button>
-                  <div class="pieces extendable" id="floor-<%= id %>">
+          <div class="floor-containers narrow-info-container-wrapper">
+            <% for (let [id, floor] of Object.entries(calculated.dungeons.master_catacombs.floors)) { %>
+            <div class="narrow-info-container">
+              <div class="narrow-info-header">
+                <div class="floor-icon" style="background-image: url(/head/<%= floor.icon_texture %>)"></div>
+                <span><%= floor.name.replace("_", " ") %></span>
+              </div>
+              <span>
+                <button class="stat-sub-header extender" aria-controls="floor-<%= id %>" aria-expanded="false">Floor Stats</button>
+                <div class="pieces extendable" id="floor-<%= id %>">
                   <% for (let [stat, value] of Object.entries(floor.stats)) { %>
-                    <span class="stat-name"><%= helper.capitalizeFirstLetter(stat.split("_").join(" ")) %>: </span>
-                    <span class="stat-value">
+                  <span class="stat-name"><%= helper.capitalizeFirstLetter(stat.split("_").join(" ")) %>: </span>
+                  <span class="stat-value">
                     <% if(stat.startsWith("fastest_time")) { %>
-                      <%= moment.duration(value, "milliseconds").format("m:ss.SSS") %>
+                    <%= moment.duration(value, "milliseconds").format("m:ss.SSS") %>
                     <% } else { %>
-                      <%= helper.formatNumber(value) %>
+                    <%= helper.formatNumber(value) %>
                     <% } %>
-                    </span><br>
+                  </span><br>
                   <% } %>
                   <% if(floor.most_damage) { %>
-                    <span class="stat-name">Most Damage: </span>
-                    <span class="stat-value"><%= helper.formatNumber(floor.most_damage.value) %></span>
-                    <span class="stat-name">(<%= helper.titleCase(floor.most_damage.class) %>)</span>
+                  <span class="stat-name">Most Damage: </span>
+                  <span class="stat-value"><%= helper.formatNumber(floor.most_damage.value) %></span>
+                  <span class="stat-name">(<%= helper.titleCase(floor.most_damage.class) %>)</span>
                   <% } %>
-                  </div>
-                  <% if(floor.best_runs) { %>
-                    <button class="stat-sub-header extender" aria-controls="runs-<%= id %>" aria-expanded="false">Best Run</button>
-                    <div class="pieces extendable" id="runs-<%= id %>">
-                      <span class="stat-name">Grade:</span>
-                      <span class="stat-value"><%= helper.calcDungeonGrade(floor.best_runs[floor.best_runs.length - 1]) %></span>
-                      <br>
-                    <% for (let [stat, value] of Object.entries(floor.best_runs[floor.best_runs.length - 1])) {
+                </div>
+                <% if(floor.best_runs) { %>
+                <button class="stat-sub-header extender" aria-controls="runs-<%= id %>" aria-expanded="false">Best Run</button>
+                <div class="pieces extendable" id="runs-<%= id %>">
+                  <span class="stat-name">Grade:</span>
+                  <span class="stat-value"><%= helper.calcDungeonGrade(floor.best_runs[floor.best_runs.length - 1]) %></span>
+                  <br>
+                  <% for (let [stat, value] of Object.entries(floor.best_runs[floor.best_runs.length - 1])) {
                       if(stat == "teammates") continue; %>
-                      <span class="stat-name"><%= helper.capitalizeFirstLetter(stat.split("_").join(" ")) %>: </span>
-                      <span class="stat-value" <%- stat == "timestamp" ? `data-tippy-content='<local-time timestamp="${value}"></local-time>'` : ""%>><%=
+                  <span class="stat-name"><%= helper.capitalizeFirstLetter(stat.split("_").join(" ")) %>: </span>
+                  <span class="stat-value" <%- stat == "timestamp" ? `data-tippy-content='<local-time timestamp="${value}"></local-time>'` : ""%>><%=
                         (() => {
                           switch (stat) {
                             case "timestamp":
@@ -1858,17 +1861,17 @@ const metaDescription = getMetaDescription()
                           }
                         })()
                       %></span><br>
-                    <% } %>
-                    </div>
                   <% } %>
-                </span>
-              </div>
-              <% } %>
+                </div>
+                <% } %>
+              </span>
             </div>
+            <% } %>
+          </div>
           <% } %>
-        <% } %>
+          <% } %>
 
-        <% if (calculated.dungeons.unlocked_collections) { %>
+          <% if (calculated.dungeons.unlocked_collections) { %>
           <p class="stat-sub-header">Boss Collections</p>
           <div class="collections">
             <%
@@ -1888,28 +1891,30 @@ const metaDescription = getMetaDescription()
                   claimedTooltip += `<span class="stat-name">Unclaimed items: </span><span class="stat-value">${collection.unclaimed}</span>`;
                 }
             %>
-              <div class="chip" <% if (claimedTooltip != "") { %>data-tippy-content="<%= claimedTooltip %>"<% } %>>
-                <div class="chip-icon-wrapper"><div style="background-image:url('/head/<%= collection.texture %>')" class="item-icon custom-icon"></div></div>
-                <div class="chip-text">
-                  <div class="collection-name <%= collection.maxed ? 'max-stat' : '' %>"><span class="stat-name"><%= collection.name %> </span><% if (collection.tier > 0) { %><span class="stat-value"><%= collection.tier %></span><% } %></div>
-                  <div class="collection-amount"><span class="stat-name">Bosses killed: </span><span class="stat-value"><%= collection.killed.toLocaleString() %></span></div>
-                </div>
+            <div class="chip" <% if (claimedTooltip != "") { %>data-tippy-content="<%= claimedTooltip %>" <% } %>>
+              <div class="chip-icon-wrapper">
+                <div style="background-image:url('/head/<%= collection.texture %>')" class="item-icon custom-icon"></div>
               </div>
+              <div class="chip-text">
+                <div class="collection-name <%= collection.maxed ? 'max-stat' : '' %>"><span class="stat-name"><%= collection.name %> </span><% if (collection.tier > 0) { %><span class="stat-value"><%= collection.tier %></span><% } %></div>
+                <div class="collection-amount"><span class="stat-name">Bosses killed: </span><span class="stat-value"><%= collection.killed.toLocaleString() %></span></div>
+              </div>
+            </div>
             <% } %>
           </div>
-        <% } %>
-      <% } %>
+          <% } %>
+          <% } %>
+        </div>
       </div>
-    </div>
-    <div class="stat-container stat-slayer">
-      <a class="stat-anchor" id="Slayer"></a>
-      <h2 class="stat-header">Slayer</h2>
-      <div class="stat-content">
-        <% if (calculated.slayer_coins_spent.total == 0 || calculated.slayer_coins_spent.total === undefined) { %>
+      <div class="stat-container stat-slayer">
+        <a class="stat-anchor" id="Slayer"></a>
+        <h2 class="stat-header">Slayer</h2>
+        <div class="stat-content">
+          <% if (calculated.slayer_coins_spent.total == 0 || calculated.slayer_coins_spent.total === undefined) { %>
           <p class="stat-raw-values">
             <%= calculated.display_name %> hasn't played any Slayer yet.
           </p>
-        <% } else { %>
+          <% } else { %>
           <p class="stat-raw-values">
             <span data-tippy-content="
               <span class='stat-name'>Approximate coins spent</span><br>
@@ -1927,10 +1932,10 @@ const metaDescription = getMetaDescription()
               <br>
               <span class='stat-name'>Total: </span><span class='stat-value'><%= formatSlayerCoinsSpent(calculated.slayer_coins_spent.total) %></span><br>
             ">
-            <span class="stat-name">Total Slayer XP: </span><span class="stat-value"><%= calculated.slayer_xp.toLocaleString() %></span></span>
+              <span class="stat-name">Total Slayer XP: </span><span class="stat-value"><%= calculated.slayer_xp.toLocaleString() %></span></span>
           </p>
           <div class="slayer-containers narrow-info-container-wrapper">
-          <%
+            <%
           let maxSlayerLevel = 0;
 
           for(const slayerName in calculated.slayers){
@@ -1966,12 +1971,18 @@ const metaDescription = getMetaDescription()
               </div>
               <div class="slayer-kills">
                 <% for(const [index, tier] of Object.keys(slayer.kills).entries()){ %>
-                  <div class="slayer-kill"><div class="tier-name">Tier <%= romanize(tier) %></div><div class="tier-kills"><%= slayer.kills[tier].toLocaleString() %></div></div>
+                <div class="slayer-kill">
+                  <div class="tier-name">Tier <%= romanize(tier) %></div>
+                  <div class="tier-kills"><%= slayer.kills[tier].toLocaleString() %></div>
+                </div>
                 <% } %>
-                <div class="slayer-kill"><div class="tier-name">Total</div><div class="tier-kills"><%= totalKills.toLocaleString() %></div></div>
+                <div class="slayer-kill">
+                  <div class="tier-name">Total</div>
+                  <div class="tier-kills"><%= totalKills.toLocaleString() %></div>
+                </div>
               </div>
               <% if(slayer.level.unclaimed){ %>
-                <div class="slayer-unclaimed">unclaimed slayer rewards!</div>
+              <div class="slayer-unclaimed">unclaimed slayer rewards!</div>
               <% } %>
               <% max = slayer.level.currentLevel == slayer.level.maxLevel ? 'golden-text' : '' %><span class="<%= max %> stat-name slayer-level"><%= slayerName %> level <span class="stat-value <%= max %>"><%= slayer.level.currentLevel %></span></span>
               <div class="slayer-bar <%= slayer.level.currentLevel == slayer.level.maxLevel ? 'maxed-slayer' : ''%>">
@@ -1981,19 +1992,19 @@ const metaDescription = getMetaDescription()
                 </div>
               </div>
             </div>
-          <% } %>
+            <% } %>
           </div>
           <% if(maxSlayerLevel > 0){ %>
-            <div data-bonus-stats="slayer_zombie,slayer_spider,slayer_wolf,slayer_enderman"></div>
+          <div data-bonus-stats="slayer_zombie,slayer_spider,slayer_wolf,slayer_enderman"></div>
           <% } %>
-        <% } %>
+          <% } %>
+        </div>
       </div>
-    </div>
-    <div class="stat-container stat-minions">
-      <a class="stat-anchor" id="Minions"></a>
-      <h2 class="stat-header">Minions</h2>
-      <div class="stat-content">
-        <%
+      <div class="stat-container stat-minions">
+        <a class="stat-anchor" id="Minions"></a>
+        <h2 class="stat-header">Minions</h2>
+        <div class="stat-content">
+          <%
           let uniqueMinions = 0;
           let maxedMinions = 0;
           let skippedMinions = 0;
@@ -2006,21 +2017,21 @@ const metaDescription = getMetaDescription()
               maxedMinions++;
           }
         %>
-        <a href="https://hypixel.net/threads/2166857/" target="_blank" rel="noreferrer" class="external-app">
-          <div class="external-app-icon icon-google-sheets"></div>
-          <div class="external-app-name">Minions Sheet <span class="grey-text">by TBlazeWarriorT</span></div>
-          <div class="external-app-description">Check the next cheapest or fastest Minion upgrades and find out which Minions will earn you the most from Bazaar, for free.</div>
-        </a>
-        <p class="stat-raw-values">
-          <% max = uniqueMinions == constants.MINIONS_MAX_UNIQUES ? 'golden-text' : '' %><span class="stat-name <%= max %>">Unique Minions: </span><span class="stat-value <%= max %>"><%= uniqueMinions %> / <%= constants.MINIONS_MAX_UNIQUES %></span><span class="grey-text"> (<%= Math.floor(uniqueMinions / constants.MINIONS_MAX_UNIQUES * 100) %>%)</span><br>
-          <% max = calculated.minion_slots.currentSlots == constants.MINIONS_MAX_SLOTS ? 'golden-text' : '' %><span class="stat-name <%= max %>">Minion Slots: </span><span class="stat-value <%= max %>""><%= calculated.minion_slots.currentSlots %></span><span class="grey-text"> (<%= calculated.minion_slots.toNextSlot %> to next slot)</span><br>
-          <% max = calculated.misc.profile_upgrades.minion_slots == 5 ? 'golden-text' : '' %><span class="stat-name <%= max %>">Bonus Minion Slots: </span><span class="stat-value <%= max %>""><%= calculated.misc.profile_upgrades.minion_slots %> / <%= constants.PROFILE_UPGRADES['minion_slots'] %></span><br>
-          <% max = maxedMinions == _.size(constants.MINIONS) ? 'golden-text' : '' %><span class="stat-name <%= max %>">Maxed Minions: </span><span class="stat-value <%= max %>"><%= maxedMinions %> / <%= _.size(constants.MINIONS) %></span><br>
-          <% if(skippedMinions > 0){ %>
-          <span class="stat-name">Skipped Minion Tiers: </span><span class="stat-value"><%= skippedMinions %></span><br>
-          <% } %>
-        </p>
-        <%
+          <a href="https://hypixel.net/threads/2166857/" target="_blank" rel="noreferrer" class="external-app">
+            <div class="external-app-icon icon-google-sheets"></div>
+            <div class="external-app-name">Minions Sheet <span class="grey-text">by TBlazeWarriorT</span></div>
+            <div class="external-app-description">Check the next cheapest or fastest Minion upgrades and find out which Minions will earn you the most from Bazaar, for free.</div>
+          </a>
+          <p class="stat-raw-values">
+            <% max = uniqueMinions == constants.MINIONS_MAX_UNIQUES ? 'golden-text' : '' %><span class="stat-name <%= max %>">Unique Minions: </span><span class="stat-value <%= max %>"><%= uniqueMinions %> / <%= constants.MINIONS_MAX_UNIQUES %></span><span class="grey-text"> (<%= Math.floor(uniqueMinions / constants.MINIONS_MAX_UNIQUES * 100) %>%)</span><br>
+            <% max = calculated.minion_slots.currentSlots == constants.MINIONS_MAX_SLOTS ? 'golden-text' : '' %><span class="stat-name <%= max %>">Minion Slots: </span><span class="stat-value <%= max %>""><%= calculated.minion_slots.currentSlots %></span><span class=" grey-text"> (<%= calculated.minion_slots.toNextSlot %> to next slot)</span><br>
+            <% max = calculated.misc.profile_upgrades.minion_slots == 5 ? 'golden-text' : '' %><span class="stat-name <%= max %>">Bonus Minion Slots: </span><span class="stat-value <%= max %>""><%= calculated.misc.profile_upgrades.minion_slots %> / <%= constants.PROFILE_UPGRADES['minion_slots'] %></span><br>
+          <% max = maxedMinions == _.size(constants.MINIONS) ? 'golden-text' : '' %><span class=" stat-name <%= max %>">Maxed Minions: </span><span class="stat-value <%= max %>"><%= maxedMinions %> / <%= _.size(constants.MINIONS) %></span><br>
+            <% if(skippedMinions > 0){ %>
+            <span class="stat-name">Skipped Minion Tiers: </span><span class="stat-value"><%= skippedMinions %></span><br>
+            <% } %>
+          </p>
+          <%
         for(const type of constants.MINION_TYPES){
           const minions = calculated.minions.filter(a => a.type == type && a.maxLevel > 0).sort((a, b) => b.maxLevel - a.maxLevel);
 
@@ -2032,17 +2043,19 @@ const metaDescription = getMetaDescription()
 
           %>
           <div class="category-header">
-            <div class="category-icon"><div class="item-icon <%= skillItems[type] %>"></div></div>
+            <div class="category-icon">
+              <div class="item-icon <%= skillItems[type] %>"></div>
+            </div>
             <span><%= type %></span>
             <% if(maxOfType >= totalOfType){ %>
-              <span class="category-header-maxed">max!</span>
+            <span class="category-header-maxed">max!</span>
             <% }else{ %>
-              <span class="category-header-detail">(<%= maxOfType %> / <%= totalOfType %> max)</span>
+            <span class="category-header-detail">(<%= maxOfType %> / <%= totalOfType %> max)</span>
             <% } %>
           </div>
           <div class="minions">
             <% for(const minion of minions){ %>
-              <div data-tippy-content="Crafted variants:<br><br>
+            <div data-tippy-content="Crafted variants:<br><br>
               <% for(let i = 1; i <= minion.tiers; i++){ %>
               <div class='minion-variant <% if(minion.levels.includes(i)){ %>minion-crafted<% } %>'><%= romanize(i) %></div>
               <% } %>
@@ -2051,18 +2064,20 @@ const metaDescription = getMetaDescription()
               <%= minion.maxLevel == minion.tiers ? 'max-stat' : '' %>
               <%= minion.maxLevel != minion.levels.length ? 'skipped-minion' : '' %>
               ">
-                <div class="chip-icon-wrapper"><div style="background-image: url(<%= minion.head %>)" class="item-icon custom-icon"></div></div>
-                <div class="chip-text">
-                  <span class="stat-name"><%= minion.name %> </span><span class="stat-value"><%= minion.maxLevel %></span>
-                </div>
+              <div class="chip-icon-wrapper">
+                <div style="background-image: url(<%= minion.head %>)" class="item-icon custom-icon"></div>
               </div>
+              <div class="chip-text">
+                <span class="stat-name"><%= minion.name %> </span><span class="stat-value"><%= minion.maxLevel %></span>
+              </div>
+            </div>
             <% } %>
           </div>
           <%
         } %>
+        </div>
       </div>
-    </div>
-    <% if(Object.keys(calculated.collections).length > 0){ %>
+      <% if(Object.keys(calculated.collections).length > 0){ %>
       <div class="stat-container stat-collections">
         <a class="stat-anchor" id="Collections"></a>
         <h2 class="stat-header">Collections</h2>
@@ -2095,17 +2110,19 @@ const metaDescription = getMetaDescription()
               continue;
 
             %>
-            <div class="category-header">
-              <div class="category-icon"><div class="item-icon <%= skillItems[type] %>"></div></div>
-              <span><%= type %></span>
-              <% if(maxOfType >= totalOfType){ %>
-                <span class="category-header-maxed">max!</span>
-              <% }else{ %>
-                <span class="category-header-detail">(<%= maxOfType %> / <%= totalOfType %> max)</span>
-              <% } %>
+          <div class="category-header">
+            <div class="category-icon">
+              <div class="item-icon <%= skillItems[type] %>"></div>
             </div>
-            <div class="collections">
-              <%
+            <span><%= type %></span>
+            <% if(maxOfType >= totalOfType){ %>
+            <span class="category-header-maxed">max!</span>
+            <% }else{ %>
+            <span class="category-header-detail">(<%= maxOfType %> / <%= totalOfType %> max)</span>
+            <% } %>
+          </div>
+          <div class="collections">
+            <%
 
               for(const collection of collections){
                 let amountsTooltip = '';
@@ -2119,26 +2136,26 @@ const metaDescription = getMetaDescription()
 
                 amountsTooltip += `<br><span class="stat-name">Total: </span><span class="stat-value">${collection.totalAmount.toLocaleString()}</span>`;
               %>
-                <div class="chip" data-tippy-content="<%= amountsTooltip %>">
-                  <div class="chip-icon-wrapper">
-                    <% if ("texture" in collection) { %>
-                      <div style="background-image:url(/head/<%= collection.texture %>)" class="item-icon custom-icon"></div>
-                    <% } else { %>
-                      <div class="item-icon icon-<%= collection.id %>_<%= collection.damage %>"></div>
-                    <% } %>
-                  </div>
-                  <div class="chip-text">
-                    <div class="collection-name <%= collection.tier >= collection.maxTier ? 'max-stat' : '' %>"><span class="stat-name"><%= collection.name %> </span><span class="stat-value"><%= collection.tier %></span></div>
-                    <div class="collection-amount"><span class="stat-name">Amount: </span><span class="stat-value"><%= collection.amount.toLocaleString() %></span></div>
-                  </div>
-                </div>
-              <% } %>
+            <div class="chip" data-tippy-content="<%= amountsTooltip %>">
+              <div class="chip-icon-wrapper">
+                <% if ("texture" in collection) { %>
+                <div style="background-image:url(/head/<%= collection.texture %>)" class="item-icon custom-icon"></div>
+                <% } else { %>
+                <div class="item-icon icon-<%= collection.id %>_<%= collection.damage %>"></div>
+                <% } %>
+              </div>
+              <div class="chip-text">
+                <div class="collection-name <%= collection.tier >= collection.maxTier ? 'max-stat' : '' %>"><span class="stat-name"><%= collection.name %> </span><span class="stat-value"><%= collection.tier %></span></div>
+                <div class="collection-amount"><span class="stat-name">Amount: </span><span class="stat-value"><%= collection.amount.toLocaleString() %></span></div>
+              </div>
             </div>
+            <% } %>
+          </div>
           <% } %>
         </div>
       </div>
-    <% } %>
-    <% if(Object.keys(calculated.misc).length > 0){ %>
+      <% } %>
+      <% if(Object.keys(calculated.misc).length > 0){ %>
       <div class="stat-container stat-misc">
         <a class="stat-anchor" id="Misc"></a>
         <h2 class="stat-header">Miscellaneous</h2>
@@ -2146,83 +2163,104 @@ const metaDescription = getMetaDescription()
 
           <div class="category-header">
             <div class="category-icon">
-              <div
-                class="item-icon custom-icon"
-                style="background-image: url(/head/1e5574a4ef94ef4ca300d02f644d98be07dbfba7df78808e8a9a021b067d996d)"
-              ></div>
+              <div class="item-icon custom-icon" style="background-image: url(/head/1e5574a4ef94ef4ca300d02f644d98be07dbfba7df78808e8a9a021b067d996d)"></div>
             </div>
             <span>Essence</span>
           </div>
           <div class="collections">
             <% for (const [key, value] of Object.entries(calculated.essence)) { %>
-              <div class="chip" data-missing="<%= value === 0 %>">
-                <div class="chip-icon-wrapper"><div style="background-image:url('<%= constants.ESSENCE[key].head %>')" class="item-icon custom-icon"></div></div>
-                <div class="chip-text">
-                  <div class="collection-name"><span class="stat-name"><%= constants.ESSENCE[key].name %></span></div>
-                  <div class="collection-amount"><span class="stat-name">Amount: </span><span class="stat-value"><%= value.toLocaleString() %></span></div>
-                </div>
+            <div class="chip" data-missing="<%= value === 0 %>">
+              <div class="chip-icon-wrapper">
+                <div style="background-image:url('<%= constants.ESSENCE[key].head %>')" class="item-icon custom-icon"></div>
               </div>
+              <div class="chip-text">
+                <div class="collection-name"><span class="stat-name"><%= constants.ESSENCE[key].name %></span></div>
+                <div class="collection-amount"><span class="stat-name">Amount: </span><span class="stat-value"><%= value.toLocaleString() %></span></div>
+              </div>
+            </div>
             <% } %>
           </div>
 
-        <% if(calculated.kills.length > 0 || calculated.deaths.length > 0){
+          <% if(calculated.kills.length > 0 || calculated.deaths.length > 0){
           let totalKills = calculated.kills.length;
           let totalDeaths = calculated.deaths.length;
 
           let rows = Math.min(Math.max(totalKills, totalDeaths), 10);
 
           %>
-          <div class="category-header"><div class="category-icon"><div class="item-icon icon-267_0"></div></div><span>kills</span></div>
+          <div class="category-header">
+            <div class="category-icon">
+              <div class="item-icon icon-267_0"></div>
+            </div><span>kills</span>
+          </div>
           <p class="stat-raw-values stat-kills">
             <span class="stat-name">Total Kills: </span><span class="stat-value"><%= calculated.kills.map(a => a.amount).reduce((a, b) => a + b, 0).toLocaleString() %></span><br>
             <span class="stat-name">Total Deaths: </span><span class="stat-value"><%= calculated.deaths.map(a => a.amount).reduce((a, b) => a + b, 0).toLocaleString() %></span><br>
 
-            <div class="kills-deaths-container narrow-info-container-wrapper">
-              <div class="narrow-info-container top-kills">
-                <div class="narrow-info-header">Kills</div>
-                <div class="narrow-info-content">
-                  <% for(let i = 0; i < rows; i++){
+          <div class="kills-deaths-container narrow-info-container-wrapper">
+            <div class="narrow-info-container top-kills">
+              <div class="narrow-info-header">Kills</div>
+              <div class="narrow-info-content">
+                <% for(let i = 0; i < rows; i++){
                     const kill = calculated.kills[i];
 
                     if(typeof calculated.kills[i] === 'undefined'){
                     %>
-                      <div class="kill-stat"><div class="kill-rank"></div></div>
-                    <% }else{ %>
-                      <div class="kill-stat"><div class="kill-rank">#<%= i + 1 %>&nbsp;</div><div class="kill-entity"><%= kill.entityName %></div><div class="stat-separator">:&nbsp;</div><div class="kill-amount"><%= kill.amount.toLocaleString() %></div></div>
-                    <% }
-                  } %>
-                  <% if(calculated.kills.length > 10 || calculated.deaths.length > 10){ %>
-                    <button class="kill-stat show-all <%= calculated.kills.length > 10 ? 'enabled' : '' %>" data-type="kills">show all</button>
-                  <% } %>
+                <div class="kill-stat">
+                  <div class="kill-rank"></div>
                 </div>
+                <% }else{ %>
+                <div class="kill-stat">
+                  <div class="kill-rank">#<%= i + 1 %>&nbsp;</div>
+                  <div class="kill-entity"><%= kill.entityName %></div>
+                  <div class="stat-separator">:&nbsp;</div>
+                  <div class="kill-amount"><%= kill.amount.toLocaleString() %></div>
+                </div>
+                <% }
+                  } %>
+                <% if(calculated.kills.length > 10 || calculated.deaths.length > 10){ %>
+                <button class="kill-stat show-all <%= calculated.kills.length > 10 ? 'enabled' : '' %>" data-type="kills">show all</button>
+                <% } %>
               </div>
-              <div class="narrow-info-container top-deaths">
-                <div class="narrow-info-header">Deaths</div>
-                <div class="narrow-info-content">
-                  <% for(let i = 0; i < rows; i++){
+            </div>
+            <div class="narrow-info-container top-deaths">
+              <div class="narrow-info-header">Deaths</div>
+              <div class="narrow-info-content">
+                <% for(let i = 0; i < rows; i++){
                     const death = calculated.deaths[i];
 
                     if(typeof death === 'undefined'){
                     %>
-                      <div class="kill-stat"><div class="kill-rank"></div></div>
-                    <% }else{ %>
-                      <div class="kill-stat"><div class="kill-rank">#<%= i + 1 %>&nbsp;</div><div class="kill-entity"><%= death.entityName %></div><div class="stat-separator">:&nbsp;</div><div class="kill-amount"><%= death.amount.toLocaleString() %></div></div>
-                    <% }
-                  } %>
-                  <% if(calculated.kills.length > 10 || calculated.deaths.length > 10){ %>
-                    <button class="kill-stat show-all <%= calculated.deaths.length > 10 ? 'enabled' : '' %>" data-type="deaths">show all</button>
-                  <% } %>
+                <div class="kill-stat">
+                  <div class="kill-rank"></div>
                 </div>
+                <% }else{ %>
+                <div class="kill-stat">
+                  <div class="kill-rank">#<%= i + 1 %>&nbsp;</div>
+                  <div class="kill-entity"><%= death.entityName %></div>
+                  <div class="stat-separator">:&nbsp;</div>
+                  <div class="kill-amount"><%= death.amount.toLocaleString() %></div>
+                </div>
+                <% }
+                  } %>
+                <% if(calculated.kills.length > 10 || calculated.deaths.length > 10){ %>
+                <button class="kill-stat show-all <%= calculated.deaths.length > 10 ? 'enabled' : '' %>" data-type="deaths">show all</button>
+                <% } %>
               </div>
             </div>
+          </div>
           </p>
           <% } %>
 
           <% if('races' in calculated.misc){ %>
-            <div class="category-header"><div class="category-icon"><div class="item-icon icon-317_0"></div></div><span>races</span></div>
+          <div class="category-header">
+            <div class="category-icon">
+              <div class="item-icon icon-317_0"></div>
+            </div><span>races</span>
+          </div>
 
-            <div class="race-containers narrow-info-container-wrapper">
-              <%
+          <div class="race-containers narrow-info-container-wrapper">
+            <%
               const races = [
                 { id: "dungeon_hub_crystal_core", name: "Crystal Core", icon: '399_0' },
                 { id: "dungeon_hub_giant_mushroom", name: "Giant Mushroom", icon: '100_0' },
@@ -2236,16 +2274,16 @@ const metaDescription = getMetaDescription()
 
                 if(times.length > 0){
                 %>
-                <div class="narrow-info-container">
-                  <div class="narrow-info-header"><%= race.name %></div>
-                  <div class="narrow-info-content">
-                    <%
+            <div class="narrow-info-container">
+              <div class="narrow-info-header"><%= race.name %></div>
+              <div class="narrow-info-content">
+                <%
                     const races_no_return = times.filter(a => a.includes("no_return"));
                     const races_with_return = times.filter(a => a.includes("with_return"));
 
                     if(races_no_return.length > 0){ %>
-                      <div class="narrow-info-section-header">No Return:</div>
-                    <% }
+                <div class="narrow-info-section-header">No Return:</div>
+                <% }
 
                     for(const type of types){
                       const key = `${race.id}_${type}_no_return_best_time`;
@@ -2260,20 +2298,20 @@ const metaDescription = getMetaDescription()
                       if(duration < 1000)
                         raceDuration = '0.' + raceDuration;
                       %>
-                      <div class="narrow-info-flexsb">
-                        <div>
-                          <span class="stat-name"><%= helper.titleCase(type.split("_").join(" ")) %>: </span>
-                          <span class="stat-value"><%= raceDuration %></span>
-                        </div>
-                        <div>
-                          <span class="stat-value"><%= helper.renderRaceTier(raceTier) %></span>
-                        </div>
-                      </div>
-                    <% }
+                <div class="narrow-info-flexsb">
+                  <div>
+                    <span class="stat-name"><%= helper.titleCase(type.split("_").join(" ")) %>: </span>
+                    <span class="stat-value"><%= raceDuration %></span>
+                  </div>
+                  <div>
+                    <span class="stat-value"><%= helper.renderRaceTier(raceTier) %></span>
+                  </div>
+                </div>
+                <% }
 
                     if(races_with_return.length > 0){ %>
-                      <div class="narrow-info-section-header">With Return:</div>
-                    <% }
+                <div class="narrow-info-section-header">With Return:</div>
+                <% }
 
                     for(const type of types){
                       const key = `${race.id}_${type}_with_return_best_time`;
@@ -2288,26 +2326,26 @@ const metaDescription = getMetaDescription()
                       if(duration < 1000)
                         raceDuration = '0.' + raceDuration;
                       %>
-                      <div class="narrow-info-flexsb">
-                        <div>
-                          <span class="stat-name"><%= helper.titleCase(type.split("_").join(" ")) %>: </span>
-                          <span class="stat-value"><%= raceDuration %></span>
-                        </div>
-                        <div>
-                          <span class="stat-value"><%= helper.renderRaceTier(raceTier) %></span>
-                        </div>
-                      </div>
-                    <% } %>
+                <div class="narrow-info-flexsb">
+                  <div>
+                    <span class="stat-name"><%= helper.titleCase(type.split("_").join(" ")) %>: </span>
+                    <span class="stat-value"><%= raceDuration %></span>
+                  </div>
+                  <div>
+                    <span class="stat-value"><%= helper.renderRaceTier(raceTier) %></span>
                   </div>
                 </div>
-                <%
+                <% } %>
+              </div>
+            </div>
+            <%
                 }
               }
               %>
-              <div class="narrow-info-container">
-                  <div class="narrow-info-header">Other Races</div>
-                  <div class="narrow-info-content">
-                    <% for(const key in calculated.misc.races){
+            <div class="narrow-info-container">
+              <div class="narrow-info-header">Other Races</div>
+              <div class="narrow-info-content">
+                <% for(const key in calculated.misc.races){
                       if(key.startsWith('dungeon_hub'))
                         continue;
 
@@ -2318,40 +2356,52 @@ const metaDescription = getMetaDescription()
                       if(calculated.misc.races[key] < 1000)
                         raceDuration = '0.' + raceDuration;
                     %>
-                    <div class="narrow-info-flexsb">
-                      <div>
-                        <span class="stat-name"><%= raceName %>: </span>
-                        <span class="stat-value"><%= raceDuration %></span>
-                      </div>
-                      <div>
-                        <span class="stat-value"><%= helper.renderRaceTier(raceTier) %></span>
-                      </div>
-                    </div>
-                    <% } %>
+                <div class="narrow-info-flexsb">
+                  <div>
+                    <span class="stat-name"><%= raceName %>: </span>
+                    <span class="stat-value"><%= raceDuration %></span>
                   </div>
+                  <div>
+                    <span class="stat-value"><%= helper.renderRaceTier(raceTier) %></span>
+                  </div>
+                </div>
+                <% } %>
               </div>
             </div>
+          </div>
           <% } %>
           <% if('gifts' in calculated.misc){ %>
-            <div class="category-header"><div class="category-icon"><div class="item-icon custom-icon" style="background-image: url(/head/b73a2114136b8ee4926caa51785414036a2b76e4f1668cb89d99716c421)"></div></div><span>Gifts</span></div>
-            <p class="stat-raw-values">
-              <% for(const key in calculated.misc.gifts){ %>
-              <span class="stat-name"><%= helper.capitalizeFirstLetter(key.split("_").join(" ")); %>: </span><span class="stat-value"><%= calculated.misc.gifts[key].toLocaleString() %></span><br>
-              <% } %>
-            </p>
+          <div class="category-header">
+            <div class="category-icon">
+              <div class="item-icon custom-icon" style="background-image: url(/head/b73a2114136b8ee4926caa51785414036a2b76e4f1668cb89d99716c421)"></div>
+            </div><span>Gifts</span>
+          </div>
+          <p class="stat-raw-values">
+            <% for(const key in calculated.misc.gifts){ %>
+            <span class="stat-name"><%= helper.capitalizeFirstLetter(key.split("_").join(" ")); %>: </span><span class="stat-value"><%= calculated.misc.gifts[key].toLocaleString() %></span><br>
+            <% } %>
+          </p>
           <% } %>
           <% if('winter' in calculated.misc){ %>
-            <div class="category-header"><div class="category-icon"><div class="item-icon icon-332_0"></div></div><span>Season of jerry</span></div>
-            <p class="stat-raw-values">
-              <% for(const key in calculated.misc.winter){ %>
-              <span class="stat-name"><%= helper.capitalizeFirstLetter(key.split("_").join(" ")); %>: </span><span class="stat-value"><%= calculated.misc.winter[key].toLocaleString() %></span><br>
-              <% } %>
-            </p>
+          <div class="category-header">
+            <div class="category-icon">
+              <div class="item-icon icon-332_0"></div>
+            </div><span>Season of jerry</span>
+          </div>
+          <p class="stat-raw-values">
+            <% for(const key in calculated.misc.winter){ %>
+            <span class="stat-name"><%= helper.capitalizeFirstLetter(key.split("_").join(" ")); %>: </span><span class="stat-value"><%= calculated.misc.winter[key].toLocaleString() %></span><br>
+            <% } %>
+          </p>
           <% } %>
           <% if('dragons' in calculated.misc){ %>
-            <div class="category-header"><div class="category-icon"><div class="item-icon custom-icon" style="background-image: url(/head/aec3ff563290b13ff3bcc36898af7eaa988b6cc18dc254147f58374afe9b21b9)"></div></div><span>Dragons</span></div>
-            <p class="stat-raw-values">
-              <% for(const key in calculated.misc.dragons){
+          <div class="category-header">
+            <div class="category-icon">
+              <div class="item-icon custom-icon" style="background-image: url(/head/aec3ff563290b13ff3bcc36898af7eaa988b6cc18dc254147f58374afe9b21b9)"></div>
+            </div><span>Dragons</span>
+          </div>
+          <p class="stat-raw-values">
+            <% for(const key in calculated.misc.dragons){
                 let tooltip = "";
 
                 if(key == 'last_hits')
@@ -2362,30 +2412,42 @@ const metaDescription = getMetaDescription()
                   for(const death of calculated.deaths.filter(a => a.entityId.endsWith('_dragon')))
                     tooltip += `<span class="stat-name">${ death.entityName }: </span><span class="stat-value">${ death.amount }</span><br>`;
               %>
-              <span <%- tooltip ? `data-tippy-content='${tooltip}'` : "" %>><span class="stat-name"><%= helper.capitalizeFirstLetter(key.split("_").join(" ")); %>: </span><span class="stat-value"><%= calculated.misc.dragons[key].toLocaleString() %></span></span><br>
-              <% } %>
+            <span <%- tooltip ? `data-tippy-content='${tooltip}'` : "" %>><span class="stat-name"><%= helper.capitalizeFirstLetter(key.split("_").join(" ")); %>: </span><span class="stat-value"><%= calculated.misc.dragons[key].toLocaleString() %></span></span><br>
+            <% } %>
           </p>
           <% } %>
           <% if('protector' in calculated.misc){ %>
-            <div class="category-header"><div class="category-icon"><div class="item-icon custom-icon" style="background-image: url(https://sky.lea.moe/head/89091d79ea0f59ef7ef94d7bba6e5f17f2f7d4572c44f90f76c4819a714)"></div></div><span>Endstone protectors</span></div>
-            <p class="stat-raw-values">
-              <% for(const key in calculated.misc.protector){ %>
-              <span class="stat-name"><%= helper.capitalizeFirstLetter(key.split("_").join(" ")); %>: </span><span class="stat-value"><%= calculated.misc.protector[key].toLocaleString() %></span><br>
-              <% } %>
+          <div class="category-header">
+            <div class="category-icon">
+              <div class="item-icon custom-icon" style="background-image: url(https://sky.lea.moe/head/89091d79ea0f59ef7ef94d7bba6e5f17f2f7d4572c44f90f76c4819a714)"></div>
+            </div><span>Endstone protectors</span>
+          </div>
+          <p class="stat-raw-values">
+            <% for(const key in calculated.misc.protector){ %>
+            <span class="stat-name"><%= helper.capitalizeFirstLetter(key.split("_").join(" ")); %>: </span><span class="stat-value"><%= calculated.misc.protector[key].toLocaleString() %></span><br>
+            <% } %>
           </p>
           <% } %>
           <% if('damage' in calculated.misc){ %>
-            <div class="category-header"><div class="category-icon"><div class="item-icon icon-267_0"></div></div><span>Damage</span></div>
-            <p class="stat-raw-values">
-              <% for(const key in calculated.misc.damage){ %>
-              <span class="stat-name"><%= helper.capitalizeFirstLetter(key.split("_").join(" ")); %>: </span><span class="stat-value"><%= Math.floor(calculated.misc.damage[key]).toLocaleString() %></span><br>
-              <% } %>
-            </p>
+          <div class="category-header">
+            <div class="category-icon">
+              <div class="item-icon icon-267_0"></div>
+            </div><span>Damage</span>
+          </div>
+          <p class="stat-raw-values">
+            <% for(const key in calculated.misc.damage){ %>
+            <span class="stat-name"><%= helper.capitalizeFirstLetter(key.split("_").join(" ")); %>: </span><span class="stat-value"><%= Math.floor(calculated.misc.damage[key]).toLocaleString() %></span><br>
+            <% } %>
+          </p>
           <% } %>
           <% if('milestones' in calculated.misc){ %>
-            <div class="category-header"><div class="category-icon"><div class="item-icon custom-icon" style="background-image: url(/head/93c8aa3fde295fa9f9c27f734bdbab11d33a2e43e855accd7465352377413b)"></div></div><span>Pet milestones</span></div>
-            <p class="stat-raw-values">
-              <% for(const key in calculated.misc.milestones){
+          <div class="category-header">
+            <div class="category-icon">
+              <div class="item-icon custom-icon" style="background-image: url(/head/93c8aa3fde295fa9f9c27f734bdbab11d33a2e43e855accd7465352377413b)"></div>
+            </div><span>Pet milestones</span>
+          </div>
+          <p class="stat-raw-values">
+            <% for(const key in calculated.misc.milestones){
                 let progress = {
                   rarity: milestone_rarities[pet_milestones[key].length-1],
                   maxed: true
@@ -2409,15 +2471,19 @@ const metaDescription = getMetaDescription()
                 else
                   tooltip += `<span class="stat-value percent">${ progress.percentage.toLocaleString() }</span>`;
                 %>
-              <span <%- tooltip ? `data-tippy-content='${tooltip}'` : "" %>>
-                <span class="stat-name"><%= helper.capitalizeFirstLetter(key.split("_").join(" ")); %>: </span><span class="stat-value"><%= calculated.misc.milestones[key].toLocaleString() %></span></span><br>
-              <% } %>
-            </p>
+            <span <%- tooltip ? `data-tippy-content='${tooltip}'` : "" %>>
+              <span class="stat-name"><%= helper.capitalizeFirstLetter(key.split("_").join(" ")); %>: </span><span class="stat-value"><%= calculated.misc.milestones[key].toLocaleString() %></span></span><br>
+            <% } %>
+          </p>
           <% } %>
           <% if('burrows' in calculated.misc){ %>
-            <div class="category-header"><div class="category-icon"><div class="item-icon custom-icon" style="background-image: url(/head/4c27e3cb52a64968e60c861ef1ab84e0a0cb5f07be103ac78da67761731f00c8)"></div></div><span>Griffin burrows</span></div>
-            <p class="stat-raw-values">
-              <%  let burrow_naming = {"dug_next": "dug_arrows", "dug_combat": "dug_monsters"}
+          <div class="category-header">
+            <div class="category-icon">
+              <div class="item-icon custom-icon" style="background-image: url(/head/4c27e3cb52a64968e60c861ef1ab84e0a0cb5f07be103ac78da67761731f00c8)"></div>
+            </div><span>Griffin burrows</span>
+          </div>
+          <p class="stat-raw-values">
+            <%  let burrow_naming = {"dug_next": "dug_arrows", "dug_combat": "dug_monsters"}
               for(const key in calculated.misc.burrows){
                 let name = burrow_naming[key] || key;
                 let tooltip = "";
@@ -2426,70 +2492,90 @@ const metaDescription = getMetaDescription()
                   if(rarity != "total" && rarity != "null")
                     tooltip += `<span class="stat-name piece-${ rarity }-fg">${ helper.capitalizeFirstLetter(rarity) }: </span><span class="stat-value">${ calculated.misc.burrows[key][rarity] }</span><br>`;
               %>
-                <span <%- tooltip ? `data-tippy-content='<span class="stat-name">Rarities used:</span><br>${tooltip}'` : "" %>><span class="stat-name"><%= helper.capitalizeFirstLetter(name.split("_").join(" ")); %>: </span><span class="stat-value"><%= calculated.misc.burrows[key].total.toLocaleString() %></span></span><br>
-              <% } %>
-            </p>
+            <span <%- tooltip ? `data-tippy-content='<span class="stat-name">Rarities used:</span><br>${tooltip}'` : "" %>><span class="stat-name"><%= helper.capitalizeFirstLetter(name.split("_").join(" ")); %>: </span><span class="stat-value"><%= calculated.misc.burrows[key].total.toLocaleString() %></span></span><br>
+            <% } %>
+          </p>
           <% } %>
           <% if('profile_upgrades' in calculated.misc){ %>
-            <div class="category-header"><div class="category-icon"><div class="item-icon icon-154_0"></div></div><span>Profile upgrades</span></div>
-            <p class="stat-raw-values">
-              <% for(const upgrade in constants.PROFILE_UPGRADES){ %>
-              <% max = calculated.misc.profile_upgrades[upgrade] == constants.PROFILE_UPGRADES[upgrade] ? 'golden-text' : '' %><span class="stat-name <%= max %>"><%= helper.capitalizeFirstLetter(upgrade.split("_").join(" ")); %>: </span><span class="stat-value <%= max %>""><%= calculated.misc.profile_upgrades[upgrade] %> / <%= constants.PROFILE_UPGRADES[upgrade] %></span><br>
+          <div class="category-header">
+            <div class="category-icon">
+              <div class="item-icon icon-154_0"></div>
+            </div><span>Profile upgrades</span>
+          </div>
+          <p class="stat-raw-values">
+            <% for(const upgrade in constants.PROFILE_UPGRADES){ %>
+            <% max = calculated.misc.profile_upgrades[upgrade] == constants.PROFILE_UPGRADES[upgrade] ? 'golden-text' : '' %><span class="stat-name <%= max %>"><%= helper.capitalizeFirstLetter(upgrade.split("_").join(" ")); %>: </span><span class="stat-value <%= max %>""><%= calculated.misc.profile_upgrades[upgrade] %> / <%= constants.PROFILE_UPGRADES[upgrade] %></span><br>
               <% } %>
             </p>
           <% } %>
           <% if('auctions_sell' in calculated.misc){ %>
-            <div class="category-header"><div class="category-icon"><div class="item-icon icon-266_0"></div></div><span>Auctions sold</span></div>
-            <p class="stat-raw-values">
-              <% for(const key in calculated.misc.auctions_sell){
+            <div class=" category-header">
+              <div class="category-icon">
+                <div class="item-icon icon-266_0"></div>
+              </div><span>Auctions sold</span>
+        </div>
+        <p class="stat-raw-values">
+          <% for(const key in calculated.misc.auctions_sell){
                 let tooltip = "";
 
                 if(key == 'items_sold')
                   for(const key of Object.keys(calculated.auctions_sold).sort((a, b) => rarityOrder.indexOf(a) - rarityOrder.indexOf(b)))
                     tooltip += `<span class="stat-name piece-${ key }-fg">${ helper.capitalizeFirstLetter(key) }: </span><span class="stat-value">${ calculated.auctions_sold[key] }</span><br>`;
               %>
-              <span <%- tooltip ? `data-tippy-content='${tooltip}'` : "" %>><span class="stat-name"><%= helper.capitalizeFirstLetter(key.split("_").join(" ")); %>: </span><span class="stat-value"><%= calculated.misc.auctions_sell[key].toLocaleString() %></span></span><br>
-              <% } %>
-            </p>
+          <span <%- tooltip ? `data-tippy-content='${tooltip}'` : "" %>><span class="stat-name"><%= helper.capitalizeFirstLetter(key.split("_").join(" ")); %>: </span><span class="stat-value"><%= calculated.misc.auctions_sell[key].toLocaleString() %></span></span><br>
           <% } %>
-          <% if('auctions_buy' in calculated.misc){ %>
-            <div class="category-header"><div class="category-icon"><div class="item-icon icon-264_0"></div></div><span>Auctions bought</span></div>
-            <p class="stat-raw-values">
-              <% for(const key in calculated.misc.auctions_buy){
+        </p>
+        <% } %>
+        <% if('auctions_buy' in calculated.misc){ %>
+        <div class="category-header">
+          <div class="category-icon">
+            <div class="item-icon icon-264_0"></div>
+          </div><span>Auctions bought</span>
+        </div>
+        <p class="stat-raw-values">
+          <% for(const key in calculated.misc.auctions_buy){
                 let tooltip = "";
 
                 if(key == 'items_bought')
                   for(const key of Object.keys(calculated.auctions_bought).sort((a, b) => rarityOrder.indexOf(a) - rarityOrder.indexOf(b)))
                     tooltip += `<span class="stat-name piece-${ key }-fg">${ helper.capitalizeFirstLetter(key) }: </span><span class="stat-value">${ calculated.auctions_bought[key] }</span><br>`;
               %>
-              <span <%- tooltip ? `data-tippy-content='${tooltip}'` : "" %>><span class="stat-name"><%= helper.capitalizeFirstLetter(key.split("_").join(" ")); %>: </span><span class="stat-value"><%= calculated.misc.auctions_buy[key].toLocaleString() %></span></span><br>
-              <% } %>
-            </p>
+          <span <%- tooltip ? `data-tippy-content='${tooltip}'` : "" %>><span class="stat-name"><%= helper.capitalizeFirstLetter(key.split("_").join(" ")); %>: </span><span class="stat-value"><%= calculated.misc.auctions_buy[key].toLocaleString() %></span></span><br>
           <% } %>
+        </p>
+        <% } %>
 
-          <% if('claimed_items' in calculated.misc){ %>
-            <div class="category-header"><div class="category-icon"><div class="item-icon icon-339_0"></div></div><span>Claimed items</span></div>
-            <p class="stat-raw-values">
-              <% for(const key in calculated.misc.claimed_items){
+        <% if('claimed_items' in calculated.misc){ %>
+        <div class="category-header">
+          <div class="category-icon">
+            <div class="item-icon icon-339_0"></div>
+          </div><span>Claimed items</span>
+        </div>
+        <p class="stat-raw-values">
+          <% for(const key in calculated.misc.claimed_items){
                 let timestamp = calculated.misc.claimed_items[key];
               %>
-              <span class="stat-name"><%= helper.capitalizeFirstLetter(key.split("_").join(" ")); %>: </span>
-              <span class="stat-value" data-tippy-content='Claimed on <local-time timestamp="<%= timestamp %>"></local-time>'><%= moment(timestamp).fromNow() %></span><br>
-              <% } %>
-            </p>
+          <span class="stat-name"><%= helper.capitalizeFirstLetter(key.split("_").join(" ")); %>: </span>
+          <span class="stat-value" data-tippy-content='Claimed on <local-time timestamp="<%= timestamp %>"></local-time>'><%= moment(timestamp).fromNow() %></span><br>
           <% } %>
+        </p>
+        <% } %>
 
-          <% if ('uncategorized' in calculated.misc && Object.keys(calculated.misc.uncategorized).length > 0) { %>
-            <div class="category-header"><div class="category-icon"><div class="item-icon icon-421_0"></div></div><span>Uncategorized</span></div>
-            <p class="stat-raw-values">
-              <% for (const [key, value] of Object.entries(calculated.misc.uncategorized)) { %>
-              <span class="stat-name"><%= helper.capitalizeFirstLetter(key.split("_").join(" ")); %>: </span>
-              <span class="stat-value"><%= value.formatted %></span><br>
-              <% } %>
-            </p>
-          <% } %>
+        <% if ('uncategorized' in calculated.misc && Object.keys(calculated.misc.uncategorized).length > 0) { %>
+        <div class="category-header">
+          <div class="category-icon">
+            <div class="item-icon icon-421_0"></div>
+          </div><span>Uncategorized</span>
         </div>
+        <p class="stat-raw-values">
+          <% for (const [key, value] of Object.entries(calculated.misc.uncategorized)) { %>
+          <span class="stat-name"><%= helper.capitalizeFirstLetter(key.split("_").join(" ")); %>: </span>
+          <span class="stat-value"><%= value.formatted %></span><br>
+          <% } %>
+        </p>
+        <% } %>
       </div>
+    </div>
     <% } %>
     </div>
   </main>
@@ -2505,4 +2591,5 @@ const metaDescription = getMetaDescription()
     const constants = JSON.parse(`<%- JSON.stringify(clientConstants).replaceAll('\\', '\\\\') %>`);
   </script>
 </body>
+
 </html>


### PR DESCRIPTION
this PR literally only runs `j69.ejs-beautify` extension in stats.ejs, no other change has been dome from origin/development branch

edit: also adds the extension as a suggested one for vscode

Name: EJS Beautify
Id: j69.ejs-beautify
Description: A formatter extension for EJS files for VS Code. 'js-beautify' is used as the format engine.
Version: 1.0.6
Publisher: j69
VS Marketplace Link: https://marketplace.visualstudio.com/items?itemName=j69.ejs-beautify