### PR TITLE
Fix for "User not found" when directly entering cute_name in URL

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -3362,7 +3362,11 @@ export async function getProfile(
       return;
     }
 
-    if (_profile?.selected || _profile.profile_id.toLowerCase() == paramProfile) {
+    if (
+      _profile?.selected ||
+      _profile.profile_id.toLowerCase() == paramProfile ||
+      _profile.cute_name.toLowerCase() == paramProfile
+    ) {
       profile = _profile;
     }
   }


### PR DESCRIPTION
This mainly happens when you try to directly get a currently not selected profile by it's `cute_name`. 

Examples: https://sky.shiiyu.moe/stats/MartinNemi03/Cucumber, https://sky.shiiyu.moe/stats/Oblivion239/Mango

_Thanks to Oblivion239 for reporting this bug!_