### PR TITLE
Add LetsEncrypt to SkyCrypt README.md and updated Nginx Description

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You are free to report bugs or contribute to this project. Just open <a href="..
 - <a href="https://docs.mongodb.com/manual/administration/install-community/">MongoDB</a>
 - <a href="https://redis.io/">Redis</a>
 - <a href="https://api.hypixel.net/">Hypixel API Key</a>
-- <a href="https://www.nginx.com/">Nginx</a> (Optional for full/production deployment. Helps with web requests  and load balancing.)
+- <a href="https://www.nginx.com/">Nginx</a> (Optional for full/production deployment. Helps with web requests and load balancing.)
 - <a href="https://letsencrypt.org/">LetsEncrypt</a> (Optional for full/production deployment. Provision free HTTPS certifications.)
 
 <h3>Installation</h3>

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ You are free to report bugs or contribute to this project. Just open <a href="..
 - <a href="https://nodejs.org/">Node.js</a>
 - <a href="https://docs.mongodb.com/manual/administration/install-community/">MongoDB</a>
 - <a href="https://redis.io/">Redis</a>
-- <a href="https://api.hypixel.net/">Hypixel API Key</a>?
-- <a href="https://www.nginx.com/">Nginx</a> (Optional for Full/Production Deployment. Helps with Web Requests and Load Balancing.)
-- <a href="https://letsencrypt.org/">LetsEncrypt</a> (Optional for Full/Production Deployment. Provisions Free HTTPS Certifications.)
+- <a href="https://api.hypixel.net/">Hypixel API Key</a>
+- <a href="https://www.nginx.com/">Nginx</a> (Optional for full/production deployment. Helps with web requests  and load balancing.)
+- <a href="https://letsencrypt.org/">LetsEncrypt</a> (Optional for full/production deployment. Provision free HTTPS certifications.)
 
 <h3>Installation</h3>
 A more explanatory guide can be found in <a href="/CONTRIBUTING.md">CONTRIBUTING.md</a>

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ You are free to report bugs or contribute to this project. Just open <a href="..
 - <a href="https://nodejs.org/">Node.js</a>
 - <a href="https://docs.mongodb.com/manual/administration/install-community/">MongoDB</a>
 - <a href="https://redis.io/">Redis</a>
-- <a href="https://api.hypixel.net/">Hypixel API Key</a>
-- <a href="https://www.nginx.com/">Nginx</a> (Optional but an ideal choice for full deployment)
+- <a href="https://api.hypixel.net/">Hypixel API Key</a>?
+- <a href="https://www.nginx.com/">Nginx</a> (Optional for Full/Production Deployment. Helps with Web Requests and Load Balancing.)
+- <a href="https://letsencrypt.org/">LetsEncrypt</a> (Optional for Full/Production Deployment. Provisions Free HTTPS Certifications.)
 
 <h3>Installation</h3>
 A more explanatory guide can be found in <a href="/CONTRIBUTING.md">CONTRIBUTING.md</a>


### PR DESCRIPTION
Added LetsEncrypt as an optional deployment tool in the documentation. This also helps service workers who only operate on secure origins—also updated the Nginx blurb to provide clarity on its benefits. Note that both are not optional to self-host SkyCrypt. Both LetsEncrypt and Nginx are suggestions for Production/Full Deployments and are not required for Hobby/Development Deployments.