### PR TITLE
feat: add Class Average & fix: MM7 Dragons counted in Dragons Section

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -2153,9 +2153,9 @@ export async function getStats(
       auctions_sold[key.replace("auctions_sold_", "")] = userProfile.stats[key];
     } else if (key.includes("auctions_bought_")) {
       auctions_bought[key.replace("auctions_bought_", "")] = userProfile.stats[key];
-    } else if (key.startsWith("kills_") && key.endsWith("_dragon")) {
+    } else if (key.startsWith("kills_") && key.endsWith("_dragon") && key !== "kills_master_wither_king_dragon") {
       misc.dragons["last_hits"] += userProfile.stats[key];
-    } else if (key.startsWith("deaths_") && key.endsWith("_dragon")) {
+    } else if (key.startsWith("deaths_") && key.endsWith("_dragon") && key !== "deaths_master_wither_king_dragon") {
       misc.dragons["deaths"] += userProfile.stats[key];
     } else if (key.includes("kills_corrupted_protector")) {
       misc.protector["last_hits"] = userProfile.stats[key];
@@ -2896,9 +2896,13 @@ export function getDungeons(userProfile, hypixelProfile) {
     if (className == current_class) {
       output.classes[className].current = true;
     }
+
+    output.class_average ??= 0;
+    output.class_average += output.classes[className].experience.level;
   }
 
   output.used_classes = used_classes;
+  output.class_average = output.class_average / Object.keys(output.classes).length;
 
   output.selected_class = current_class;
   output.secrets_found = hypixelProfile.achievements.skyblock_treasure_hunter || 0;

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1780,6 +1780,10 @@ const metaDescription = getMetaDescription()
             <span class="stat-name">Selected Class: </span>
             <span class="stat-value"><%= helper.titleCase(calculated.dungeons.selected_class) %></span>
             <br>
+            <% max = calculated.dungeons.class_average === 50 ? "golden-text" : "" %>
+            <span class="stat-name <%= max %>">Class Average: </span>
+            <span class="stat-value <%= max %>"><%= calculated.dungeons.class_average.toLocaleString() %></span>
+            <br>
             <% max = calculated.dungeons.catacombs.bonuses.item_boost === 465 ? "golden-text" : "" %>
             <span class="stat-name <%= max %>">Dungeon Item Boost: </span>
             <span class="stat-value percent <%= max %>"><%= calculated.dungeons.catacombs.bonuses.item_boost.toLocaleString() %></span>
@@ -2592,11 +2596,11 @@ const metaDescription = getMetaDescription()
                 let tooltip = "";
 
                 if(key == 'last_hits')
-                  for(const kill of calculated.kills.filter(a => a.entityId.endsWith('_dragon')))
+                  for(const kill of calculated.kills.filter(a => a.entityId.endsWith('_dragon') && a.entityId != 'master_wither_king_dragon'))
                     tooltip += `<span class="stat-name">${ kill.entityName }: </span><span class="stat-value">${ kill.amount }</span> <span class="grey-text">(${ Math.round(kill.amount / calculated.misc.dragons[key] * 100) }%)</span><br>`;
 
                 if(key == 'deaths')
-                  for(const death of calculated.deaths.filter(a => a.entityId.endsWith('_dragon')))
+                  for(const death of calculated.deaths.filter(a => a.entityId.endsWith('_dragon') && a.entityId != 'master_wither_king_dragon'))
                     tooltip += `<span class="stat-name">${ death.entityName }: </span><span class="stat-value">${ death.amount }</span><br>`;
               %>
             <span <%- tooltip ? `data-tippy-content='${tooltip}'` : "" %>><span class="stat-name"><%= helper.capitalizeFirstLetter(key.split("_").join(" ")); %>: </span><span class="stat-value"><%= calculated.misc.dragons[key].toLocaleString() %></span></span><br>


### PR DESCRIPTION
## Description

Closes #1707
Added Class Average to Dungeons Section (https://canary.discord.com/channels/738971489411399761/738990231348314123/1030085431645184030)

## Examples 
> Before
![image](https://user-images.githubusercontent.com/75372052/195791269-4d7465e9-ae88-47d7-96d4-34d8e4fd219f.png)

> After
![image](https://user-images.githubusercontent.com/75372052/195791037-30edda1d-f2d2-45fd-873c-e70e65c831ca.png)


![image](https://user-images.githubusercontent.com/75372052/195791150-66f6b0de-8de4-40e5-89fe-15d83850f594.png)
![image](https://user-images.githubusercontent.com/75372052/195791333-bc00bd26-d758-4549-adf1-c6af1c8d1a19.png)

