### PR TITLE
Added support for custom format in cache methods

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,5 +1,5 @@
 {
-  "ignore": [".git", "node_modules", "public"],
+  "ignore": [".git", "node_modules", "public", "cache"],
   "env": {
     "NODE_ENV": "development"
   }

--- a/src/app.js
+++ b/src/app.js
@@ -15,7 +15,6 @@ import "axios-debug-log";
 import fs from "fs-extra";
 
 import path from "path";
-import { fileURLToPath } from "url";
 import * as renderer from "./renderer.js";
 
 import credentials from "./credentials.js";
@@ -38,7 +37,7 @@ import { execSync } from "child_process";
 import * as api from "./routes/api.js";
 import * as apiv2 from "./routes/apiv2.js";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = helper.getFolderPath();
 
 const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, "../public/manifest.json")));
 
@@ -96,7 +95,7 @@ const cacheMaxAge = 30 * 24 * 60 * 60; // 30 days should be cached for
  */
 const volatileCacheMaxAge = 12 * 60 * 60; // 12 hours
 
-const cachePath = path.resolve(__dirname, "../cache");
+const cachePath = helper.getCacheFolderPath(__dirname);
 await fs.ensureDir(cachePath);
 
 if (credentials.hypixel_api_key.length == 0) {
@@ -140,12 +139,12 @@ function updateCommitHash() {
 }
 const commitHash = updateCommitHash();
 
+const featuredProfiles = fs.readJSONSync(helper.getCacheFilePath(cachePath, "json", "featured-profiles", "json"));
+
 // Wait for APIs to be ready..
 // Maybe these awaits are done wrong or just unnecessary, idk.. -Martin
 await apiv2.init();
 await api.init();
-
-const featuredProfiles = fs.readJSONSync(path.resolve("./public/resources/js/featured-profiles.json"));
 
 const app = express();
 const port = process.env.SKYCRYPT_PORT ?? 32464;

--- a/src/helper.js
+++ b/src/helper.js
@@ -6,6 +6,7 @@ import { v4 } from "uuid";
 import retry from "async-retry";
 import path from "path";
 import fs from "fs-extra";
+import { fileURLToPath } from "url";
 
 export { renderLore, formatNumber } from "../common/formatting.js";
 export * from "../common/helper.js";
@@ -953,10 +954,18 @@ export function parseItemTypeFromLore(lore) {
   };
 }
 
-export function getCacheFilePath(dirPath, type, name) {
+export function getFolderPath() {
+  return path.dirname(fileURLToPath(import.meta.url));
+}
+
+export function getCacheFolderPath(dirPath) {
+  return path.resolve(dirPath, "../cache");
+}
+
+export function getCacheFilePath(dirPath, type, name, format = "png") {
   // we don't care about folder optimization when we're developing
   if (process.env?.NODE_ENV == "development") {
-    return path.resolve(dirPath, `${type}_${name}.png`);
+    return path.resolve(dirPath, `${type}_${name}.${format}`);
   }
 
   const subdirs = [type];
@@ -984,7 +993,7 @@ export function getCacheFilePath(dirPath, type, name) {
     }
   }
 
-  return path.resolve(dirPath, `${subdirs.join("/")}/${type}_${name}.png`);
+  return path.resolve(dirPath, `${subdirs.join("/")}/${type}_${name}.${format}`);
 }
 
 function getCategoriesFromType(type) {

--- a/src/scripts/update-featured-profiles.js
+++ b/src/scripts/update-featured-profiles.js
@@ -1,5 +1,4 @@
 import fs from "fs-extra";
-import path from "path";
 import { db } from "../mongo.js";
 import * as helper from "../helper.js";
 
@@ -70,7 +69,8 @@ const FEATURED_PROFILES = [
     })
   );
 
-  await fs.writeJson(path.resolve("./public/resources/js/featured-profiles.json"), FEATURED_PROFILES);
+  const cachePath = helper.getCacheFolderPath(helper.getFolderPath());
+  await fs.writeJson(helper.getCacheFilePath(cachePath, "json", "featured-profiles", "json"), FEATURED_PROFILES);
 
   console.log("Featured profiles updated!");
 }


### PR DESCRIPTION
Also added some additional methods for things regarding some folders and changed features profiles to actually use the cache folder instead of the quick workaround of putting it into public/js folder. 
Now when I think about it, maybe we could start utilizing this to save more things that wouldn't make sense in the DB, but would be useful saving. _(Maybe the custom resources data would be cozy in there, but idk how hard it would be)_