### PR TITLE
fix: API profile selection

### DIFF
--- a/src/routes/apiv2/profile.js
+++ b/src/routes/apiv2/profile.js
@@ -26,8 +26,8 @@ router.get("/:player", async (req, res, next) => {
       output.profiles[singleProfile.profile_id] = {
         profile_id: singleProfile.profile_id,
         cute_name: singleProfile.cute_name,
-        current: Math.max(...allProfiles.map((a) => a.members[profile.uuid].last_save)) == userProfile.last_save,
-        last_save: userProfile.last_save,
+        game_mode: singleProfile.game_mode,
+        current: singleProfile.selected,
         raw: userProfile,
         items,
         data,


### PR DESCRIPTION
## Description

Closes #1742
Fixes `current` tag in API using old selection system (`last_save`)
Also adds `game_mode` tag

## Example
> Before

![image](https://user-images.githubusercontent.com/75372052/198685134-075e41f4-72d4-45fa-b928-b7ca62bd4326.png)

> After

![image](https://user-images.githubusercontent.com/75372052/198685198-b04a109f-f039-48df-afb2-5be24eb5750c.png)
