### PR TITLE
Custom resources caching

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -28,6 +28,7 @@ import { mongo, db } from "./mongo.js";
 import sanitize from "mongo-sanitize";
 import * as helper from "./helper.js";
 import * as constants from "./constants.js";
+import * as custom_resources from "./custom-resources.js";
 import { SitemapStream, streamToPromise } from "sitemap";
 import { createGzip } from "zlib";
 import twemoji from "twemoji";
@@ -37,15 +38,16 @@ import { execSync } from "child_process";
 import * as api from "./routes/api.js";
 import * as apiv2 from "./routes/apiv2.js";
 
-const __dirname = helper.getFolderPath();
+const folderPath = helper.getFolderPath();
 
-const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, "../public/manifest.json")));
+const manifest = JSON.parse(fs.readFileSync(path.join(folderPath, "../public/manifest.json")));
 
 await renderer.init();
+await custom_resources.init();
 
 const fileHashes = await getFileHashes();
 
-const fileNameMapFileName = path.join(__dirname, "../public/resources/js/file-name-map.json");
+const fileNameMapFileName = path.join(folderPath, "../public/resources/js/file-name-map.json");
 
 while (!fs.existsSync(fileNameMapFileName)) {
   console.log(`waiting for: "${fileNameMapFileName}" make sure you ran rollup`);
@@ -95,7 +97,7 @@ const cacheMaxAge = 30 * 24 * 60 * 60; // 30 days should be cached for
  */
 const volatileCacheMaxAge = 12 * 60 * 60; // 12 hours
 
-const cachePath = helper.getCacheFolderPath(__dirname);
+const cachePath = helper.getCacheFolderPath(folderPath);
 await fs.ensureDir(cachePath);
 
 if (credentials.hypixel_api_key.length == 0) {
@@ -132,7 +134,7 @@ updateCacheOnly();
 setInterval(updateCacheOnly, 60_000 * 5);
 
 function updateCommitHash() {
-  return execSync("git rev-parse HEAD", { cwd: path.resolve(__dirname, "../") })
+  return execSync("git rev-parse HEAD", { cwd: path.resolve(folderPath, "../") })
     .toString()
     .trim()
     .slice(0, 10);
@@ -218,7 +220,7 @@ async function getExtra(page = null, favoriteUUIDs = [], cacheOnly) {
 
   output.twemoji = twemoji;
 
-  output.packs = lib.getPacks();
+  output.packs = custom_resources.getPacks();
 
   output.isFoolsDay = isFoolsDay;
   output.cacheOnly = cacheOnly;

--- a/src/custom-resources.js
+++ b/src/custom-resources.js
@@ -1,7 +1,6 @@
 import fs from "fs-extra";
 import path from "path";
-import { fileURLToPath } from "url";
-import { getClusterId, hasPath, getPath } from "./helper.js";
+import { getClusterId, getFolderPath, getCacheFolderPath, getCacheFilePath, hasPath, getPath } from "./helper.js";
 import mm from "micromatch";
 import util from "util";
 import apng2gif from "apng2gif-bin";
@@ -15,13 +14,27 @@ import UPNG from "upng-js";
 import RJSON from "relaxed-json";
 
 import child_process from "child_process";
+import { getFileHash } from "./hashes.js";
 const execFile = util.promisify(child_process.execFile);
 
 const NORMALIZED_SIZE = 128;
+const RESOURCE_CACHING = true;
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const folderPath = getFolderPath();
+const RESOURCE_PACK_FOLDER = path.resolve(getFolderPath(), "..", "public", "resourcepacks");
 
-const RESOURCE_PACK_FOLDER = path.resolve(__dirname, "..", "public", "resourcepacks");
+const cacheFolderPath = getCacheFolderPath(folderPath);
+const PACK_HASH_CACHE_FILE = getCacheFilePath(cacheFolderPath, "json", "pack_hashes", "json");
+const RESOURCES_CACHE_FILE = getCacheFilePath(cacheFolderPath, "json", "custom_resources", "json");
+
+let resourcesReady = false;
+const readyPromise = new Promise((resolve) => {
+  setInterval(() => {
+    if (resourcesReady) {
+      resolve();
+    }
+  }, 1000);
+});
 
 const removeFormatting = new RegExp("§[0-9a-z]{1}", "g");
 
@@ -53,11 +66,69 @@ function getFrame(src, frame) {
 }
 
 let resourcePacks = [];
+let packConfigHashes = {};
 
-async function init() {
+const outputPacks = [];
+
+export async function init() {
   console.log(`Custom Resources loading started on ${getClusterId(true)}.`);
   console.time(`custom_resources_${getClusterId()}`);
 
+  await loadPackConfigs();
+  let resourcesUpToDate = false;
+
+  try {
+    packConfigHashes = JSON.parse(fs.readFileSync(PACK_HASH_CACHE_FILE));
+
+    resourcePacks.forEach((pack) => {
+      if (packConfigHashes[pack.config.id] !== pack.config.hash) {
+        throw new Error("Config hashes were not matching!");
+      }
+    });
+
+    resourcesUpToDate = true;
+  } catch (e) {
+    resourcePacks.forEach((pack) => {
+      packConfigHashes[pack.config.id] = pack.config.hash;
+    });
+
+    fs.writeFileSync(PACK_HASH_CACHE_FILE, JSON.stringify(packConfigHashes));
+  }
+
+  try {
+    if (!RESOURCE_CACHING) {
+      throw new Error("Resource caching has been disabled!");
+    }
+
+    if (resourcesUpToDate) {
+      resourcePacks = JSON.parse(fs.readFileSync(RESOURCES_CACHE_FILE));
+    } else {
+      throw new Error("Resources need to be loaded!");
+    }
+  } catch (e) {
+    await loadResourcePacks();
+
+    fs.writeFileSync(RESOURCES_CACHE_FILE, JSON.stringify(resourcePacks));
+  }
+
+  resourcePacks.forEach((pack) => {
+    outputPacks.push(
+      Object.assign(
+        {
+          basePath: "/" + path.relative(path.resolve(folderPath, "..", "public"), pack.basePath),
+        },
+        pack.config
+      )
+    );
+  });
+
+  resourcesReady = true;
+
+  console.log(`Custom Resources loading done. (${getClusterId(true)})`);
+  console.timeEnd(`custom_resources_${getClusterId()}`);
+}
+
+async function loadPackConfigs() {
   for (const packOrFile of await fs.readdir(RESOURCE_PACK_FOLDER, { withFileTypes: true })) {
     if (!packOrFile.isDirectory()) {
       continue;
@@ -67,7 +138,10 @@ async function init() {
     const basePath = path.resolve(RESOURCE_PACK_FOLDER, pack);
 
     try {
-      const config = JSON.parse(fs.readFileSync(path.resolve(basePath, "config.json")));
+      const configPath = path.resolve(basePath, "config.json");
+
+      const config = JSON.parse(fs.readFileSync(configPath));
+      config.hash = await getFileHash(configPath);
 
       resourcePacks.push({
         basePath,
@@ -77,7 +151,9 @@ async function init() {
       console.log("Couldn't find config for resource pack", pack);
     }
   }
+}
 
+async function loadResourcePacks() {
   resourcePacks = resourcePacks.sort((a, b) => a.config.priority - b.config.priority);
 
   for (const pack of resourcePacks) {
@@ -91,6 +167,8 @@ async function init() {
 
       const lines = fs.readFileSync(file, "utf8").split(/\r?\n/);
       const properties = {};
+
+      if (!lines.some((line) => line.startsWith("nbt.ExtraAttributes.id"))) continue;
 
       for (const line of lines) {
         // Skipping comments
@@ -274,7 +352,7 @@ async function init() {
 
         texture.match.push({
           value: property.substring(4),
-          regex,
+          regex: regex.toString(),
         });
       }
 
@@ -407,56 +485,47 @@ async function init() {
       pack.textures.push(texture);
     }
   }
-
-  console.log(`Custom Resources loading done. (${getClusterId(true)})`);
-  console.timeEnd(`custom_resources_${getClusterId()}`);
 }
 
-const outputPacks = [];
-const readyPromise = init();
+export function getPacks() {
+  return outputPacks.sort((a, b) => b.priority - a.priority);
+}
 
-readyPromise.then(() => {
-  ready = true;
+export function getCompletePacks() {
+  return resourcePacks;
+}
 
-  for (const pack of resourcePacks) {
-    outputPacks.push(
-      Object.assign(
-        {
-          basePath: "/" + path.relative(path.resolve(__dirname, "..", "public"), pack.basePath),
-        },
-        pack.config
-      )
-    );
-  }
-});
-
-export let ready = false;
-export const packs = outputPacks;
-export const completePacks = resourcePacks;
-export async function getTexture(item, ignoreId = false, packIds) {
-  if (!ready) {
+export async function getTexture(item, options = { ignore_id: false, pack_ids: [], debug: false }) {
+  if (!resourcesReady) {
     await readyPromise;
   }
 
+  const timeStarted = Date.now();
+  const debugStats = {
+    processed_packs: 0,
+    processed_textures: 0,
+    found_matches: 0,
+  };
+
   let outputTexture = { weight: -9999 };
 
-  let _resourcePacks = resourcePacks;
+  let tempPacks = resourcePacks;
 
-  packIds = packIds !== undefined ? packIds.split(",") : [];
+  options.pack_ids = options.pack_ids !== undefined ? options.pack_ids.split(",") : [];
 
-  if (packIds.length > 0) {
-    _resourcePacks = _resourcePacks.filter((a) => packIds.includes(a.config.id));
+  if (options.pack_ids.length > 0) {
+    tempPacks = tempPacks.filter((a) => options.pack_ids.includes(a.config.id));
   }
 
-  _resourcePacks = _resourcePacks.sort((a, b) => packIds.indexOf(a) - packIds.indexOf(b));
+  tempPacks = tempPacks.sort((a, b) => options.pack_ids.indexOf(a) - options.pack_ids.indexOf(b));
 
-  for (const pack of _resourcePacks) {
+  for (const pack of tempPacks) {
     for (const texture of pack.textures) {
-      if (ignoreId === false && texture.id != item.id) {
+      if (options.ignore_id === false && texture.id != item.id) {
         continue;
       }
 
-      if (ignoreId === false && "damage" in texture && texture.damage != item.Damage) {
+      if (options.ignore_id === false && "damage" in texture && texture.damage != item.Damage) {
         continue;
       }
 
@@ -479,10 +548,20 @@ export async function getTexture(item, ignoreId = false, packIds) {
           matchValues = [matchValues];
         }
 
-        if (matchValues.some((matchValue) => regex.test(matchValue.toString().replace(removeFormatting, "")))) {
+        const slash = regex.lastIndexOf("/");
+        regex = new RegExp(regex.slice(1, slash), regex.slice(slash + 1));
+
+        if (
+          matchValues.some((matchValue) => {
+            return regex.test(matchValue.toString().replace(removeFormatting, ""));
+          })
+        ) {
           matches++;
         }
       }
+
+      debugStats.found_matches += matches;
+      debugStats.processed_textures++;
 
       if (matches == texture.match.length) {
         if (texture.weight < outputTexture.weight) {
@@ -496,13 +575,21 @@ export async function getTexture(item, ignoreId = false, packIds) {
         outputTexture = Object.assign({ pack: { basePath: pack.basePath, config: pack.config } }, texture);
       }
     }
+
+    debugStats.processed_packs++;
   }
 
   if (!("path" in outputTexture)) {
     return null;
   }
 
-  outputTexture.path = path.relative(path.resolve(__dirname, "..", "public"), outputTexture.path).replaceAll("\\", "/");
+  outputTexture.path = path
+    .relative(path.resolve(folderPath, "..", "public"), outputTexture.path)
+    .replaceAll("\\", "/");
+
+  debugStats.time_spent_ms = Date.now() - timeStarted;
+  outputTexture.debug = debugStats;
+
   process.send({ type: "used_pack", id: outputTexture?.pack.config.id });
 
   return outputTexture;

--- a/src/lib.js
+++ b/src/lib.js
@@ -12,7 +12,7 @@ import { v4 } from "uuid";
 
 import * as constants from "./constants.js";
 import credentials from "./credentials.js";
-import { getTexture, packs } from "./custom-resources.js";
+import { getTexture } from "./custom-resources.js";
 import * as helper from "./helper.js";
 import { db } from "./mongo.js";
 import { redisClient } from "./redis.js";
@@ -515,7 +515,10 @@ async function processItems(base64, customTextures = false, packs, cacheOnly = f
     }
 
     if (item.tag?.ExtraAttributes?.skin == undefined && customTextures) {
-      const customTexture = await getTexture(item, false, packs);
+      const customTexture = await getTexture(item, {
+        ignore_id: false,
+        pack_ids: packs,
+      });
 
       if (customTexture) {
         item.animated = customTexture.animated;
@@ -2774,13 +2777,13 @@ export function getBestiary(uuid, profile) {
 
       const boss = mob.boss == true ? "boss" : "regular";
 
-      let kills = bestiaryFamilies[mob.id] || 0;
-      let head = mob.head;
-      let itemId = mob.itemId;
-      let damage = mob.damage;
-      let name = mob.name;
-      let maxTier = mob.maxTier ?? 41;
-      let tier =
+      const kills = bestiaryFamilies[mob.id] || 0;
+      const head = mob.head;
+      const itemId = mob.itemId;
+      const damage = mob.damage;
+      const name = mob.name;
+      const maxTier = mob.maxTier ?? 41;
+      const tier =
         constants.BEASTIARY_KILLS[boss].filter((k) => k <= kills).length > maxTier
           ? maxTier
           : constants.BEASTIARY_KILLS[boss].filter((k) => k <= kills).length;
@@ -3193,7 +3196,10 @@ function getHotmItems(userProfile, packs) {
 
   // Processing textures
   output.forEach(async (item) => {
-    const customTexture = await getTexture(item, false, packs);
+    const customTexture = await getTexture(item, {
+      ignore_id: false,
+      pack_ids: packs,
+    });
 
     if (customTexture) {
       item.animated = customTexture.animated;
@@ -3753,10 +3759,6 @@ async function updateLeaderboardPositions(db, uuid, allProfiles) {
   } catch (e) {
     console.error(e);
   }
-}
-
-export function getPacks() {
-  return packs.sort((a, b) => b.priority - a.priority);
 }
 
 async function init() {

--- a/src/master.js
+++ b/src/master.js
@@ -1,5 +1,6 @@
 // this file only run on the master thread
 await import("./scripts/init-collections.js");
+await import("./scripts/init-custom-resources.js");
 
 await Promise.all([
   import("./scripts/cap-leaderboards.js"),

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -360,7 +360,10 @@ export async function renderItem(skyblockId, query, db) {
     outputTexture.image = await getPart(itemsSheet, ...coords, 128, 128, 1).toBuffer("image/png");
   }
 
-  const customTexture = await customResources.getTexture(item, "name" in query, query.pack);
+  const customTexture = await customResources.getTexture(item, {
+    ignore_id: "name" in query,
+    pack_ids: query.pack,
+  });
 
   if (customTexture) {
     if (customTexture.animated) {

--- a/src/routes/apiv2.js
+++ b/src/routes/apiv2.js
@@ -3,7 +3,7 @@ import express from "express";
 import sanitize from "mongo-sanitize";
 import leaderboard from "../leaderboards.js";
 
-import { completePacks } from "../custom-resources.js";
+import { getCompletePacks } from "../custom-resources.js";
 import { db } from "../mongo.js";
 import { redisClient } from "../redis.js";
 
@@ -49,7 +49,7 @@ router.use(async (req, res, next) => {
  */
 router.get("/packs", async (req, res) => {
   if (req.apiKey) {
-    res.json(completePacks);
+    res.json(getCompletePacks());
   } else {
     res.status(404).json({ error: "This endpoint isn't available to the public." });
   }

--- a/src/scripts/init-custom-resources.js
+++ b/src/scripts/init-custom-resources.js
@@ -1,0 +1,3 @@
+import * as custom_resources from "../custom-resources.js";
+
+await custom_resources.init();


### PR DESCRIPTION
Custom Resources are famous for their ridiculous load times that slow down startup times, so we went ahead and implemented caching for custom resources! 

Upon the first load, a cache with pack config hashes (for checking changes) and loaded resource packs will be created in your local /cache folder. From there, every startup it will check if pack configs have changed and if not, just load the packs from cache!

Included with this PR is a optimization change (by @DuckySoLucky) from #1694! 
_...And some new debug stats for how many resources needed to be checked with how long it took I guess._
