### PR TITLE
fix: Pet Score MF Symbol

### DIFF
--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1191,8 +1191,10 @@ const metaDescription = getMetaDescription()
               <table>
               <% 
               const entries = Object.entries(petRewards)
-              let reduced = Object.keys(petRewards).reduce((prev, curr) => Math.abs(curr - petScore) < Math.abs(prev - petScore) ? curr : prev)
-              if (petScore < reduced) reduced = entries[Object.keys(petRewards).indexOf(reduced) - 1][0]
+
+              let reduced = entries.reduce((prev, curr) => {
+                return petScore >= curr[0] ? curr : prev
+              })[0]
               %>
 
               <% for (let i = 1; i < entries.length; i++) { %>

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1073,7 +1073,7 @@ const metaDescription = getMetaDescription()
               <% } %>
               <% if (rarities.abicase && Math.floor(Object.keys(calculated.abiphone).length / 2) > 0) {%>
                 <span style='color: var(--§<%= constants.RARITY_COLORS["rare"] %>);' class='grey-text'>Abicase</span> = <span style='color: var(--§6);' class='grey-text'>+<%= Math.floor(Object.keys(calculated.abiphone).length / 2).toLocaleString() %> MP</span><br>
-              <% } %> 
+              <% } %>
               <br>
               Total: <span style='color: var(--§6);' class='grey-text'><%= mp_total.toLocaleString() %> Magical Power</span>
               ">
@@ -1189,12 +1189,9 @@ const metaDescription = getMetaDescription()
             <span data-tippy-content="
               Increase your pet score by collecting unique pets with a high rarity.<br><br>
               <table>
-              <% 
+              <%
               const entries = Object.entries(petRewards)
-
-              let reduced = entries.reduce((prev, curr) => {
-                return petScore >= curr[0] ? curr : prev
-              })[0]
+              const reduced = entries.reduce((prev, curr) => petScore >= curr[0] ? curr : prev)[0]
               %>
 
               <% for (let i = 1; i < entries.length; i++) { %>

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1189,8 +1189,11 @@ const metaDescription = getMetaDescription()
             <span data-tippy-content="
               Increase your pet score by collecting unique pets with a high rarity.<br><br>
               <table>
-              <% const entries = Object.entries(petRewards) %>
-              <% const reduced = Object.keys(petRewards).reduce((prev, curr) => Math.abs(curr - petScore) < Math.abs(prev - petScore) ? curr : prev) %>
+              <% 
+              const entries = Object.entries(petRewards)
+              let reduced = Object.keys(petRewards).reduce((prev, curr) => Math.abs(curr - petScore) < Math.abs(prev - petScore) ? curr : prev)
+              if (petScore < reduced) reduced = entries[Object.keys(petRewards).indexOf(reduced) - 1][0]
+              %>
 
               <% for (let i = 1; i < entries.length; i++) { %>
                 <% const [score, {magic_find}] = entries[i] %>


### PR DESCRIPTION
## Description

Fixes https://canary.discord.com/channels/738971489411399761/738990246825427084/1036219139108380752
> TL;DR Calculation would put pointing arrow to closest value even without meeting requirements

Example: https://sky.shiiyu.moe/stats/dukioooo/Raspberry#Pets

## Example
> Before

![image](https://user-images.githubusercontent.com/75372052/199767060-9eac3d9b-efa9-4fe4-8264-fbf2cc5b4455.png)

> After

![image](https://user-images.githubusercontent.com/75372052/199767012-115ef9cf-b997-47c5-afa4-a93166f71d16.png)
