### PR TITLE
fix: Error caused by enrichments

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -1450,17 +1450,18 @@ async function getLevels(userProfile, hypixelProfile, levelCaps, profileMembers)
         skill: "runecrafting",
         type: "runecrafting",
       }),
-      social: Object.keys(profileMembers)
-        ? getLevelByXp(
-            Object.keys(profileMembers)
-              .map((member) => profileMembers[member].experience_skill_social2 || 0)
-              .reduce((a, b) => a + b, 0),
-            { skill: "social", type: "social" }
-          )
-        : getLevelByXp(userProfile.experience_skill_social2, {
-            skill: "social",
-            type: "social",
-          }),
+      social:
+        Object.keys(profileMembers || {}).length > 0
+          ? getLevelByXp(
+              Object.keys(profileMembers)
+                .map((member) => profileMembers[member].experience_skill_social2 || 0)
+                .reduce((a, b) => a + b, 0),
+              { skill: "social", type: "social" }
+            )
+          : getLevelByXp(userProfile.experience_skill_social2, {
+              skill: "social",
+              type: "social",
+            }),
     };
 
     for (const skill in skillLevels) {

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -256,7 +256,7 @@ function enrichmentToStatName(enrichment) {
 function getEnrichments(accessories) {
   const enrichmentCounts = {}
   const filteredAccessories = accessories
-    .filter(acc => ['legendary', 'mythic', 'divine', 'special', 'very_special'].includes(acc.rarity.toLowerCase()))
+    .filter(acc => ['legendary', 'mythic', 'divine', 'special', 'very_special'].includes(acc.rarity?.toLowerCase()))
 
   if (filteredAccessories.length > 0) {
     filteredAccessories.forEach(acc => {


### PR DESCRIPTION
## Description

Fixes `Cannot read properties of null (reading 'toLowerCase')` caused by `getEnrichments()` function
Example: https://sky.shiiyu.moe/stats/Milo0209
Also refactor to social experience leveling not really required but it wasn't really safe, it could have caused error. So that's fixed now