### PR TITLE
fix: wrong max Experience enchantment level

### DIFF
--- a/common/constants/enchantments.js
+++ b/common/constants/enchantments.js
@@ -26,7 +26,7 @@ export const MAX_ENCHANTS = new Set([
   "Efficiency X",
   "Ender Slayer VII",
   "Execute VI",
-  "Experience IV",
+  "Experience V",
   "Expertise X",
   "Feather Falling X",
   "Feather Falling XX",


### PR DESCRIPTION
## Description

Changed Experience Enchantment level from IV to V, Experience V book was added in Jerry Island Update in the Ice Essence shop

## Example
![image](https://user-images.githubusercontent.com/75372052/206926298-227d5f0a-a7be-4ee0-8434-d620892e8fba.png)
