### PR TITLE
fix: incorrect Ice and Snow Minion max tier

### DIFF
--- a/src/constants/minions.js
+++ b/src/constants/minions.js
@@ -60,10 +60,12 @@ export const MINIONS = {
   ICE: {
     type: "mining",
     head: "/head/e500064321b12972f8e5750793ec1c823da4627535e9d12feaee78394b86dabe",
+    tiers: 12,
   },
   SNOW: {
     type: "mining",
     head: "/head/f6d180684c3521c9fc89478ba4405ae9ce497da8124fa0da5a0126431c4b78c3",
+    tiers: 12,
   },
   COAL: {
     type: "mining",


### PR DESCRIPTION
## Description

Fixed incorrect Ice and Snow Minion max tier, added in Winter Island Update

## Examples
> Before

![image](https://user-images.githubusercontent.com/75372052/206927436-b4916674-294c-4c86-8b1f-2bf037245176.png)
> After

![image](https://user-images.githubusercontent.com/75372052/206927414-fcbf4fc2-4ba2-4599-8253-189c79688dfe.png)
