### PR TITLE
fix: missingAccessories being hidden sometimes

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -1674,7 +1674,7 @@ export async function getStats(
     output.missingAccessories.missing =
       PARTY_HAT_CRAB === true
         ? output.missingAccessories.missing.filter((accessory) => accessory.name.startsWith("PARTY_HAT_CRAB") === false)
-        : output.missingAccessories.missing.entries();
+        : output.missingAccessories.missing;
   }
 
   output.base_stats = Object.assign({}, output.stats);


### PR DESCRIPTION
## Description

Fixes missing accessories being hidden sometimes
Fixes #1821

## Examples

https://sky.shiiyu.moe/stats/Cookie_Wookie_7/Raspberry#Accessories