### PR TITLE
fix: Wisp Pet Lore

### DIFF
--- a/src/constants/pet-stats.js
+++ b/src/constants/pet-stats.js
@@ -2996,7 +2996,7 @@ class Wisp extends Pet {
       { kills: 200000, defense: 600, true_defense: 60 },
     ];
 
-    const blazeKills = this.extra?.blazeKills ?? 0;
+    const blazeKills = this.extra?.blaze_kills ?? 0;
 
     let maxTier = false;
     let bonusIndex = BONUSES.findIndex((x) => x.kills > blazeKills);

--- a/src/constants/pet-stats.js
+++ b/src/constants/pet-stats.js
@@ -2945,15 +2945,17 @@ class Wisp extends Pet {
     const healthMultiplier = getValue(this.rarity, { uncommon: 1, rare: 2.5, epic: 4, legendary: 6 });
     const intelligenceMultiplier = getValue(this.rarity, { rare: 0.5, epic: 1.25, legendary: 2.5 });
 
-    return this.rarity >= RARE
-      ? {
-          true_defense: this.level * trueDefenseMultiplier,
-          health: this.level * healthMultiplier,
-          intelligence: this.level * intelligenceMultiplier,
-        }
-      : {
-          health: this.level * healthMultiplier,
-        };
+    if (this.rarity <= UNCOMMON) {
+      return {
+        health: this.level * healthMultiplier,
+      };
+    } else {
+      return {
+        true_defense: this.level * trueDefenseMultiplier,
+        health: this.level * healthMultiplier,
+        intelligence: this.level * intelligenceMultiplier,
+      };
+    }
   }
 
   get abilities() {

--- a/src/constants/pet-stats.js
+++ b/src/constants/pet-stats.js
@@ -3028,7 +3028,7 @@ class Wisp extends Pet {
   }
 
   get third() {
-    const mult = getValue(this.rarity, { uncommon: 0.3, rare: 0.4, epic: 0.45, legendary: 50 });
+    const mult = getValue(this.rarity, { uncommon: 0.3, rare: 0.4, epic: 0.45, legendary: 0.5 });
     const prc = round(this.level * mult, 1);
 
     return {

--- a/src/constants/pet-stats.js
+++ b/src/constants/pet-stats.js
@@ -2941,11 +2941,19 @@ class Bingo extends Pet {
 
 class Wisp extends Pet {
   get stats() {
-    return {
-      true_defense: this.level * 0.1 + 5,
-      health: this.level * 1,
-      intelligence: this.level * 0.5,
-    };
+    const trueDefenseMultiplier = getValue(this.rarity, { rare: 0.15, epic: 0.3, legendary: 0.35 });
+    const healthMultiplier = getValue(this.rarity, { uncommon: 1, rare: 2.5, epic: 4, legendary: 6 });
+    const intelligenceMultiplier = getValue(this.rarity, { rare: 0.5, epic: 1.25, legendary: 2.5 });
+
+    return this.rarity >= RARE
+      ? {
+          true_defense: this.level * trueDefenseMultiplier,
+          health: this.level * healthMultiplier,
+          intelligence: this.level * intelligenceMultiplier,
+        }
+      : {
+          health: this.level * healthMultiplier,
+        };
   }
 
   get abilities() {
@@ -3020,7 +3028,7 @@ class Wisp extends Pet {
   }
 
   get third() {
-    const mult = getValue(this.rarity, { uncommon: 0.3, rare: 0.4, epic: 0.45, legenedary: 50 });
+    const mult = getValue(this.rarity, { uncommon: 0.3, rare: 0.4, epic: 0.45, legendary: 50 });
     const prc = round(this.level * mult, 1);
 
     return {


### PR DESCRIPTION
## Description

Fixes lore of Wisp Pet (base stats & typo for rarity)
Also fixed Bulwark perk not working

## Examples

> Before

![image](https://user-images.githubusercontent.com/75372052/213118504-c15d34e9-5e26-41f7-bea4-cbd39aaefc7f.png)
![image](https://user-images.githubusercontent.com/75372052/213119154-e303d20d-220c-4aa9-becb-9f4dce7c4c57.png)
> After

![image](https://user-images.githubusercontent.com/75372052/213118586-0edc6672-fb31-449a-96af-779a335c8769.png)
![image](https://user-images.githubusercontent.com/75372052/213119520-bf4ba497-24db-4763-ab03-2ef2076ef14e.png)

