### PR TITLE
fix: pets having incorrect stats / lore

### DIFF
--- a/src/constants/pet-stats.js
+++ b/src/constants/pet-stats.js
@@ -2435,7 +2435,7 @@ class BlueWhale extends Pet {
 class Ammonite extends Pet {
   get stats() {
     return {
-      sea_creature_chance: this.level * 0.05,
+      sea_creature_chance: this.level * 0.05 + (this.profile?.mining?.core?.tier?.level || 0),
     };
   }
 
@@ -2449,7 +2449,7 @@ class Ammonite extends Pet {
     return {
       name: "§6Heart of the Sea",
       desc: [
-        `§7Grants §3+${round(this.level * mult, 2)}${
+        `§7Grants §3+${round(this.level * mult, 2)} ${
           SYMBOLS.sea_creature_chance
         } Sea Creature Chance §7to your pet for each §5Heart of the Mountain §7level.`,
       ],

--- a/src/constants/pet-stats.js
+++ b/src/constants/pet-stats.js
@@ -72,7 +72,7 @@ class Pet {
           list.push(`§7Crit Chance: ${formatStat(newStats[stat])}`);
           break;
         case "crit_damage":
-          list.push(`§7Crit Damage: ${formatStat(newStats[stat])}`);
+          list.push(`§7Crit Damage: ${formatStat(newStats[stat])}%`);
           break;
         case "intelligence":
           list.push(`§7Intelligence: ${formatStat(newStats[stat])}`);
@@ -81,7 +81,7 @@ class Pet {
           list.push(`§7Speed: ${formatStat(newStats[stat])}`);
           break;
         case "bonus_attack_speed":
-          list.push(`§7Bonus Attack Speed: ${formatStat(newStats[stat])}`);
+          list.push(`§7Bonus Attack Speed: ${formatStat(newStats[stat])}%`);
           break;
         case "sea_creature_chance":
           list.push(`§7Sea Creature Chance: ${formatStat(newStats[stat])}%`);
@@ -168,7 +168,7 @@ class Bee extends Pet {
     const mult = getValue(this.rarity, { rare: 0.5, epic: 1 });
     return {
       name: "§6Busy Buzz Buzz",
-      desc: [`§7Has §a${round(this.level * mult, 1)}% §7chance for flowers to drop an extra one`],
+      desc: [`§7Has §a${round(this.level * mult, 1)}% §7chance for flowers to drop an extra one§7.`],
     };
   }
 
@@ -176,7 +176,7 @@ class Bee extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.2 });
     return {
       name: "§6Weaponized Honey",
-      desc: [`§7Gain §a${round(5 + this.level * mult, 1)}% §7of received damage as §6${SYMBOLS.health} Absorption`],
+      desc: [`§7Gain §a${round(5 + this.level * mult, 1)}% §7of received damage as §6${SYMBOLS.health} Absorption§7.`],
     };
   }
 }
@@ -203,15 +203,15 @@ class Chicken extends Pet {
     const mult = getValue(this.rarity, { common: 0.3, uncommon: 0.4, epic: 0.5 });
     return {
       name: "§6Light Feet",
-      desc: [`§7Reduces fall damage by §a${round(this.level * mult, 1)}%`],
+      desc: [`§7Reduces fall damage by §a${round(this.level * mult, 1)}%§7.`],
     };
   }
 
   get second() {
-    const mult = getValue(this.rarity, { rare: 0.8, epic: 1 });
+    const mult = getValue(this.rarity, { rare: 0.75, epic: 1 });
     return {
       name: "§6Eggstra",
-      desc: [`§7Killing chickens has a §a${round(this.level * mult, 1)}% §7chance to drop an egg`],
+      desc: [`§7Killing chickens has a §a${round(this.level * mult, 1)}% §7chance to drop an egg§7.`],
     };
   }
 
@@ -219,7 +219,7 @@ class Chicken extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.3 });
     return {
       name: "§6Mighty Chickens",
-      desc: [`§7Chicken minions work §a${round(this.level * mult, 1)}% §7faster while on your island`],
+      desc: [`§7Chicken minions work §a${round(this.level * mult, 1)}% §7faster while on your island§7.`],
     };
   }
 }
@@ -248,7 +248,9 @@ class Elephant extends Pet {
     return {
       name: "§6Stomp",
       desc: [
-        `§7Gain §a${round(this.level * mult, 1)} ${SYMBOLS.defense} Defense §7for every §f100 ${SYMBOLS.speed} Speed`,
+        `§7Gain §a${round(this.level * mult, 1)} ${SYMBOLS.defense} Defense §7for every §f100 ${
+          SYMBOLS.speed
+        } Speed§7.`,
       ],
     };
   }
@@ -258,7 +260,9 @@ class Elephant extends Pet {
     return {
       name: "§6Walking Fortress",
       desc: [
-        `§7Gain §c${round(this.level * mult, 1)} ${SYMBOLS.health} Health §7for every §a10 ${SYMBOLS.defense} Defense`,
+        `§7Gain §c${round(this.level * mult, 1)} ${SYMBOLS.health} Health §7for every §a10 ${
+          SYMBOLS.defense
+        } Defense§7.`,
       ],
     };
   }
@@ -270,7 +274,7 @@ class Elephant extends Pet {
       desc: [
         `§7Grants §a+${round(this.level * mult, 1)} §6${
           SYMBOLS.farming_fortune
-        } Farming Fortune§7, which increases your chance for multiple drops`,
+        } Farming Fortune§7, which increases your chance for multiple drops§7.`,
       ],
     };
   }
@@ -317,7 +321,7 @@ class Pig extends Pet {
         `§7While holding an Enchanted Carrot on a Stick, increase the speed of your mount by §a${round(
           this.level * mult,
           1
-        )}%`,
+        )}%§7.`,
       ],
     };
   }
@@ -325,7 +329,7 @@ class Pig extends Pet {
   get fourth() {
     return {
       name: "§6Trample",
-      desc: [`§7While on your private island, break all crops your pig rides over`],
+      desc: [`§7While on your private island, break all crops your pig rides over§7.`],
     };
   }
 }
@@ -353,7 +357,7 @@ class Rabbit extends Pet {
     const mult = getValue(this.rarity, { common: 0.3, uncommon: 0.4, epic: 0.5 });
     return {
       name: "§6Happy Feet ",
-      desc: [`§7Jump Potions also give §a+${round(this.level * mult, 0)} §7speed`],
+      desc: [`§7Jump Potions also give §a+${round(this.level * mult, 0)} §7speed§7.`],
     };
   }
 
@@ -402,7 +406,9 @@ class Armadillo extends Pet {
   get second() {
     return {
       name: "§6Tunneler",
-      desc: [`§7The Armadillo breaks all stone or ore in it's path while you are riding it in the §3Crystal Hollows`],
+      desc: [
+        `§7The Armadillo breaks all stone or ore in its path while you are riding it in the §3Crystal Hollows §7using your held item.`,
+      ],
     };
   }
 
@@ -417,7 +423,7 @@ class Armadillo extends Pet {
     const mult = getValue(this.rarity, { rare: 0.2, epic: 0.3 });
     return {
       name: "§6Rolling Miner",
-      desc: [`§7Every §a${round(60 - this.level * mult, 1)} §7seconds, the next gemstone you mine gives 2x drops.`],
+      desc: [`§7Every §a${round(60 - this.level * mult, 1)} §7seconds, the next gemstone you mine gives §a2x §7drops.`],
     };
   }
 
@@ -464,7 +470,7 @@ class Bat extends Pet {
     const mult = getValue(this.rarity, { common: 0.1, uncommon: 0.15, epic: 0.2 });
     return {
       name: "§6Candy Lover",
-      desc: [`§7Increases the chance for mobs to drop Candy by §a${round(this.level * mult, 1)}%`],
+      desc: [`§7Increases the chance for mobs to drop Candy by §a${round(this.level * mult, 1)}%§7.`],
     };
   }
 
@@ -474,10 +480,10 @@ class Bat extends Pet {
     return {
       name: "§6Nightmare",
       desc: [
-        `§7During night, gain §a${round(this.level * multIntel, 1)} §9${SYMBOLS.intelligence} Intelligence, §a${round(
+        `§7During night, gain §a${round(this.level * multIntel, 1)} §9${SYMBOLS.intelligence} Intelligence§7, §a${round(
           this.level * multSpeed,
           1
-        )} §f${SYMBOLS.speed} Speed§7, and night vision`,
+        )} §f${SYMBOLS.speed} Speed §7and §aNight Vision§7.`,
       ],
     };
   }
@@ -486,7 +492,9 @@ class Bat extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.5 });
     return {
       name: "§6Wings of Steel",
-      desc: [`§7Deals §a+${round(this.level * mult, 1)}% §7damage to §6Spooky §7enemies during the §6Spooky Festival`],
+      desc: [
+        `§7Deals §a+${round(this.level * mult, 1)}% §7damage to §6Spooky §7enemies during the §6Spooky Festival§7.`,
+      ],
     };
   }
 
@@ -494,7 +502,7 @@ class Bat extends Pet {
     const mult = getValue(this.rarity, { mythic: 0.25 });
     return {
       name: "§6Sonar",
-      desc: [`§7+§a${round(this.level * mult, 1)}% §7chance to fish up spooky sea creatures`],
+      desc: [`§7+§a${round(this.level * mult, 1)}% §7chance to fish up spooky sea creatures§7.`],
     };
   }
 }
@@ -523,7 +531,7 @@ class Endermite extends Pet {
   }
 
   get first() {
-    const mult = getValue(this.rarity, { common: 0.5, uncommon: 0.8, epic: 1 });
+    const mult = getValue(this.rarity, { common: 0.5, uncommon: 0.75, epic: 1 });
     return {
       name: "§6More Stonks",
       desc: [
@@ -561,7 +569,7 @@ class Endermite extends Pet {
         `§7Increases the odds of rolling for bonus items in the §cDraconic Altar §7by §a${round(
           this.level * 0.1,
           1
-        )}%.`,
+        )}%§7.`,
       ],
     };
   }
@@ -589,7 +597,9 @@ class MithrilGolem extends Pet {
     const mult = getValue(this.rarity, { common: 0.5, uncommon: 0.75, epic: 1 });
     return {
       name: "§6Mithril Affinity",
-      desc: [`§7Gain +§a${round(this.level * mult, 1)} §6${SYMBOLS.mining_speed} Mining Speed §7when mining §eMithril`],
+      desc: [
+        `§7Gain +§a${round(this.level * mult, 1)} §6${SYMBOLS.mining_speed} Mining Speed §7when mining §eMithril§7.`,
+      ],
     };
   }
 
@@ -597,7 +607,7 @@ class MithrilGolem extends Pet {
     const mult = getValue(this.rarity, { rare: 0.1, epic: 0.2 });
     return {
       name: "§6The Smell Of Powder",
-      desc: [`§7Gain +§a${round(this.level * mult, 1)}% §7more §2Mithril Powder`],
+      desc: [`§7Gain +§a${round(this.level * mult, 1)}% §7more §2Mithril Powder §7while mining.`],
     };
   }
 
@@ -605,7 +615,7 @@ class MithrilGolem extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.2 });
     return {
       name: "§6Danger Averse",
-      desc: [`§7Increases your combat stats by +§a${round(this.level * mult, 1)}% §7on mining islands`],
+      desc: [`§7Increases your combat stats by §a+${round(this.level * mult, 1)}% §7on mining islands.`],
     };
   }
 }
@@ -639,7 +649,7 @@ class Rock extends Pet {
   get second() {
     return {
       name: "§6Sailing Stone",
-      desc: [`§7Sneak to move your rock to your location (15s cooldown)`],
+      desc: [`§7Sneak to move your rock to your location (15s cooldown)§7.`],
     };
   }
 
@@ -647,7 +657,7 @@ class Rock extends Pet {
     const mult = getValue(this.rarity, { rare: 0.2, epic: 0.25 });
     return {
       name: "§6Fortify",
-      desc: [`§7While sitting on your rock, gain §a+${round(this.level * mult, 1)}% §7defense`],
+      desc: [`§7While sitting on your rock, gain §a+${round(this.level * mult, 1)}% §7defense.`],
     };
   }
 
@@ -655,7 +665,7 @@ class Rock extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.3 });
     return {
       name: "§6Steady Ground",
-      desc: [`§7While sitting on your rock, gain §c+${round(this.level * mult, 1)}% §7damage`],
+      desc: [`§7While sitting on your rock, gain §c+${round(this.level * mult, 1)}% §7damage.`],
     };
   }
 }
@@ -686,7 +696,7 @@ class Scatha extends Pet {
     const mult = getValue(this.rarity, { rare: 1, epic: 1.25 });
     return {
       name: "§6Grounded",
-      desc: [`§7Gain §6+${round(this.level * mult - 0.01, 1)}${SYMBOLS.mining_fortune} Mining Fortune§7`],
+      desc: [`§7Gain §6+${round(this.level * mult - 0.01, 1)}${SYMBOLS.mining_fortune} Mining Fortune§7.`],
     };
   }
 
@@ -694,7 +704,7 @@ class Scatha extends Pet {
     const mult = getValue(this.rarity, { rare: 0.025, epic: 0.03 });
     return {
       name: "§6Burrowing",
-      desc: [`§7Grants a §a+${round(this.level * mult, 1)}% §7chance to find treasure while mining`],
+      desc: [`§7Grants a §a+${round(this.level * mult, 1)}% §7chance to find treasure while mining.`],
     };
   }
 
@@ -702,14 +712,14 @@ class Scatha extends Pet {
     const mult = getValue(this.rarity, { legendary: 1 });
     return {
       name: "§6Wormhole",
-      desc: [`§7Gives a §a${round(this.level * mult, 1)}% §7to mine 2 adjacent stone or hard stone`],
+      desc: [`§7Gives a §a${round(this.level * mult, 1)}% §7to mine 2 adjacent stone or hard stone.`],
     };
   }
   get fourth() {
     const mult = getValue(this.rarity, { legendary: 0.2 });
     return {
       name: "§6Gemstone Power",
-      desc: [`§7Gain §a+${round(this.level * mult, 1)}% §7more Gemstone Powder from all sources.`],
+      desc: [`§7Gain §a+${round(this.level * mult, 1)}% §7more §dGemstone Powder§7.`],
     };
   }
 }
@@ -737,7 +747,7 @@ class Silverfish extends Pet {
     const mult = getValue(this.rarity, { common: 0.05, uncommon: 0.1, epic: 0.15 });
     return {
       name: "§6True Defense Boost",
-      desc: [`§7Boosts your §f${SYMBOLS.true_defense} True Defense §7by §a${floor(this.level * mult, 1)}`],
+      desc: [`§7Boosts your §f${SYMBOLS.true_defense} True Defense §7by §a${floor(this.level * mult, 1)}§7.`],
     };
   }
 
@@ -745,14 +755,14 @@ class Silverfish extends Pet {
     const mult = getValue(this.rarity, { rare: 0.25, epic: 0.3 });
     return {
       name: "§6Mining Wisdom Boost",
-      desc: [`§7Grants by §3+${round(this.level * mult, 1)}${SYMBOLS.wisdom} Mining Wisdom§7.`],
+      desc: [`§7Grants §3+${round(this.level * mult, 1)}${SYMBOLS.wisdom} Mining Wisdom§7.`],
     };
   }
 
   get third() {
     return {
       name: "§6Dexterity",
-      desc: [`§7Gives permanent haste III`],
+      desc: [`§7Gives permanent haste III§7.`],
     };
   }
 }
@@ -760,11 +770,11 @@ class Silverfish extends Pet {
 class WitherSkeleton extends Pet {
   get stats() {
     return {
-      crit_chance: this.level * 0.05,
-      intelligence: this.level * 0.25,
       crit_damage: this.level * 0.25,
+      intelligence: this.level * 0.25,
       defense: this.level * 0.25,
       strength: this.level * 0.25,
+      crit_chance: this.level * 0.05,
     };
   }
 
@@ -783,7 +793,7 @@ class WitherSkeleton extends Pet {
     const mult = getValue(this.rarity, { epic: 0.3 });
     return {
       name: "§6Stronger Bones",
-      desc: [`§7Take §a${round(this.level * mult, 1)}% §7less damage from skeletons`],
+      desc: [`§7Take §a${round(this.level * mult, 1)}% §7less damage from skeletons.`],
     };
   }
 
@@ -791,7 +801,7 @@ class WitherSkeleton extends Pet {
     const mult = getValue(this.rarity, { epic: 0.25 });
     return {
       name: "§6Wither Blood",
-      desc: [`§7Deal §a${round(this.level * mult, 1)}% §7more damage to wither mobs`],
+      desc: [`§7Deal §a${round(this.level * mult, 1)}% §7more damage to wither mobs.`],
     };
   }
 
@@ -803,7 +813,7 @@ class WitherSkeleton extends Pet {
         `§7Upon hitting an enemy inflict the wither effect for §a${round(
           this.level * mult,
           1
-        )}% §7damage over 3 seconds`,
+        )}% §7damage over 3 seconds.`,
         `§8Does not stack`,
       ],
     };
@@ -832,7 +842,7 @@ class Bal extends Pet {
   get first() {
     return {
       name: "§6Protective Skin",
-      desc: [`§7§7Gives §cheat immunity.`],
+      desc: [`§7§7Gives §cheat immunity§7.`],
     };
   }
 
@@ -841,10 +851,10 @@ class Bal extends Pet {
     return {
       name: "§6Fire Whip",
       desc: [
-        `§7Every §a5s §7while in combat the Balrog will strike nearby enemies with his fire whip dealing §c${round(
+        `§7Every §a5s §7while in combat Bal will strike nearby enemies with his fire whip dealing §c${round(
           this.level * mult,
           1
-        )}% §7of your damage as §ftrue damage.`,
+        )}% §7of your damage as §ftrue damage§7.`,
       ],
     };
   }
@@ -853,7 +863,7 @@ class Bal extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.15 });
     return {
       name: "§6Made of Lava",
-      desc: [`§7Gain §a${round(this.level * mult, 1)}% §7on ALL stats when inside the §cMagma Fields.`],
+      desc: [`§7Gain §a${round(this.level * mult, 1)}% §7on ALL stats when inside the §cMagma Fields§7.`],
     };
   }
 }
@@ -881,7 +891,7 @@ class BlackCat extends Pet {
     const mult = getValue(this.rarity, { legendary: 1 });
     return {
       name: "§6Hunter",
-      desc: [`§7Increases your speed and speed cap by +§a${round(this.level * mult, 1)}`],
+      desc: [`§7Increases your speed and speed cap by +§a${round(this.level * mult, 1)}§7.`],
     };
   }
 
@@ -889,7 +899,7 @@ class BlackCat extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.15 });
     return {
       name: "§6Omen",
-      desc: [`§7Grants §d${floor(this.level * mult, 1)} ${SYMBOLS.pet_luck} Pet Luck`],
+      desc: [`§7Grants §d${floor(this.level * mult, 1)} ${SYMBOLS.pet_luck} Pet Luck§7.`],
     };
   }
 
@@ -897,7 +907,7 @@ class BlackCat extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.15 });
     return {
       name: "§6Supernatural",
-      desc: [`§7Grants §b${floor(this.level * mult, 1)} ${SYMBOLS.magic_find} Magic Find`],
+      desc: [`§7Grants §b${floor(this.level * mult, 1)} ${SYMBOLS.magic_find} Magic Find§7.`],
     };
   }
 }
@@ -925,7 +935,7 @@ class Blaze extends Pet {
     const mult = getValue(this.rarity, { epic: 0.1 });
     return {
       name: "§6Nether Embodiment",
-      desc: [`§7Increases all stats by §a${round(this.level * mult, 1)}% §7while on the Blazing Fortress`],
+      desc: [`§7Increases most stats by §a${round(this.level * mult, 1)}% §7while on the Crimson Isle.`],
     };
   }
 
@@ -933,14 +943,14 @@ class Blaze extends Pet {
     const mult = getValue(this.rarity, { epic: 0.4 });
     return {
       name: "§6Bling Armor",
-      desc: [`§7Upgrades §cBlaze Armor §7stats and ability by §a${round(this.level * mult, 1)}%`],
+      desc: [`§7Upgrades §cBlaze Armor §7stats and ability by §a${round(this.level * mult, 1)}%§7.`],
     };
   }
 
   get third() {
     return {
       name: "§6Fusion-Style Potato",
-      desc: [`§7Doubles effects of hot potato books`],
+      desc: [`§7Double effects of hot potato books.`],
     };
   }
 }
@@ -966,7 +976,7 @@ class EnderDragon extends Pet {
     const mult = getValue(this.rarity, { epic: 2 });
     return {
       name: "§6End Strike",
-      desc: [`§7Deal §a${round(this.level * mult, 1)}% §7more damage to end mobs`],
+      desc: [`§7Deal §a${round(this.level * mult, 1)}% §7more damage to end mobs§7.`],
     };
   }
 
@@ -976,7 +986,7 @@ class EnderDragon extends Pet {
       desc: [
         `§7Buffs the Aspect of the Dragons sword by §a${round(this.level * 0.5, 1)} §c${
           SYMBOLS.strength
-        } Damage and §a${round(this.level * 0.3, 1)} §c${SYMBOLS.strength} Strength`,
+        } Damage and §a${round(this.level * 0.3, 1)} §c${SYMBOLS.strength} Strength§7.`,
       ],
     };
   }
@@ -985,7 +995,7 @@ class EnderDragon extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.1 });
     return {
       name: "§6Superior",
-      desc: [`§7Increases most stats by §a${round(this.level * mult, 1)}%`],
+      desc: [`§7Increases most stats by §a${round(this.level * mult, 1)}%§7.`],
     };
   }
 }
@@ -994,13 +1004,11 @@ class GoldenDragon extends Pet {
   get stats() {
     const stats = {};
     if (this.level >= 100) {
-      stats.strength =
-        round(25 + Math.max(0, this.level - 100) * 0.25, 0) +
-        10 * Math.max(Math.floor(Math.log10(Math.abs(this.profile?.collections?.GOLD_INGOT?.totalAmount || 0))), 0);
+      const goldCollectionDigits = Math.max(this.profile?.collections?.GOLD_INGOT?.totalAmount.toString().length, 0);
+
+      stats.strength = round(25 + Math.max(0, this.level - 100) * 0.25, 0) + 10 * goldCollectionDigits;
       stats.bonus_attack_speed = round(25 + Math.max(0, this.level - 100) * 0.25, 0);
-      stats.magic_find =
-        round(25 + Math.max(0, this.level - 100) * 0.25, 0) +
-        2 * Math.max(Math.floor(Math.log10(Math.abs(this.profile?.collections?.GOLD_INGOT?.totalAmount || 0))), 0);
+      stats.magic_find = round(5 + Math.max(0, (this.level - 100) / 10) * 0.5, 0) + 2 * goldCollectionDigits;
     }
     return stats;
   }
@@ -1091,19 +1099,16 @@ class Enderman extends Pet {
     const mult = getValue(this.rarity, { common: 0.1, uncommon: 0.2, epic: 0.3 });
     return {
       name: "§6Enderian",
-      desc: [`§7Take §a${round(this.level * mult, 1)}% §7less damage from end monsters`],
+      desc: [`§7Take §a${round(this.level * mult, 1)}% §7less damage from end monsters§7.`],
     };
   }
 
   get second() {
-    const mult = getValue(this.rarity, { rare: 0.5, epic: 0.5 });
+    const mult = getValue(this.rarity, { rare: 0.4, epic: 0.5 });
     return {
       name: "§6Teleport Savvy",
       desc: [
-        `§7Buffs the Aspect of the End ability granting §a${round(
-          this.level * mult,
-          1
-        )} §7weapon damage for 5s on use.`,
+        `§7Buffs the Transmission abilities granting §a${round(this.level * mult, 1)} §7weapon damage for 5s on use.`,
       ],
     };
   }
@@ -1112,7 +1117,7 @@ class Enderman extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.25 });
     return {
       name: "§6Zealot Madness",
-      desc: [`§7Increases your odds to find a special Zealot by §a${round(this.level * mult, 1)}%.`],
+      desc: [`§7Increases your odds to find a special Zealot by §a${round(this.level * mult, 1)}%§7.`],
     };
   }
 
@@ -1149,7 +1154,7 @@ class Ghoul extends Pet {
     const mult = getValue(this.rarity, { epic: 0.25 });
     return {
       name: "§6Amplified Healing",
-      desc: [`§7Increase all healing by §a${round(this.level * mult, 1)}%`],
+      desc: [`§7Grants §4${round(this.level * mult, 1)} ${SYMBOLS.vitality}§7, which increases your incoming healing.`],
     };
   }
 
@@ -1157,7 +1162,7 @@ class Ghoul extends Pet {
     const mult = getValue(this.rarity, { epic: 0.5 });
     return {
       name: "§6Zombie Arm",
-      desc: [`§7Increase the health and range of the Zombie sword by §a${round(this.level * mult, 1)}%`],
+      desc: [`§7Increase the health and range of the Zombie sword by §a${round(this.level * mult, 1)}%§7.`],
     };
   }
 
@@ -1165,7 +1170,9 @@ class Ghoul extends Pet {
     const mult = getValue(this.rarity, { legendary: 1 });
     return {
       name: "§6Reaper Soul",
-      desc: [`§7Increases the health and lifespan of the Reaper Scythe zombies by §a${round(this.level * mult, 1)}%`],
+      desc: [
+        `§7Increases the health and lifespan of the Reaper Scythe zombies by §a${round(this.level * mult, 1)}%§7.`,
+      ],
     };
   }
 }
@@ -1193,7 +1200,7 @@ class Golem extends Pet {
     const mult = getValue(this.rarity, { epic: 0.3 });
     return {
       name: "§6Last Stand",
-      desc: [`§7While less than 25% HP, deal §a${round(this.level * mult, 1)}% §7more damage`],
+      desc: [`§7While less than 25% HP, deal §a${round(this.level * mult, 1)}% §7more damage§7.`],
     };
   }
 
@@ -1202,7 +1209,7 @@ class Golem extends Pet {
     return {
       name: "§6Ricochet",
       desc: [
-        `§7Your iron plating causes §a${round(this.level * mult, 1)}% §7of attacks to ricochet and hit the attacker`,
+        `§7Your iron plating causes §a${round(this.level * mult, 1)}% §7of attacks to ricochet and hit the attacker§7.`,
       ],
     };
   }
@@ -1306,13 +1313,13 @@ class Guardian extends Pet {
   }
 
   get first() {
-    const mult = getValue(this.rarity, { common: 0.02, uncommon: 0.04, rare: 0.1, epic: 0.15, legendary: 0.2 });
+    const mult = getValue(this.rarity, { common: 0.02, uncommon: 0.06, rare: 0.1, epic: 0.15, legendary: 0.2 });
     return {
       name: "§6Lazerbeam",
       desc: [
         `§7Zap your enemies for §b${round(this.level * mult, 1)}x §7your §b${
           SYMBOLS.intelligence
-        } Intelligence §7every §a3s`,
+        } Intelligence §7every §a3s§7.`,
       ],
     };
   }
@@ -1329,7 +1336,7 @@ class Guardian extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.3 });
     return {
       name: "§6Mana Pool",
-      desc: [`§7Regenerate §b${round(this.level * mult, 1)}% §7extra mana, doubled when near or in water`],
+      desc: [`§7Regenerate §b${round(this.level * mult, 1)}% §7extra mana, doubled when near or in water§7.`],
     };
   }
 }
@@ -1364,7 +1371,7 @@ class Horse extends Pet {
     const mult = getValue(this.rarity, { rare: 1.1, epic: 1.2 });
     return {
       name: "§6Run",
-      desc: [`§7Increase the speed of your mount by §a${round(this.level * mult, 1)}%`],
+      desc: [`§7Increase the speed of your mount by §a${round(this.level * mult, 1)}%§7.`],
     };
   }
 
@@ -1372,7 +1379,7 @@ class Horse extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.25 });
     return {
       name: "§6Ride Into Battle",
-      desc: [`§7When riding your horse, gain +§a${round(this.level * mult, 1)}% §7bow damage`],
+      desc: [`§7When riding your horse, gain +§a${round(this.level * mult, 1)}% §7bow damage.`],
     };
   }
 }
@@ -1401,7 +1408,7 @@ class Hound extends Pet {
     const mult = getValue(this.rarity, { epic: 0.05 });
     return {
       name: "§6Scavenger",
-      desc: [`§7Gain +§a${round(this.level * mult, 1)} §7coins per monster kill`],
+      desc: [`§7Gain +§a${round(this.level * mult, 1)} §7coins per monster kill§7.`],
     };
   }
 
@@ -1409,7 +1416,7 @@ class Hound extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.1 });
     return {
       name: "§6Finder",
-      desc: [`§7Increases the chance for monsters to drop their armor by §a${round(this.level * mult, 1)}%`],
+      desc: [`§7Increases the chance for monsters to drop their armor by §a${round(this.level * mult, 1)}%§7.`],
     };
   }
 
@@ -1417,7 +1424,7 @@ class Hound extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.1 });
     return {
       name: "§6Fury Claws",
-      desc: [`§7Grants ${round(this.level * mult, 1)}	§e${SYMBOLS.bonus_attack_speed} Bonus Attack Speed`],
+      desc: [`§7Grants ${round(this.level * mult, 1)}	§e${SYMBOLS.bonus_attack_speed} Bonus Attack Speed§7.`],
     };
   }
 }
@@ -1454,7 +1461,7 @@ class MagmaCube extends Pet {
     const mult = getValue(this.rarity, { rare: 0.2, epic: 0.25 });
     return {
       name: "§6Salt Blade",
-      desc: [`§7Deal §a${round(this.level * mult, 1)}% §7more damage to slimes`],
+      desc: [`§7Deal §a${round(this.level * mult, 1)}% §7more damage to slimes.`],
     };
   }
 
@@ -1462,7 +1469,7 @@ class MagmaCube extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.5 });
     return {
       name: "§6Hot Ember",
-      desc: [`§7Buffs the stats of Ember Armor by §a${round(this.level * mult, 1)}%`],
+      desc: [`§7Buffs the stats of §5Rekindled Ember Armor §7by §a${round(this.level * mult, 1)}%§7.`],
     };
   }
 }
@@ -1493,15 +1500,15 @@ class Phoenix extends Pet {
       desc: [
         `§7Before death, become §eimmune §7and gain §c${startStrength + round(this.level * multStrength, 1)} ${
           SYMBOLS.strength
-        } Strength §7for ${2 + round(this.level * multTime, 1)} §7seconds`,
-        `§71m cooldown`,
+        } Strength §7for §a${2 + round(this.level * multTime, 1)} §7seconds§7.`,
+        `§81m cooldown`,
       ],
     };
   }
 
   get second() {
     const multDamage = getValue(this.rarity, { epic: 0.12, legendary: 0.14 });
-    const multTime = getValue(this.rarity, { epic: 0.04 });
+    const multTime = getValue(this.rarity, { epic: 0.04, legendary: 0.03 });
     return {
       name: "§6Fourth Flare",
       desc: [
@@ -1515,7 +1522,7 @@ class Phoenix extends Pet {
   get third() {
     return {
       name: "§6Magic Bird",
-      desc: [`§7You may always fly on your private island`],
+      desc: [`§7You may always fly on your private island§7.`],
     };
   }
 
@@ -1548,7 +1555,7 @@ class Pigman extends Pet {
     const mult = getValue(this.rarity, { epic: 0.3 });
     return {
       name: "§6Bacon Farmer",
-      desc: [`§7Pig minions work §a${round(this.level * mult, 1)}% §7faster while on your island`],
+      desc: [`§7Pig minions work §a${round(this.level * mult, 1)}% §7faster while on your island§7.`],
     };
   }
 
@@ -1560,7 +1567,7 @@ class Pigman extends Pet {
       desc: [
         `§7Buffs the Pigman sword by §a${round(this.level * multDamage, 1)} §c${
           SYMBOLS.strength
-        } Damage and §7§a${round(this.level * multStrength, 1)} §c${SYMBOLS.strength} Strength`,
+        } Damage and §7§a${round(this.level * multStrength, 1)} §c${SYMBOLS.strength} Strength§7.`,
       ],
     };
   }
@@ -1569,7 +1576,7 @@ class Pigman extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.25 });
     return {
       name: "§6Giant Slayer",
-      desc: [`§7Deal §a${round(this.level * mult, 1)}% §7extra damage to monsters level 100 and up`],
+      desc: [`§7Deal §a${round(this.level * mult, 1)}% §7extra damage to monsters level 100 and up§7.`],
     };
   }
 }
@@ -1591,6 +1598,9 @@ class Rat extends Pet {
     if (this.rarity >= LEGENDARY) {
       list.push(this.third);
     }
+    if (this.rarity >= MYTHIC) {
+      list.push(this.fourth);
+    }
     return list;
   }
 
@@ -1610,7 +1620,7 @@ class Rat extends Pet {
 
   get third() {
     const multMf = getValue(this.rarity, { legendary: 0.05 });
-    const multTime = getValue(this.rarity, { legendary: 0.2 });
+    const multTime = getValue(this.rarity, { legendary: 0.4 });
     return {
       name: "§6Rat's Blessing",
       desc: [
@@ -1621,6 +1631,13 @@ class Rat extends Pet {
           0
         )} §7seconds after finding a yummy piece of Cheese! If the player gets a drop during this buff, you have a §a20% §7to get it too.`,
       ],
+    };
+  }
+
+  get fourth() {
+    return {
+      name: "§6Extreme Speed",
+      desc: [`§7The Rat is TWO times faster.`],
     };
   }
 }
@@ -1649,7 +1666,7 @@ class SkeletonHorse extends Pet {
     const mult = getValue(this.rarity, { legendary: 1.5 });
     return {
       name: "§6Run",
-      desc: [`§7Increase the speed of your mount by §a${round(this.level * mult, 1)}%`],
+      desc: [`§7Increase the speed of your mount by §a${round(this.level * mult, 1)}%§7.`],
     };
   }
 
@@ -1657,7 +1674,7 @@ class SkeletonHorse extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.4 });
     return {
       name: "§6Ride Into Battle",
-      desc: [`§7When riding your horse, gain +§a${round(this.level * mult, 1)}% §7bow damage`],
+      desc: [`§7When riding your horse, gain §a+${round(this.level * mult, 1)}% §7bow damage§7.`],
     };
   }
 }
@@ -1685,7 +1702,7 @@ class Skeleton extends Pet {
     const mult = getValue(this.rarity, { common: 0.1, uncommon: 0.15, epic: 0.2 });
     return {
       name: "§6Bone Arrows",
-      desc: [`§7Increase arrow damage by §a${round(this.level * mult, 1)}% §7which is tripled while in dungeons`],
+      desc: [`§7Increase arrow damage by §a${round(this.level * mult, 1)}% §7which is tripled while in dungeons§7.`],
     };
   }
 
@@ -1694,10 +1711,10 @@ class Skeleton extends Pet {
     return {
       name: "§6Combo",
       desc: [
-        `§7Gain a combo stack for every bow hit granting +§a3 §c${SYMBOLS.strength} Strength§7. Max §a${round(
+        `§7Gain a combo stack for every bow hit granting §c+3 ${SYMBOLS.strength} Strength§7. Max §a${round(
           this.level * mult,
           1
-        )} §7stacks, stacks disappear after 8 seconds`,
+        )} §7stacks, stacks disappear after 8 seconds§7.`,
       ],
     };
   }
@@ -1706,7 +1723,7 @@ class Skeleton extends Pet {
     return {
       name: "§6Skeletal Defense",
       desc: [
-        `§7Your skeleton shoots an arrow dealing §a30x §7your §9${SYMBOLS.crit_damage} Crit Damage §7when a mob gets close to you (5s cooldown)`,
+        `§7Your skeleton shoots an arrow dealing §a30x §7your §9${SYMBOLS.crit_damage} Crit Damage §7when a mob gets close to you (5s cooldown)§7.`,
       ],
     };
   }
@@ -1730,7 +1747,7 @@ class Snowman extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.04 });
     return {
       name: "§6Blizzard",
-      desc: [`§7Slow all enemies within §a${4 + round(this.level * mult, 1)} §7blocks`],
+      desc: [`§7Slow all enemies within §a${4 + round(this.level * mult, 1)} §7blocks.`],
     };
   }
 
@@ -1742,7 +1759,7 @@ class Snowman extends Pet {
         `§7Your freezing aura slows enemy attacks causing you to take §a${floor(
           this.level * mult,
           1
-        )}% §7reduced damage`,
+        )}% §7reduced damage.`,
       ],
     };
   }
@@ -1751,7 +1768,7 @@ class Snowman extends Pet {
     return {
       name: "§6Snow Cannon",
       desc: [
-        `§7Your snowman fires a snowball dealing §a5x §7your §c${SYMBOLS.strength} Strength §7when a mob gets close to you (1s cooldown)`,
+        `§7Your snowman fires a snowball dealing §a5x §7your §c${SYMBOLS.strength} Strength §7when a mob gets close to you (1s cooldown).`,
       ],
     };
   }
@@ -1777,21 +1794,21 @@ class Spider extends Pet {
   }
 
   get first() {
-    const mult = getValue(this.rarity, { common: 0.1 });
+    const mult = getValue(this.rarity, { common: 0.05, uncommon: 0.075, epic: 0.1 });
     return {
       name: "§6One With The Spider",
       desc: [
-        `§7Gain §a${round(this.level * mult, 1)} §c${SYMBOLS.strength} Strength §7for every nearby spider`,
+        `§7Gain §a${round(this.level * mult, 1)} §c${SYMBOLS.strength} Strength §7for every nearby spider.`,
         `§8Max 10 spiders`,
       ],
     };
   }
 
   get second() {
-    const mult = getValue(this.rarity, { rare: 0.4 });
+    const mult = getValue(this.rarity, { rare: 0.3, epic: 0.4 });
     return {
       name: "§6Web-weaver",
-      desc: [`§7Upon hitting a monster it becomes slowed by §a${round(this.level * mult, 1)}%`],
+      desc: [`§7Upon hitting a monster it becomes slowed by §a${round(this.level * mult, 1)}%§7.`],
     };
   }
 
@@ -1799,7 +1816,7 @@ class Spider extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.3 });
     return {
       name: "§6Spider Whisperer",
-      desc: [`§7Spider and tarantula minions work §a${round(this.level * mult, 1)}% §7faster while on your island`],
+      desc: [`§7Spider and tarantula minions work §a${round(this.level * mult, 1)}% §7faster while on your island.`],
     };
   }
 }
@@ -1823,7 +1840,7 @@ class Spirit extends Pet {
   get first() {
     return {
       name: "§6Spirit Assistance",
-      desc: [`§7Spawns and assists you when you are ghost in dungeons.`],
+      desc: [`§7Spawns and assists you when you are ghost in Dungeons.`],
     };
   }
 
@@ -1866,7 +1883,7 @@ class Tarantula extends Pet {
     const mult = getValue(this.rarity, { epic: 0.3 });
     return {
       name: "§6Webbed Cells",
-      desc: [`§7Anti-healing is §a${round(this.level * mult, 1)}% §7less effective against you`],
+      desc: [`§7Anti-healing is §a${round(this.level * mult, 1)}% §7less effective against you.`],
     };
   }
 
@@ -1874,12 +1891,14 @@ class Tarantula extends Pet {
     const mult = getValue(this.rarity, { epic: 0.5 });
     return {
       name: "§6Eight Legs",
-      desc: [`§7Decreases the mana cost of Spider, Tarantula and Thorn's boots by §a${round(this.level * mult, 1)}%`],
+      desc: [
+        `§7Decreases the mana cost of Spider, Tarantula and Thorn's boots by §a${round(this.level * mult, 1)}%§7.`,
+      ],
     };
   }
 
   get third() {
-    const mult = getValue(this.rarity, { legendary: 0.4 });
+    const mult = getValue(this.rarity, { legendary: 0.5 });
     return {
       name: "§6Arachnid Slayer",
       desc: [`§7Grants §a${round(this.level * mult, 1)}% §3${SYMBOLS.wisdom} Combat Wisdom §7against §aSpiders§7.`],
@@ -1912,7 +1931,7 @@ class Tiger extends Pet {
     const mult = getValue(this.rarity, { common: 0.1, uncommon: 0.2, epic: 0.3 });
     return {
       name: "§6Merciless Swipe",
-      desc: [`§7Gain 	§c+${round(this.level * mult, 1)}% ${SYMBOLS.ferocity} Ferocity.`],
+      desc: [`§7Gain 	§c+${round(this.level * mult, 1)}% ${SYMBOLS.ferocity} Ferocity§7.`],
     };
   }
 
@@ -1920,7 +1939,7 @@ class Tiger extends Pet {
     const mult = getValue(this.rarity, { rare: 0.3, epic: 0.55 });
     return {
       name: "§6Hemorrhage",
-      desc: [`§7Melee attacks reduce healing by §6${round(this.level * mult, 1)}% §7for §a10s`],
+      desc: [`§7Melee attacks reduce healing by §6${round(this.level * mult, 1)}% §7for §a10s§7.`],
     };
   }
 
@@ -1929,7 +1948,7 @@ class Tiger extends Pet {
     return {
       name: "§6Apex Predator",
       desc: [
-        `§7Deal §c+${round(this.level * mult, 1)}% §7damage against targets with no other mobs within §a15 §7blocks`,
+        `§7Deal §c+${round(this.level * mult, 1)}% §7damage against targets with no other mobs within §a15 §7blocks.`,
       ],
     };
   }
@@ -1956,7 +1975,7 @@ class Turtle extends Pet {
     const mult = getValue(this.rarity, { epic: 0.27 });
     return {
       name: "§6Turtle Tactics",
-      desc: [`§7Gain §a+${round(3 + this.level * mult, 1)}% ${SYMBOLS.defense} Defense`],
+      desc: [`§7Gain §a+${round(3 + this.level * mult, 1)}% ${SYMBOLS.defense} Defense§7.`],
     };
   }
 
@@ -1975,7 +1994,7 @@ class Turtle extends Pet {
   get third() {
     return {
       name: "§6Unflippable",
-      desc: [`§7Gain §aimmunity §7to knockback`],
+      desc: [`§7Gain §aimmunity §7to knockback.`],
     };
   }
 
@@ -2013,7 +2032,7 @@ class Wolf extends Pet {
     const mult = getValue(this.rarity, { common: 0.1, uncommon: 0.2, epic: 0.3 });
     return {
       name: "§6Alpha Dog",
-      desc: [`§7Take §a${round(this.level * mult, 1)}% §7less damage from wolves`],
+      desc: [`§7Take §a${round(this.level * mult, 1)}% §7less damage from wolves.`],
     };
   }
 
@@ -2024,7 +2043,7 @@ class Wolf extends Pet {
       desc: [
         `§7Gain §a${round(this.level * mult, 1)} §9 ${
           SYMBOLS.crit_damage
-        } Crit Damage §7for every nearby wolf monsters`,
+        } Crit Damage §7for every nearby wolf monsters.`,
         `§8Max 10 wolves`,
       ],
     };
@@ -2053,6 +2072,8 @@ class GrandmaWolf extends Pet {
   }
 
   get first() {
+    const coins = getValue(this.rarity, { common: 2, uncommon: 4, rare: 6, epic: 8, legendary: 10 });
+
     return {
       name: "§6Kill Combo",
       desc: [
@@ -2061,7 +2082,7 @@ class GrandmaWolf extends Pet {
         `§a5 Combo §8(lasts §a${Math.floor((8 + this.level * 0.02) * 10) / 10}s§8)`,
         `§8+§b3% §b${SYMBOLS.magic_find} Magic Find`,
         `§a10 Combo §8(lasts §a${Math.floor((6 + this.level * 0.02) * 10) / 10}s§8)`,
-        `§8+§610 §7coins per kill`,
+        `§8+§6${coins} Coins §7per kill`,
         `§a15 Combo §8(lasts §a${Math.floor((4 + this.level * 0.02) * 10) / 10}s§8)`,
         `§8+§b3% §b${SYMBOLS.magic_find} Magic Find`,
         `§a20 Combo §8(lasts §a${Math.floor((3 + this.level * 0.02) * 10) / 10}s§8)`,
@@ -2069,7 +2090,7 @@ class GrandmaWolf extends Pet {
         `§a25 Combo §8(lasts §a${Math.floor((3 + this.level * 0.01) * 10) / 10}s§8)`,
         `§8+§b3% §b${SYMBOLS.magic_find} Magic Find`,
         `§a30 Combo §8(lasts §a${Math.floor((2 + this.level * 0.01) * 10) / 10}s§8)`,
-        `§8+§610 §7coins per kill`,
+        `§8+§6${coins} Coins §7per kill`,
       ],
     };
   }
@@ -2098,15 +2119,15 @@ class Zombie extends Pet {
     const mult = getValue(this.rarity, { common: 0.15, epic: 0.25 });
     return {
       name: "§6Chomp",
-      desc: [`§7Gain +§a${round(this.level * mult, 1)} §7hp per zombie kill`],
+      desc: [`§7Gain +§a${round(this.level * mult, 1)} §7HP per Zombie kill.`],
     };
   }
 
   get second() {
-    const mult = getValue(this.rarity, { rare: 0.2 });
+    const mult = getValue(this.rarity, { rare: 0.2, epic: 0.25 });
     return {
       name: "§6Rotten Blade",
-      desc: [`§7Deal §a${round(this.level * mult, 1)}% §7more damage to zombies`],
+      desc: [`§7Deal §a${round(this.level * mult, 1)}% §7more damage to zombies.`],
     };
   }
 
@@ -2114,7 +2135,7 @@ class Zombie extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.25 });
     return {
       name: "§6Living Dead",
-      desc: [`§7Increases the defense of all undead armor sets by §a${round(this.level * mult, 1)}%`],
+      desc: [`§7Increases the defense of all undead armor sets by §a${round(this.level * mult, 1)}%§7.`],
     };
   }
 }
@@ -2142,7 +2163,7 @@ class Giraffe extends Pet {
     const mult = getValue(this.rarity, { common: 0.05, uncommon: 0.1, rare: 0.15, epic: 0.2, legendary: 0.25 });
     return {
       name: "§6Good Heart",
-      desc: [`§7Regen §c${round(this.level * mult, 1)} ${SYMBOLS.health} §7per second`],
+      desc: [`§7Regen §c${round(this.level * mult, 1)} ${SYMBOLS.health} §7per second§7.`],
     };
   }
 
@@ -2155,7 +2176,7 @@ class Giraffe extends Pet {
         `§7Grants §c+${round(this.level * multStrength, 1)} ${SYMBOLS.strength} Strength §7and §9+${round(
           this.level * multCd + 20,
           1
-        )} ${SYMBOLS.crit_damage} Crit Damage §7when mid air or jumping`,
+        )} ${SYMBOLS.crit_damage} Crit Damage §7when mid air or jumping§7.`,
       ],
     };
   }
@@ -2164,7 +2185,7 @@ class Giraffe extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.25 });
     return {
       name: "§6Long Neck",
-      desc: [`§7See enemies from afar and gain §a${round(this.level * mult, 1)}% §7dodge chance`],
+      desc: [`§7See enemies from afar and gain §a${round(this.level * mult, 1)}% §7dodge chance§7.`],
     };
   }
 }
@@ -2196,7 +2217,7 @@ class Lion extends Pet {
       desc: [
         `§7Adds §c+${round(this.level * mult, 1)} ${SYMBOLS.strength} Damage §7and §c+${round(this.level * mult, 1)} ${
           SYMBOLS.strength
-        } Strength §7to your weapons`,
+        } Strength §7to your weapons§7.`,
       ],
     };
   }
@@ -2248,7 +2269,7 @@ class Monkey extends Pet {
       desc: [
         `§7Grants §a+${round(this.level * mult, 1)} §6${
           SYMBOLS.foraging_fortune
-        } Foraging Fortune§7, which increases your chance at double logs`,
+        } Foraging Fortune§7, which increases your chance at double logs.`,
       ],
     };
   }
@@ -2257,7 +2278,7 @@ class Monkey extends Pet {
     const mult = getValue(this.rarity, { rare: 0.75, epic: 1 });
     return {
       name: "§6Vine Swing",
-      desc: [`§7Gain +§a${round(this.level * mult, 1)}	§f${SYMBOLS.speed} Speed §7while in The Park`],
+      desc: [`§7Gain +§a${round(this.level * mult, 1)}	§f${SYMBOLS.speed} Speed §7while in The Park.`],
     };
   }
 
@@ -2265,7 +2286,7 @@ class Monkey extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.5 });
     return {
       name: "§6Evolved Axes",
-      desc: [`§7Reduce the cooldown of Jungle Axe and Treecapitator by §a${round(this.level * mult, 1)}%`],
+      desc: [`§7Reduce the cooldown of Jungle Axe and Treecapitator by §a${round(this.level * mult, 1)}%§7.`],
     };
   }
 }
@@ -2301,7 +2322,7 @@ class Ocelot extends Pet {
     const mult = getValue(this.rarity, { rare: 0.3 });
     return {
       name: "§6Tree Hugger",
-      desc: [`§7Foraging minions work §a${round(this.level * mult, 1)}% §7faster while on your island`],
+      desc: [`§7Foraging minions work §a${round(this.level * mult, 1)}% §7faster while on your island§7.`],
     };
   }
 
@@ -2309,7 +2330,7 @@ class Ocelot extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.3 });
     return {
       name: "§6Tree Essence",
-      desc: [`§7Gain a §a${round(this.level * mult, 1)}% §7chance to get exp from breaking a log`],
+      desc: [`§7Gain a §a${round(this.level * mult, 1)}% §7chance to get exp from breaking a log§7.`],
     };
   }
 }
@@ -2346,7 +2367,7 @@ class BabyYeti extends Pet {
     const mult = getValue(this.rarity, { epic: 0.5, legendary: 0.75 });
     return {
       name: "§6Ice Shields",
-      desc: [`§7Gain §a${floor(this.level * mult, 1)}% §7of your strength as §a${SYMBOLS.defense} Defense`],
+      desc: [`§7Gain §a${floor(this.level * mult, 1)}% §7of your strength as §a${SYMBOLS.defense} Defense§7.`],
     };
   }
 
@@ -2357,7 +2378,7 @@ class BabyYeti extends Pet {
       desc: [
         `§7Buff the Yeti sword by §a${round(this.level * mult, 1)} §c${SYMBOLS.strength} Damage §7and §9${
           SYMBOLS.intelligence
-        } Intelligence`,
+        } Intelligence§7.`,
       ],
     };
   }
@@ -2385,7 +2406,7 @@ class BlueWhale extends Pet {
     const mult = getValue(this.rarity, { common: 0.5, uncommon: 1, rare: 1.5, epic: 2, legendary: 2.5 });
     return {
       name: "§6Ingest",
-      desc: [`§7All potions heal §c+${round(this.level * mult, 1)} ${SYMBOLS.health}`],
+      desc: [`§7All potions heal §c+${round(this.level * mult, 1)} ${SYMBOLS.health}§7.`],
     };
   }
 
@@ -2397,7 +2418,7 @@ class BlueWhale extends Pet {
       desc: [
         `§7Gain §a${round(this.level * mult, 1)} ${SYMBOLS.defense} Defense §7per §c${health} Max ${
           SYMBOLS.health
-        } Health`,
+        } Health§7.`,
       ],
     };
   }
@@ -2406,7 +2427,7 @@ class BlueWhale extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.2 });
     return {
       name: "§6Archimedes",
-      desc: [`§7Gain §c+${round(this.level * mult, 1)}% Max ${SYMBOLS.health} Health`],
+      desc: [`§7Gain §c+${round(this.level * mult, 1)}% Max ${SYMBOLS.health} Health§7.`],
     };
   }
 }
@@ -2495,17 +2516,17 @@ class Dolphin extends Pet {
   }
 
   get second() {
-    const mult = this.rarity >= EPIC ? 0.1 : 0.07;
+    const mult = getValue(this.rarity, { rare: 0.07, epic: 0.1 });
     return {
       name: "§6Echolocation",
-      desc: [`§7Grants §3+${round(this.level * mult, 2)}${SYMBOLS.sea_creature_chance} Sea Creature Chance§7.`],
+      desc: [`§7Grants §3+${round(this.level * mult, 2)} ${SYMBOLS.sea_creature_chance} Sea Creature Chance§7.`],
     };
   }
 
   get third() {
     return {
       name: "§6Splash Surprise",
-      desc: [`§7Stun sea creatures for §a5s §7after fishing them up`],
+      desc: [`§7Stun sea creatures for §a5s §7after fishing them up.`],
     };
   }
 }
@@ -2530,7 +2551,7 @@ class FlyingFish extends Pet {
   }
 
   get first() {
-    const mult = getValue(this.rarity, { rare: 0.6, epic: 0.8 });
+    const mult = getValue(this.rarity, { rare: 0.6, epic: 0.75, legendary: 0.8 });
     return {
       name: "§6Quick Reel",
       desc: [`§7Grants §b+${round(this.level * mult, 2)}${SYMBOLS.fishing_speed} Fishing Speed§7.`],
@@ -2545,7 +2566,7 @@ class FlyingFish extends Pet {
       desc: [
         `§7Gives §a${round(this.level * mult, 1)} §c${SYMBOLS.strength} Strength §7and §a${
           SYMBOLS.defense
-        } Defense §7when near ${type}`,
+        } Defense §7when near ${type}§7.`,
       ],
     };
   }
@@ -2555,7 +2576,7 @@ class FlyingFish extends Pet {
     const armor = getValue(this.rarity, { legendary: "Diver Armor", mythic: "Magma Lord armor" });
     return {
       name: getValue(this.rarity, { rare: "§6Deep Sea Diver", mythic: "§6Magmatic Diver" }),
-      desc: [`§7Increases the stats of ${armor} by §a${round(this.level * mult, 1)}%`],
+      desc: [`§7Increases the stats of ${armor} by §a${round(this.level * mult, 1)}%§7.`],
     };
   }
 
@@ -2563,7 +2584,7 @@ class FlyingFish extends Pet {
     const mult = getValue(this.rarity, { mythic: 0.5 });
     return {
       name: "§6Rapid Decay",
-      desc: [`§7Increases the chance to activate Flash Enchantment by §a${round(this.level * mult, 1)}%`],
+      desc: [`§7Increases the chance to activate Flash Enchantment by §a${round(this.level * mult, 1)}%§7.`],
     };
   }
 }
@@ -2592,7 +2613,7 @@ class Megalodon extends Pet {
       desc: [
         `§7Deal up to §c+${round(mult * this.level, 1)}% ${
           SYMBOLS.strength
-        } §7Damage based on the enemy's missing health`,
+        } Damage §7based on the enemy's missing health.`,
       ],
     };
   }
@@ -2601,7 +2622,7 @@ class Megalodon extends Pet {
     const mult = getValue(this.rarity, { epic: 0.2 });
     return {
       name: "§6Enhanced scales",
-      desc: [`§7Increases the stats of Shark Armor by §a${round(mult * this.level, 1)}%`],
+      desc: [`§7Increases the stats of Shark Armor by §a${round(mult * this.level, 1)}%§7.`],
     };
   }
 
@@ -2612,7 +2633,7 @@ class Megalodon extends Pet {
       desc: [
         `§7On kill gain §c${round(mult * this.level, 1)} ${SYMBOLS.strength} Damage §7and §f${
           SYMBOLS.speed
-        } Speed §7for 5 seconds`,
+        } Speed §7for 5 seconds§7.`,
       ],
     };
   }
@@ -2641,20 +2662,20 @@ class Squid extends Pet {
     const mult = getValue(this.rarity, { common: 0.5, uncommon: 0.75, epic: 1 });
     return {
       name: "§6More Ink",
-      desc: [`§7Gain a §a${round(this.level * mult, 1)}% §7chance to get double drops from squids`],
+      desc: [`§7Gain a §a${round(this.level * mult, 1)}% §7chance to get double drops from squids.`],
     };
   }
 
   get second() {
     const multDamage = getValue(this.rarity, { rare: 0.3, epic: 0.4 });
-    const multStrength = getValue(this.rarity, { rare: 0.1, epic: 0.2 });
+    const multStrength = getValue(this.rarity, { rare: 0.15, epic: 0.2 });
     return {
       name: "§6Ink Specialty",
       desc: [
         `§7Buffs the Ink Wand by §a${round(this.level * multDamage, 1)} §c${SYMBOLS.strength} Damage §7and §a${round(
           this.level * multStrength,
           1
-        )} §c${SYMBOLS.strength} Strength`,
+        )} §c${SYMBOLS.strength} Strength§7.`,
       ],
     };
   }
@@ -2709,7 +2730,9 @@ class Jellyfish extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.5 });
     return {
       name: "§6Powerful Potions",
-      desc: [`§7While in dungeons, increase the effectiveness of Dungeon Potions by §a${round(this.level * mult, 1)}%`],
+      desc: [
+        `§7While in dungeons, increase the effectiveness of Dungeon Potions by §a${round(this.level * mult, 1)}%§7.`,
+      ],
     };
   }
 }
@@ -2735,7 +2758,7 @@ class Parrot extends Pet {
     const mult = getValue(this.rarity, { epic: 0.15, legendary: 0.2 });
     return {
       name: "§6Flamboyant",
-      desc: [`§7Adds §a${Math.max(round(this.level * mult, 0), 1)} §7levels to intimidation accessories`],
+      desc: [`§7Adds §a${Math.max(round(this.level * mult, 0), 1)} §7levels to intimidation accessories§7.`],
     };
   }
 
@@ -2743,7 +2766,7 @@ class Parrot extends Pet {
     const mult = getValue(this.rarity, { epic: 0.35 });
     return {
       name: "§6Repeat",
-      desc: [`§7Boosts potion duration by §a${round(5 + this.level * mult, 1)}%`],
+      desc: [`§7Boosts potion duration by §a${round(5 + this.level * mult, 1)}%§7.`],
     };
   }
 
@@ -2753,7 +2776,7 @@ class Parrot extends Pet {
       name: "§6Bird Discourse",
       desc: [
         `§7Gives §c+${round(5 + this.level * mult, 1)} ${SYMBOLS.strength} Strength §7to players within §a20 §7blocks`,
-        `§7Doesn't stack`,
+        `§8Doesn't stack`,
       ],
     };
   }
@@ -2766,7 +2789,7 @@ class Parrot extends Pet {
         `§7When summoned or in your pets menu, boost the duration of consumed §cGod Potions §7by §a${round(
           this.level * mult,
           1
-        )}%`,
+        )}%§7.`,
       ],
     };
   }
@@ -2795,7 +2818,7 @@ class Sheep extends Pet {
     const mult = getValue(this.rarity, { common: 0.1, uncommon: 0.15, epic: 0.2 });
     return {
       name: "§6Mana Saver",
-      desc: [`§7Reduces the mana cost of abilities by §a${round(this.level * mult, 1)}%`],
+      desc: [`§7Reduces the mana cost of abilities by §a${round(this.level * mult, 1)}%§7.`],
     };
   }
 
@@ -2803,7 +2826,7 @@ class Sheep extends Pet {
     const mult = getValue(this.rarity, { rare: 0.1 });
     return {
       name: "§6Overheal",
-      desc: [`§7Gives a §a${round(this.level * mult, 1)}% §7shield after not taking damage for 10s`],
+      desc: [`§7Gives a §a${round(this.level * mult, 1)}% §7shield after not taking damage for 10s§7.`],
     };
   }
 
@@ -2811,7 +2834,7 @@ class Sheep extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.25 });
     return {
       name: "§6Dungeon Wizard",
-      desc: [`§7Increases your total mana by §a${round(this.level * mult, 1)}% §7while in dungeons`],
+      desc: [`§7Increases your total mana by §a${round(this.level * mult, 1)}% §7while in dungeons§7.`],
     };
   }
 }
@@ -2837,14 +2860,14 @@ class Jerry extends Pet {
   get first() {
     return {
       name: "§6Jerry",
-      desc: [`§7Gain §a50% §7chance to deal your regular damage`],
+      desc: [`§7Gain §a50% §7chance to deal your regular damage.`],
     };
   }
 
   get second() {
     return {
       name: "§6Jerry",
-      desc: [`§7Gain §a100% §7chance to receive a normal amount of drops from mobs`],
+      desc: [`§7Gain §a100% §7chance to receive a normal amount of drops from mobs.`],
     };
   }
 
@@ -2852,14 +2875,14 @@ class Jerry extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.1, mythic: 0.5 });
     return {
       name: "§6Jerry",
-      desc: [`§7Actually adds §c${Math.floor(this.level * mult)} damage §7to the Aspect of the Jerry`],
+      desc: [`§7Actually adds §c${Math.floor(this.level * mult)} damage §7to the Aspect of the Jerry.`],
     };
   }
 
   get fourth() {
     return {
       name: "§6Jerry",
-      desc: [`§7Tiny chance to find Jerry Candies when killing mobs`],
+      desc: [`§7Tiny chance to find Jerry Candies when killing mobs.`],
     };
   }
 }
@@ -2886,6 +2909,9 @@ class Bingo extends Pet {
     }
     if (this.rarity >= LEGENDARY) {
       list.push(this.fifth);
+    }
+    if (this.rarity >= MYTHIC) {
+      list.push(this.sixth);
     }
     return list;
   }
@@ -2937,15 +2963,34 @@ class Bingo extends Pet {
       ],
     };
   }
+
+  get sixth() {
+    return {
+      name: "§6Power Of Completion",
+      desc: [
+        `§7Gain §c+2 ${SYMBOLS.strength} Strength§7, §9+1 Crit Chance§7, and §c+5 ${SYMBOLS.health} Health §7per completed Personal Bingo Goal in the current Bingo Event.`,
+      ],
+    };
+  }
 }
 
 class Wisp extends Pet {
   get stats() {
-    return {
-      true_defense: this.level * 0.1 + 5,
-      health: this.level * 1,
-      intelligence: this.level * 0.5,
-    };
+    const trueDefenseMultiplier = getValue(this.rarity, { rare: 0.15, epic: 0.3, legendary: 0.35 });
+    const healthMultiplier = getValue(this.rarity, { uncommon: 1, rare: 2.5, epic: 4, legendary: 6 });
+    const intelligenceMultiplier = getValue(this.rarity, { rare: 0.5, epic: 1.25, legendary: 2.5 });
+
+    if (this.rarity <= UNCOMMON) {
+      return {
+        health: this.level * healthMultiplier,
+      };
+    } else {
+      return {
+        true_defense: this.level * trueDefenseMultiplier,
+        health: this.level * healthMultiplier,
+        intelligence: this.level * intelligenceMultiplier,
+      };
+    }
   }
 
   get abilities() {
@@ -2962,7 +3007,7 @@ class Wisp extends Pet {
   get first() {
     return {
       name: "§6Drophammer",
-      desc: [`§7Lets you break fire pillars`],
+      desc: [`§7Lets you break fire pillars§7.`],
     };
   }
 
@@ -2988,7 +3033,7 @@ class Wisp extends Pet {
       { kills: 200000, defense: 600, true_defense: 60 },
     ];
 
-    const blazeKills = this.extra?.blazeKills ?? 0;
+    const blazeKills = this.extra?.blaze_kills ?? 0;
 
     let maxTier = false;
     let bonusIndex = BONUSES.findIndex((x) => x.kills > blazeKills);
@@ -3020,7 +3065,7 @@ class Wisp extends Pet {
   }
 
   get third() {
-    const mult = getValue(this.rarity, { uncommon: 0.3, rare: 0.4, epic: 0.45, legenedary: 50 });
+    const mult = getValue(this.rarity, { uncommon: 0.3, rare: 0.4, epic: 0.45, legendary: 0.5 });
     const prc = round(this.level * mult, 1);
 
     return {
@@ -3046,7 +3091,7 @@ class Wisp extends Pet {
     const mult = getValue(this.rarity, { legendary: 0.4 });
     return {
       name: "§6Cold Fusion",
-      desc: [`§7Regenerate mana §b${round(this.level * mult, 1)}% §7faster`],
+      desc: [`§7Regenerate mana §b${round(this.level * mult, 1)}% §7faster§7.`],
     };
   }
 }
@@ -3075,7 +3120,7 @@ class MooshroomCow extends Pet {
 
     return {
       name: "§6Efficient Mushrooms",
-      desc: [`§7Mushroom and Mycelium minions work §a${round(this.level * mult, 1)}% §7faster while on your island`],
+      desc: [`§7Mushroom and Mycelium minions work §a${round(this.level * mult, 1)}% §7faster while on your island§7.`],
     };
   }
 
@@ -3084,7 +3129,10 @@ class MooshroomCow extends Pet {
     return {
       name: "§6Mushroom Eater",
       desc: [
-        `§7When breaking crops, there is a §a${round(this.level * mult + 1.01, 1)}% §7chance that a mushroom will drop`,
+        `§7When breaking crops, there is a §a${round(
+          this.level * mult + 1.01,
+          1
+        )}% §7chance that a mushroom will drop§7.`,
       ],
     };
   }
@@ -3097,7 +3145,7 @@ class MooshroomCow extends Pet {
       desc: [
         `§7Gain §6+1 ${SYMBOLS.farming_fortune} Farming Fortune §7per every §c${round(40 - this.level * mult, 1)} ${
           SYMBOLS.strength
-        } Strength`,
+        } Strength§7.`,
       ],
     };
   }
@@ -3126,7 +3174,7 @@ class Snail extends Pet {
 
     return {
       name: "§6Red Sand Enjoyer",
-      desc: [`§7Red Sand minions work §a${round(this.level * mult, 1)}% §7faster while on your island`],
+      desc: [`§7Red Sand minions work §a${round(this.level * mult, 1)}% §7faster while on your island§7.`],
     };
   }
 
@@ -3138,8 +3186,8 @@ class Snail extends Pet {
       desc: [
         `§7Converts all §f${SYMBOLS.speed} Speed §7over 100 into §6${
           SYMBOLS.mining_fortune
-        } Mining Fortune §7for Non-Ores at §a${round(this.level * mult, 1)}% §7efficiency`,
-        // `Current bonus: +0 ${SYMBOLS.mining_fortune} Mining Fortune`,
+        } Mining Fortune §7for Non-Ores at §a${round(this.level * mult, 1)}% §7efficiency§7.`,
+        `Current bonus: +0 ${SYMBOLS.mining_fortune} Mining Fortune§7.`,
       ],
     };
   }
@@ -3152,7 +3200,7 @@ class Snail extends Pet {
       desc: [
         `§7Reduces the mana cost of §9Utility Abilities §7by §a${round(this.level * mult, 1)}% §7for every +15 §f${
           SYMBOLS.speed
-        } Speed §7converted`,
+        } Speed §7converted§7.`,
       ],
     };
   }
@@ -3185,7 +3233,7 @@ class Kuudra extends Pet {
 
     return {
       name: "§6Crimson",
-      desc: [`§7Grants §a${round(this.level * mult, 1)}% §7extra crimson essence`],
+      desc: [`§7Grants §a${round(this.level * mult, 1)}% §7extra crimson essence.`],
     };
   }
 
@@ -3194,7 +3242,7 @@ class Kuudra extends Pet {
 
     return {
       name: "§6Wither Bait",
-      desc: [`§7Increases the odds of finding a vanquisher by §a${round(this.level * mult, 1)}%`],
+      desc: [`§7Increases the odds of finding a vanquisher by §a${round(this.level * mult, 1)}%§7.`],
     };
   }
 
@@ -3204,7 +3252,9 @@ class Kuudra extends Pet {
     return {
       name: "§6Kuudra Fortune",
       desc: [
-        `§7Gain §6+${round(this.level * mult, 1)} ${SYMBOLS.mining_fortune} Mining Fortune §7while on the Crimson Isle`,
+        `§7Gain §6+${round(this.level * mult, 1)} ${
+          SYMBOLS.mining_fortune
+        } Mining Fortune §7while on the Crimson Isle.`,
       ],
     };
   }
@@ -3214,14 +3264,14 @@ class Kuudra extends Pet {
 
     return {
       name: "§6Trophy Bait",
-      desc: [`§7Increases the odds of fishing Trophy Fish by §a${round(this.level * mult, 1)}%`],
+      desc: [`§7Increases the odds of fishing Trophy Fish by §a${round(this.level * mult, 1)}%§7.`],
     };
   }
 
   get fifth() {
     return {
       name: "§6Kuudra Specialist",
-      desc: [`§7Increases all damage to Kuudra by §c5%`],
+      desc: [`§7Increases all damage to Kuudra by §c5%§7.`],
     };
   }
 }
@@ -3256,7 +3306,7 @@ class Reindeer extends Pet {
       desc: [
         `§7Gives +§b${round(this.level * mult, 1)}${SYMBOLS.fishing_speed} Fishing Speed §7and §3+10 ${
           SYMBOLS.sea_creature_chance
-        } Sea Creature Chance §7while on §cJerry's Workshop.`,
+        } Sea Creature Chance §7while on §cJerry's Workshop§7.`,
       ],
     };
   }

--- a/src/constants/pet-stats.js
+++ b/src/constants/pet-stats.js
@@ -1154,7 +1154,11 @@ class Ghoul extends Pet {
     const mult = getValue(this.rarity, { epic: 0.25 });
     return {
       name: "§6Amplified Healing",
-      desc: [`§7Grants §4${round(this.level * mult, 1)} ${SYMBOLS.vitality}§7, which increases your incoming healing.`],
+      desc: [
+        `§7Grants §4${round(this.level * mult, 1)} ${
+          SYMBOLS.vitality
+        } Vitality§7, which increases your incoming healing.`,
+      ],
     };
   }
 

--- a/src/constants/pets.js
+++ b/src/constants/pets.js
@@ -281,7 +281,7 @@ export const PET_DATA = {
   ENDERMITE: {
     head: "/head/5a1a0831aa03afb4212adcbb24e5dfaa7f476a1173fce259ef75a85855",
     type: "mining",
-    maxTier: "legendary",
+    maxTier: "mythic",
     maxLevel: 100,
     emoji: "🐜",
   },
@@ -561,12 +561,12 @@ export const PET_ITEMS = {
   PET_ITEM_ALL_SKILLS_BOOST_COMMON: {
     name: "All Skills Exp Boost",
     tier: "COMMON",
-    description: "§7Gives +§a10% §7pet exp for all skills",
+    description: "§7Gives +§a10% §7pet exp for all skills.",
   },
   PET_ITEM_BIG_TEETH_COMMON: {
     name: "Big Teeth",
     tier: "COMMON",
-    description: `§7Increases §9${SYMBOLS.crit_chance} Crit Chance §7by §a5`,
+    description: `§7Increases §9${SYMBOLS.crit_chance} Crit Chance §7by §a5§7.`,
     stats: {
       crit_chance: 5,
     },
@@ -574,7 +574,7 @@ export const PET_ITEMS = {
   PET_ITEM_IRON_CLAWS_COMMON: {
     name: "Iron Claws",
     tier: "COMMON",
-    description: `§7Increases the pet's §9${SYMBOLS.crit_damage} Crit Damage §7by §a40% §7and §9${SYMBOLS.crit_chance} Crit Chance §7by §a40%`,
+    description: `§7Increases the pet's §9${SYMBOLS.crit_damage} Crit Damage §7by §a40% §7and §9${SYMBOLS.crit_chance} Crit Chance §7by §a40%§7.`,
     multStats: {
       crit_chance: 1.4,
       crit_damage: 1.4,
@@ -583,7 +583,7 @@ export const PET_ITEMS = {
   PET_ITEM_SHARPENED_CLAWS_UNCOMMON: {
     name: "Sharpened Claws",
     tier: "UNCOMMON",
-    description: `§7Increases §9${SYMBOLS.crit_damage} Crit Damage §7by §a15`,
+    description: `§7Increases §9${SYMBOLS.crit_damage} Crit Damage §7by §a15§7.`,
     stats: {
       crit_damage: 15,
     },
@@ -591,7 +591,7 @@ export const PET_ITEMS = {
   PET_ITEM_HARDENED_SCALES_UNCOMMON: {
     name: "Hardened Scales",
     tier: "UNCOMMON",
-    description: `§7Increases §a${SYMBOLS.defense} Defense §7by §a25`,
+    description: `§7Increases §a${SYMBOLS.defense} Defense §7by §a25§7.`,
     stats: {
       defense: 25,
     },
@@ -599,12 +599,12 @@ export const PET_ITEMS = {
   PET_ITEM_BUBBLEGUM: {
     name: "Bubblegum",
     tier: "RARE",
-    description: "§7Your pet fuses its power with placed §aOrbs §7to give them §a2x §7duration",
+    description: "§7Your pet fuses its power with placed §aOrbs §7to give them §a2x §7duration.",
   },
   PET_ITEM_LUCKY_CLOVER: {
     name: "Lucky Clover",
     tier: "EPIC",
-    description: `§7Increases §b${SYMBOLS.magic_find} Magic Find §7by §a7`,
+    description: `§7Increases §b${SYMBOLS.magic_find} Magic Find §7by §a7§7.`,
     stats: {
       magic_find: 7,
     },
@@ -612,7 +612,7 @@ export const PET_ITEMS = {
   PET_ITEM_TEXTBOOK: {
     name: "Textbook",
     tier: "LEGENDARY",
-    description: `§7Increases the pet's §b${SYMBOLS.intelligence} Intelligence §7by §a100%`,
+    description: `§7Increases the pet's §b${SYMBOLS.intelligence} Intelligence §7by §a100%§7.`,
     multStats: {
       intelligence: 2,
     },
@@ -620,7 +620,7 @@ export const PET_ITEMS = {
   PET_ITEM_SADDLE: {
     name: "Saddle",
     tier: "UNCOMMON",
-    description: "§7Increase horse speed by §a50% §7 and jump boost by §a100%",
+    description: "§7Increase horse speed by §a50% §7 and jump boost by §a100%§7.",
   },
   PET_ITEM_EXP_SHARE: {
     name: "Exp Share",
@@ -636,107 +636,107 @@ export const PET_ITEMS = {
   PET_ITEM_COMBAT_SKILL_BOOST_COMMON: {
     name: "Combat Exp Boost",
     tier: "COMMON",
-    description: "§7Gives +§a20% §7pet exp for Combat",
+    description: "§7Gives +§a20% §7pet exp for Combat.",
   },
   PET_ITEM_COMBAT_SKILL_BOOST_UNCOMMON: {
     name: "Combat Exp Boost",
     tier: "UNCOMMON",
-    description: "§7Gives +§a30% §7pet exp for Combat",
+    description: "§7Gives +§a30% §7pet exp for Combat.",
   },
   PET_ITEM_COMBAT_SKILL_BOOST_RARE: {
     name: "Combat Exp Boost",
     tier: "RARE",
-    description: "§7Gives +§a40% §7pet exp for Combat",
+    description: "§7Gives +§a40% §7pet exp for Combat.",
   },
   PET_ITEM_COMBAT_SKILL_BOOST_EPIC: {
     name: "Combat Exp Boost",
     tier: "EPIC",
-    description: "§7Gives +§a50% §7pet exp for Combat",
+    description: "§7Gives +§a50% §7pet exp for Combat.",
   },
   PET_ITEM_FISHING_SKILL_BOOST_COMMON: {
     name: "Fishing Exp Boost",
     tier: "COMMON",
-    description: "§7Gives +§a20% §7pet exp for Fishing",
+    description: "§7Gives +§a20% §7pet exp for Fishing.",
   },
   PET_ITEM_FISHING_SKILL_BOOST_UNCOMMON: {
     name: "Fishing Exp Boost",
     tier: "UNCOMMON",
-    description: "§7Gives +§a30% §7pet exp for Fishing",
+    description: "§7Gives +§a30% §7pet exp for Fishing.",
   },
   PET_ITEM_FISHING_SKILL_BOOST_RARE: {
     name: "Fishing Exp Boost",
     tier: "RARE",
-    description: "§7Gives +§a40% §7pet exp for Fishing",
+    description: "§7Gives +§a40% §7pet exp for Fishing.",
   },
   PET_ITEM_FISHING_SKILL_BOOST_EPIC: {
     name: "Fishing Exp Boost",
     tier: "EPIC",
-    description: "§7Gives +§a50% §7pet exp for Fishing",
+    description: "§7Gives +§a50% §7pet exp for Fishing.",
   },
   PET_ITEM_FORAGING_SKILL_BOOST_COMMON: {
     name: "Foraging Exp Boost",
     tier: "COMMON",
-    description: "§7Gives +§a20% §7pet exp for Foraging",
+    description: "§7Gives +§a20% §7pet exp for Foraging.",
   },
   PET_ITEM_FORAGING_SKILL_BOOST_UNCOMMON: {
     name: "Foraging Exp Boost",
     tier: "UNCOMMON",
-    description: "§7Gives +§a30% §7pet exp for Foraging",
+    description: "§7Gives +§a30% §7pet exp for Foraging.",
   },
   PET_ITEM_FORAGING_SKILL_BOOST_RARE: {
     name: "Foraging Exp Boost",
     tier: "RARE",
-    description: "§7Gives +§a40% §7pet exp for Foraging",
+    description: "§7Gives +§a40% §7pet exp for Foraging.",
   },
   PET_ITEM_FORAGING_SKILL_BOOST_EPIC: {
     name: "Foraging Exp Boost",
     tier: "EPIC",
-    description: "§7Gives +§a50% §7pet exp for Foraging",
+    description: "§7Gives +§a50% §7pet exp for Foraging.",
   },
   PET_ITEM_MINING_SKILL_BOOST_COMMON: {
     name: "Mining Exp Boost",
     tier: "COMMON",
-    description: "§7Gives +§a20% §7pet exp for Mining",
+    description: "§7Gives +§a20% §7pet exp for Mining.",
   },
   PET_ITEM_MINING_SKILL_BOOST_UNCOMMON: {
     name: "Mining Exp Boost",
     tier: "UNCOMMON",
-    description: "§7Gives +§a30% §7pet exp for Mining",
+    description: "§7Gives +§a30% §7pet exp for Mining.",
   },
   PET_ITEM_MINING_SKILL_BOOST_RARE: {
     name: "Mining Exp Boost",
     tier: "RARE",
-    description: "§7Gives +§a40% §7pet exp for Mining",
+    description: "§7Gives +§a40% §7pet exp for Mining.",
   },
   PET_ITEM_MINING_SKILL_BOOST_EPIC: {
     name: "Mining Exp Boost",
     tier: "EPIC",
-    description: "§7Gives +§a50% §7pet exp for Mining",
+    description: "§7Gives +§a50% §7pet exp for Mining.",
   },
   PET_ITEM_FARMING_SKILL_BOOST_COMMON: {
     name: "Farming Exp Boost",
     tier: "COMMON",
-    description: "§7Gives +§a20% §7pet exp for Farming",
+    description: "§7Gives +§a20% §7pet exp for Farming.",
   },
   PET_ITEM_FARMING_SKILL_BOOST_UNCOMMON: {
     name: "Farming Exp Boost",
     tier: "UNCOMMON",
-    description: "§7Gives +§a30% §7pet exp for Farming",
+    description: "§7Gives +§a30% §7pet exp for Farming.",
   },
   PET_ITEM_FARMING_SKILL_BOOST_RARE: {
     name: "Farming Exp Boost",
     tier: "RARE",
-    description: "§7Gives +§a40% §7pet exp for Farming",
+    description: "§7Gives +§a40% §7pet exp for Farming.",
   },
   PET_ITEM_FARMING_SKILL_BOOST_EPIC: {
     name: "Farming Exp Boost",
     tier: "EPIC",
-    description: "§7Gives +§a50% §7pet exp for Farming",
+    description: "§7Gives +§a50% §7pet exp for Farming.",
   },
   REINFORCED_SCALES: {
     name: "Reinforced Scales",
     tier: "RARE",
-    description: `§7Increases §a${SYMBOLS.defense} Defense §7by §a40`,
+    description: `§7Increases §a${SYMBOLS.defense} Defense §7by §a40§7.`,
     stats: {
       defense: 40,
     },
@@ -744,7 +744,7 @@ export const PET_ITEMS = {
   GOLD_CLAWS: {
     name: "Gold Claws",
     tier: "UNCOMMON",
-    description: `§7Increases the pet's §9${SYMBOLS.crit_damage} Crit Damage §7by §a50% §7and §9${SYMBOLS.crit_chance} Crit Chance §7by §a50%`,
+    description: `§7Increases the pet's §9${SYMBOLS.crit_damage} Crit Damage §7by §a50% §7and §9${SYMBOLS.crit_chance} Crit Chance §7by §a50%§7.`,
     multStats: {
       crit_chance: 1.5,
       crit_damage: 1.5,
@@ -753,12 +753,12 @@ export const PET_ITEMS = {
   ALL_SKILLS_SUPER_BOOST: {
     name: "All Skills Exp Super-Boost",
     tier: "COMMON",
-    description: "§7Gives +§a20% §7pet exp for all skills",
+    description: "§7Gives +§a20% §7pet exp for all skills.",
   },
   BIGGER_TEETH: {
     name: "Bigger Teeth",
     tier: "UNCOMMON",
-    description: `§7Increases §9${SYMBOLS.crit_chance} Crit Chance §7by §a10`,
+    description: `§7Increases §9${SYMBOLS.crit_chance} Crit Chance §7by §a10§7.`,
     stats: {
       crit_chance: 10,
     },
@@ -766,7 +766,7 @@ export const PET_ITEMS = {
   SERRATED_CLAWS: {
     name: "Serrated Claws",
     tier: "RARE",
-    description: `§7Increases §9${SYMBOLS.crit_damage} Crit Damage §7by §a25`,
+    description: `§7Increases §9${SYMBOLS.crit_damage} Crit Damage §7by §a25§7.`,
     stats: {
       crit_damage: 25,
     },
@@ -774,7 +774,7 @@ export const PET_ITEMS = {
   WASHED_UP_SOUVENIR: {
     name: "Washed-up Souvenir",
     tier: "LEGENDARY",
-    description: `§7Increases §3${SYMBOLS.sea_creature_chance} Sea Creature Chance §7by §a5`,
+    description: `§7Increases §3${SYMBOLS.sea_creature_chance} Sea Creature Chance §7by §a5§7.`,
     stats: {
       sea_creature_chance: 5,
     },
@@ -782,7 +782,7 @@ export const PET_ITEMS = {
   ANTIQUE_REMEDIES: {
     name: "Antique Remedies",
     tier: "EPIC",
-    description: `§7Increases the pet's §c${SYMBOLS.strength} Strength §7by §a80%`,
+    description: `§7Increases the pet's §c${SYMBOLS.strength} Strength §7by §a80%§7.`,
     multStats: {
       strength: 1.8,
     },
@@ -790,7 +790,7 @@ export const PET_ITEMS = {
   CROCHET_TIGER_PLUSHIE: {
     name: "Crochet Tiger Plushie",
     tier: "EPIC",
-    description: `§7Increases §e${SYMBOLS.bonus_attack_speed} Bonus Attack Speed §7by §a35`,
+    description: `§7Increases §e${SYMBOLS.bonus_attack_speed} Bonus Attack Speed §7by §a35§7.`,
     stats: {
       bonus_attack_speed: 35,
     },
@@ -808,7 +808,7 @@ export const PET_ITEMS = {
   PET_ITEM_SPOOKY_CUPCAKE: {
     name: "Spooky Cupcake",
     tier: "UNCOMMON",
-    description: `§7Increases §c${SYMBOLS.strength} Strength §7by §a30 §7and §f${SYMBOLS.speed} Speed §7by §a20`,
+    description: `§7Increases §c${SYMBOLS.strength} Strength §7by §a30 §7and §f${SYMBOLS.speed} Speed §7by §a20§7.`,
     stats: {
       strength: 30,
       speed: 20,
@@ -828,7 +828,7 @@ export const PET_ITEMS = {
   REAPER_GEM: {
     name: "Reaper Gem",
     tier: "LEGENDARY",
-    description: `§7Gain §c8${SYMBOLS.ferocity} Ferocity §7for 5s on kill`,
+    description: `§7Gain §c8${SYMBOLS.ferocity} Ferocity §7for §a5s §7on kill.`,
   },
   PET_ITEM_FLYING_PIG: {
     name: "Flying Pig",

--- a/src/constants/pets.js
+++ b/src/constants/pets.js
@@ -139,6 +139,7 @@ export const PET_DATA = {
     maxLevel: 100,
     emoji: "🦓",
     category: "Mount",
+    subLore: "§7Run around town on your scary, yet trusty, steed!",
   },
   WOLF: {
     head: "/head/dc3dd984bb659849bd52994046964c22725f717e986b12d548fd169367d494",
@@ -212,6 +213,7 @@ export const PET_DATA = {
     maxTier: "legendary",
     maxLevel: 100,
     emoji: "⛄",
+    subLore: "§7Fight alongside your pet Snowman!",
   },
   TURTLE: {
     head: "/head/212b58c841b394863dbcc54de1c2ad2648af8f03e648988c1f9cef0bc20ee23c",

--- a/src/constants/pets.js
+++ b/src/constants/pets.js
@@ -412,10 +412,15 @@ export const PET_DATA = {
   RAT: {
     head: "/head/a8abb471db0ab78703011979dc8b40798a941f3a4dec3ec61cbeec2af8cffe8",
     type: "combat",
-    maxTier: "legendary",
+    maxTier: "mythic",
     maxLevel: 100,
     emoji: "🐀",
     category: "Morph",
+    upgrades: {
+      mythic: {
+        head: "/head/250de7097d939e447ca2d398441cba1d2a5e1a69052ac99c19ff20ad5a3f01ab",
+      },
+    },
   },
   BAL: {
     head: "/head/c469ba2047122e0a2de3c7437ad3dd5d31f1ac2d27abde9f8841e1d92a8c5b75",

--- a/src/lib.js
+++ b/src/lib.js
@@ -2466,6 +2466,11 @@ export async function getPets(profile, userProfile) {
       pet.texture_path = petData.hatching.head;
     }
 
+    // eslint-disable-next-line no-prototype-builtins
+    if (pet.rarity in (petData?.upgrades || {})) {
+      pet.texture_path = petData.upgrades[pet.rarity]?.head || pet.texture_path;
+    }
+
     let petSkin = null;
     if (pet.skin && constants.PET_SKINS?.[`PET_SKIN_${pet.skin}`]) {
       pet.texture_path = constants.PET_SKINS[`PET_SKIN_${pet.skin}`].texture;
@@ -2533,7 +2538,7 @@ export async function getPets(profile, userProfile) {
 
       // push specific pet lore before stats added
       if (constants.PET_DATA[pet.type]?.subLore !== undefined) {
-        lore.push(constants.PET_DATA[pet.type].subLore, " ")
+        lore.push(constants.PET_DATA[pet.type].subLore, " ");
       }
 
       // push pet lore after held item stats added

--- a/src/lib.js
+++ b/src/lib.js
@@ -2531,6 +2531,11 @@ export async function getPets(profile, userProfile) {
         }
       }
 
+      // push specific pet lore before stats added
+      if (constants.PET_DATA[pet.type]?.subLore !== undefined) {
+        lore.push(constants.PET_DATA[pet.type].subLore, " ")
+      }
+
       // push pet lore after held item stats added
       const stats = pet.ref.lore(pet.stats);
       stats.forEach((line) => {

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1202,14 +1202,14 @@ const metaDescription = getMetaDescription()
           <%
             const uniquePets = _.uniq(
               calculated.pets
-                .filter(pet => !constants.PET_DATA[pet.type].bingoExclusive === true || calculated.profile.game_mode === 'bingo')
-                .map((pet) => constants.PET_DATA[pet.type].typeGroup ?? pet.type)
+                .filter(pet => !constants.PET_DATA[pet.type]?.bingoExclusive === true || calculated.profile.game_mode === 'bingo')
+                .map((pet) => constants.PET_DATA[pet.type]?.typeGroup ?? pet.type)
             )
             const totalPets = _.uniq(
               Object.entries(
                 Object.fromEntries(
                   Object.entries(constants.PET_DATA)
-                    .filter(pet => !pet[1].bingoExclusive === true || calculated.profile.game_mode === 'bingo')
+                    .filter(pet => !pet[1]?.bingoExclusive === true || calculated.profile.game_mode === 'bingo')
                 )
               )
                 .map(arr => arr[1].typeGroup || arr[0])


### PR DESCRIPTION
## Description

Fixes descriptions & stats 
Adds custom lore before stats (Snowman & Skeleton Horse)
Includes changes from #1822, #1828 and #1826 
Adds custom texture for mythic rat pet
Fixes bug where website doesn't wanna load if pet doesn't exist (example: reindeer pet issue)

# Examples
> Check those 3 PRs as well
![image](https://user-images.githubusercontent.com/75372052/213785500-bfcc295a-35f1-4d93-97f6-927d95ed67db.png)
![image](https://user-images.githubusercontent.com/75372052/213785436-37a0fc8d-1fa8-4de1-a23a-8dbc2127b5f5.png)
![image](https://user-images.githubusercontent.com/75372052/213785542-d3d5484c-ebe7-406f-b64f-1ccbd3855e50.png)
![image](https://user-images.githubusercontent.com/75372052/213785583-97b72d91-d9e6-40dd-a86a-f5c9ba0b5d58.png)
