### PR TITLE
fix: error if player doesn't have selected profile

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -3624,7 +3624,11 @@ export async function getProfile(
   }
 
   if (!profile) {
-    throw new Error("User not found in selected profile. This is probably due to a declined co-op invite.");
+    profile = profiles[0];
+
+    if (!profile) {
+      throw new Error("Couldn't find any Skyblock profile that belongs to this player.");
+    }
   }
 
   const userProfile = profile.members[paramPlayer];


### PR DESCRIPTION
## Description

Fixes error `User not found in selected profile. This is probably due to a declined co-op invite.` if player doesn't have selected profile (hasn't joined after Hypixel's change from `last_save` to `selected`)

## Example

https://sky.shiiyu.moe/stats/zCris1xV2