### PR TITLE
Account For Finnegan Perk and Correct Medal Brackets

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -1934,7 +1934,11 @@ export async function getStats(
         // Use the claimed medal if it exists and is valid
         // This accounts for the farming mayor increased brackets perk
         // Note: The medal brackets are the percentage + 1 extra person
-        if (contest.claimed_medal === "bronze" || contest.claimed_medal === "silver" || contest.claimed_medal === "gold") {
+        if (
+          contest.claimed_medal === "bronze" ||
+          contest.claimed_medal === "silver" ||
+          contest.claimed_medal === "gold"
+        ) {
           contest.medal = contest.claimed_medal;
         } else if (placing.position <= participants * 0.05 + 1) {
           contest.medal = "gold";


### PR DESCRIPTION
Fixes #1852

Adjusts calculations to the ones as described in the issue, and ensures the `claimed_medal` property is respected.

Note that `placing.percentage` is unused now, but I'm unsure if that is planned on being used elsewhere, so I left it.