### PR TITLE
fix: SkyBlock Level bar width

### DIFF
--- a/public/resources/scss/stats.scss
+++ b/public/resources/scss/stats.scss
@@ -94,8 +94,11 @@
 
     &[type="skyblock_level"] {
       margin-bottom: 25px;
-      padding-right: 24px;
-      width: 200%;
+
+      @media (min-width: 481px) {
+        padding-right: 24px;
+        width: 200%;
+      }
     }
 
     .skill-icon {

--- a/public/resources/scss/stats.scss
+++ b/public/resources/scss/stats.scss
@@ -2497,7 +2497,6 @@ inventory-view {
 
   #skill_levels_container skill-component {
     width: 100%;
-    margin: 0;
   }
 
   .wardrobe .wardrobe-set {


### PR DESCRIPTION
## Description

Fixes https://canary.discord.com/channels/738971489411399761/738990246825427084/1075509107882209312
> Width of SkyBlock Level bar isn't correct on mobile devices

## Examples

> Before

![image](https://user-images.githubusercontent.com/75372052/219144399-5e5ed118-5d9a-493a-9381-af46cc5559c6.png)

> After

![image](https://user-images.githubusercontent.com/75372052/219144450-ba34b282-26da-458c-9f93-45ecd768f024.png)
![image](https://user-images.githubusercontent.com/75372052/219144473-505ff7d7-3000-492f-812d-474cb6c56b9f.png)
