### PR TITLE
refactor: add `LandonHP` to blocked players

### DIFF
--- a/src/constants/misc.js
+++ b/src/constants/misc.js
@@ -152,12 +152,15 @@ export const AREA_NAMES = {
   mining_2: "Deep Caverns",
   mining_3: "Dwarven Mines",
   combat_1: "Spider's Den",
-  combat_2: "Blazing Fortress",
+  crimson_isle: "Crimson Isle",
   combat_3: "The End",
-  farming_1: "The Barn",
-  farming_2: "Mushroom Desert",
+  farming_1: "The Farming Islands",
   foraging_1: "The Park",
+  dungeon: "Dungeon",
+  dungeon_hub: "Dungeon Hub",
   winter: "Jerry's Workshop",
+  instanced: "Kuudra's End",
+  garden: "The Garden",
 };
 
 export const COLOR_NAMES = {
@@ -346,7 +349,7 @@ export const INCREASE_MOST_STATS_EXCLUDE = [
 
 export const FAIRY_SOULS = {
   max: {
-    normal: 238,
+    normal: 239,
     stranded: 3,
   },
 };

--- a/src/constants/misc.js
+++ b/src/constants/misc.js
@@ -2,6 +2,7 @@
 export const BLOCKED_PLAYERS = [
   "20934ef9488c465180a78f861586b4cf", // Minikloon (Admin)
   "f025c1c7f55a4ea0b8d93f47d17dfe0f", // Plancke (Admin)
+  "c552c04a40fb4a17bf549a031b3ab1a1", // LandonHP (Admin)
 ];
 
 // Number of kills required for each level of expertise
@@ -151,15 +152,12 @@ export const AREA_NAMES = {
   mining_2: "Deep Caverns",
   mining_3: "Dwarven Mines",
   combat_1: "Spider's Den",
-  crimson_isle: "Crimson Isle",
+  combat_2: "Blazing Fortress",
   combat_3: "The End",
-  farming_1: "The Farming Islands",
+  farming_1: "The Barn",
+  farming_2: "Mushroom Desert",
   foraging_1: "The Park",
-  dungeon: "Dungeon",
-  dungeon_hub: "Dungeon Hub",
   winter: "Jerry's Workshop",
-  instanced: "Kuudra's End",
-  garden: "The Garden",
 };
 
 export const COLOR_NAMES = {
@@ -348,7 +346,7 @@ export const INCREASE_MOST_STATS_EXCLUDE = [
 
 export const FAIRY_SOULS = {
   max: {
-    normal: 239,
+    normal: 238,
     stranded: 3,
   },
 };


### PR DESCRIPTION
## Description

Adds LandonHP to `BLOCKED_PLAYERS`
> Recently he gave himself catacombs level 57
![image](https://user-images.githubusercontent.com/75372052/221180484-c24bc8e1-cf6b-48ba-92f1-71575e8b82cc.png)
