### PR TITLE
fix: text not being gold at unique medal

### DIFF
--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1694,7 +1694,7 @@ const metaDescription = getMetaDescription()
                   <div class="item-icon icon-<%= crop.icon %>"></div>
                 </div>
                 <div class="chip-text">
-                  <div class="collection-name <%= crop.unique_gold ? 'max-minion' : '' %>"><span class="stat-name"><%= crop.name %></span></div>
+                  <div class="collection-name <%= crop.unique_gold ? 'max-stat' : '' %>"><span class="stat-name"><%= crop.name %></span></div>
                   <div class="collection-amount">
                     <small class="stat-name">Personal Best: </small><small class="stat-value"><%= helper.formatNumber(crop.personal_best, true) %></small><br>
                     <small class="stat-name">Contests: </small><small class="stat-value"><%= crop.contests.toLocaleString() %></small><br>


### PR DESCRIPTION
## Description

Adds https://discord.com/channels/738971489411399761/738990231348314123/1081924938027507743
> Actually fixes but yeah.. 

## Example
> Before

![mahwjcep](https://user-images.githubusercontent.com/75372052/222969577-8a5b62d0-f85c-4b6a-810a-e6dfbbff0600.png)

> After

![uldjvd17](https://user-images.githubusercontent.com/75372052/222969585-baa90adb-c734-4671-abdf-63ca505357b1.png)

