### PR TITLE
fix: highest critical damage format

### DIFF
--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -2792,7 +2792,8 @@ const metaDescription = getMetaDescription()
           </div>
           <p class="stat-raw-values">
             <% for(const key in calculated.misc.damage){ %>
-            <span class="stat-name"><%= helper.capitalizeFirstLetter(key.split("_").join(" ")); %>: </span><span class="stat-value"><%= Math.floor(calculated.misc.damage[key]).toLocaleString() %></span><br>
+              <% const damage = calculated.misc.damage[key] > 100_000_000_000 ? helper.formatNumber(Math.floor(calculated.misc.damage[key]).toFixed(0), true) : Math.floor(calculated.misc.damage[key]).toLocaleString(); %>
+            <span class="stat-name"><%= helper.capitalizeFirstLetter(key.split("_").join(" ")); %>: </span><span class="stat-value"><%= damage %></span><br>
             <% } %>
           </p>
           <% } %>


### PR DESCRIPTION
## Description

Fixes https://discord.com/channels/738971489411399761/738990246825427084/1084473370143379477
> Javascript doesn't allow rounding big numbers like this to x decimals so it looks kinda ugly ;-;

## Examples

> Before

![image](https://user-images.githubusercontent.com/75372052/225602256-907cec05-a3bf-4bcc-be0f-e5f7adfb1a71.png)

> After

![image](https://user-images.githubusercontent.com/75372052/225602157-f684f1fd-1035-4782-8ca0-adf1fd3e6c45.png)
