### PR TITLE
refactor: `Price Paid at Dark Auction:` color

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -714,7 +714,7 @@ async function processItems(base64, source, customTextures = false, packs, cache
       }
 
       if (item.extra?.price_paid) {
-        itemLore.push(`§7Price Paid at Dark Auction: §b${item.extra.price_paid.toLocaleString()} coins`);
+        itemLore.push("", `§7Price Paid at Dark Auction: §6${item.extra.price_paid.toLocaleString()} Coins`);
       }
     }
 


### PR DESCRIPTION
## Description

Changes color of `Price Paid at Dark Auction:` field, also adds spacing

## Examples

> Before

![image](https://user-images.githubusercontent.com/75372052/226121716-1263bd30-4ded-48c8-8ab0-c0a8deb0f357.png)

> After

![image](https://user-images.githubusercontent.com/75372052/226121712-6028b145-558d-41f6-8786-054f612e9467.png)
