### PR TITLE
fix: `renderLore()` breaking with `§L`

### DIFF
--- a/common/formatting.js
+++ b/common/formatting.js
@@ -37,7 +37,7 @@ export function renderLore(text) {
   const formats = new Set();
 
   // @ts-ignore - this regex always matches so we don't need to check for null
-  for (let part of text.match(/(§[0-9A-Fa-fk-or])*[^§]*/g)) {
+  for (let part of text.match(/(§[0-9A-Fa-fk-or])*[^§L]*/g)) {
     formats.clear();
     while (part.charAt(0) === "§") {
       const code = part.charAt(1).toLowerCase();


### PR DESCRIPTION
## Description

Fixes https://discord.com/channels/738971489411399761/738990246825427084/1088103147634962472

## Examples

> Before

![image](https://user-images.githubusercontent.com/75372052/227728775-02896b34-6562-41bb-84ba-eafaa0c7d424.png)

> After 

![image](https://user-images.githubusercontent.com/75372052/227728779-0d2db24e-2346-4b7f-9213-79dced55bcc5.png)
