### PR TITLE
fix: Skyblock Level maxLevel from 386 to 500

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -2140,7 +2140,7 @@ export async function getStats(
   output.skyblock_level = {
     xp: userProfile.leveling?.experience || 0,
     level: Math.floor(userProfile.leveling?.experience / 100 || 0),
-    maxLevel: 386,
+    maxLevel: 500,
     progress: (userProfile.leveling?.experience % 100) / 100 || 0,
     xpCurrent: userProfile.leveling?.experience % 100 || 0,
     xpForNext: 100,


### PR DESCRIPTION
## Description

https://cdn.discordapp.com/attachments/738990246825427084/1091086444153544744/image.png

The maximum SkyBlock Level is SkyBlock Level 500.
https://wiki.hypixel.net/SkyBlock_Levels