### PR TITLE
fix: `validateURL()` | empty profile UUID & ID -> UUID

### DIFF
--- a/public/resources/ts/common-defer.ts
+++ b/public/resources/ts/common-defer.ts
@@ -13,7 +13,10 @@ function validateURL(url: string) {
       if (urlSegments[1].match(/^[A-Za-z]+/)) {
         urlSegments[1] = urlSegments[1].charAt(0).toUpperCase() + urlSegments[1].substring(1).toLowerCase();
       } else if (!urlSegments[1].match(/^([0-9a-fA-F]{32})$/)) {
-        throw new Error(`"${urlSegments[1]}" is not a valid profile name or ID`);
+        if (urlSegments[1] === "") {
+          throw new Error(`please enter valid profile name or UUID after "/"`);
+        }
+        throw new Error(`"${urlSegments[1]}" is not a valid profile name or UUID`);
       }
     }
     if (


### PR DESCRIPTION
## Description

Fixes https://canary.discord.com/channels/738971489411399761/738990246825427084/1091066614402777209

## Examples
> Before

![image](https://user-images.githubusercontent.com/75372052/229353968-49806e29-6b76-4a33-86eb-1bc5060ab8f3.png)
> After

![image](https://user-images.githubusercontent.com/75372052/229353971-52bde195-db56-4d0a-8270-502f67cf7fbd.png)
> Before

![image](https://user-images.githubusercontent.com/75372052/229353982-527691e1-dae0-47e6-a4c0-5fe0707697c9.png)
> After

![image](https://user-images.githubusercontent.com/75372052/229353990-c782bb63-46a1-401f-becc-2c274222b4ba.png)
