### PR TITLE
fix: max `Sunder VI` -> `Sunder V` enchantment

### DIFF
--- a/common/constants/enchantments.js
+++ b/common/constants/enchantments.js
@@ -82,7 +82,7 @@ export const MAX_ENCHANTS = new Set([
   "Spiked Hook VI",
   "Strong Mana X",
   "Sugar Rush III",
-  "Sunder VI",
+  "Sunder V",
   "Syphon V",
   "Tabasco III",
   "Thorns III",


### PR DESCRIPTION
## Description

Fixes https://canary.discord.com/channels/738971489411399761/738990246825427084/1099377879747395715