### PR TITLE
fix: `/item` Endpoint not being able to return vanilla items

### DIFF
--- a/src/helper/item.js
+++ b/src/helper/item.js
@@ -11,14 +11,14 @@ import sanitize from "mongo-sanitize";
  * @returns {*} Item Data
  */
 export async function getItemData(query = {}) {
-  query = Object.assign({ skyblockId: undefined, id: undefined, name: undefined, damage: undefined }, query);
+  query = Object.assign({ skyblockId: undefined, id: undefined, name: undefined, Damage: undefined }, query);
   const item = { id: -1, damage: 0, Count: 1, tag: { ExtraAttributes: {} } };
   let dbItem = {};
 
   /**
    * Look for DB items if possible with Skyblock ID or query name
    */
-  if (query.skyblockId !== undefined) {
+  if (query.skyblockId !== undefined && query.skyblockId !== null) {
     query.skyblockId = sanitize(query.skyblockId);
 
     if (query.skyblockId.includes(":")) {
@@ -28,7 +28,7 @@ export async function getItemData(query = {}) {
       query.damage = new Number(split[1]);
     }
 
-    dbItem = (await db.collection("items").findOne({ id: query.skyblockId })) ?? {};
+    dbItem = Object.assign(item, await db.collection("items").findOne({ id: query.skyblockId }));
   }
 
   if (query.name !== undefined) {
@@ -48,10 +48,6 @@ export async function getItemData(query = {}) {
     item.id = query.id;
   }
 
-  if (query.damage !== undefined) {
-    item.Damage = query.damage;
-  }
-
   if (query.name !== undefined) {
     item.tag.display = { Name: query.name };
   }
@@ -61,7 +57,7 @@ export async function getItemData(query = {}) {
   }
 
   if ("damage" in dbItem) {
-    item.damage = dbItem.damage;
+    item.Damage = query.damage ?? dbItem.damage;
   }
 
   if ("name" in dbItem) {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -462,7 +462,7 @@ export async function renderItem(skyblockId, query) {
     itemQuery = Object.assign(query, { skyblockId });
   }
 
-  const item = await getItemData(itemQuery);
+  const item = await getItemData({ skyblockId, ...itemQuery });
   const outputTexture = { mime: "image/png" };
 
   for (const rule of itemsCss.stylesheet.rules) {

--- a/src/routes/item.js
+++ b/src/routes/item.js
@@ -1,8 +1,6 @@
 import cors from "cors";
 import express from "express";
 
-import { db } from "../mongo.js";
-
 import * as app from "../app.js";
 import * as helper from "../helper.js";
 import * as renderer from "../renderer.js";
@@ -12,12 +10,12 @@ router.use(cors());
 
 router.all("/:itemId?", cors(), async (req, res, next) => {
   try {
-    const itemId = req.params.itemId?.toUpperCase() || null;
+    const itemId = req.params.itemId || null;
     if (!req.query.pack && req.cookies.pack) {
       req.query.pack = req.cookies.pack;
     }
 
-    const item = await renderer.renderItem(itemId, req.query, db);
+    const item = await renderer.renderItem(itemId, req.query);
 
     if (item.error) {
       throw new Error(item.error);


### PR DESCRIPTION
## Description

Fixes https://canary.discord.com/channels/738971489411399761/749694587689369711/1114258396212895889
> Also fixed `Cannot read properties of null (reading 'includes')` error being thrown when trying to access endpoint without argument, Example: https://sky.shiiyu.moe/item/

## Preview
> Before

![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/9fce1e79-04ad-44a1-a49a-9864477c0bbb)

> After

![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/f94cc95a-abf4-4b0a-ad60-5b709b86a77a)
