### PR TITLE
fix: div tag missing `<`

### DIFF
--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -2196,7 +2196,7 @@ const metaDescription = getMetaDescription()
               </div>
 
               <% if (slayer.level.unclaimed){ %>
-                div class="slayer-unclaimed">unclaimed slayer rewards!</div>
+                <div class="slayer-unclaimed">unclaimed slayer rewards!</div>
               <% } %>
               
               <% max = slayer.level.currentLevel == slayer.level.maxLevel ? 'golden-text' : '' %>


### PR DESCRIPTION
## Description

Fixes https://canary.discord.com/channels/738971489411399761/738990246825427084/1121439882745757716
> https://sky.shiiyu.moe/stats/TimeDeo

## Preview

> Before

![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/ade1b88f-f4de-4993-a202-0e2ce23b0cb9)
> After

![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/3c7689dd-3603-44bd-a0c6-883ac1eaee9e)
