### PR TITLE
fix: hide kicked coop members

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -1813,7 +1813,7 @@ export async function getStats(
 
   const memberUuids = [];
   for (const [uuid, memberProfile] of Object.entries(profile.members)) {
-    if (memberProfile?.coop_invitation?.confirmed === false) {
+    if (memberProfile?.coop_invitation?.confirmed === false || memberProfile.deletion_notice?.timestamp !== undefined) {
       continue;
     }
 


### PR DESCRIPTION
## Description

Fixes https://canary.discord.com/channels/738971489411399761/738990231348314123/1127924781732335616

## Preview

> Before

![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/b7b5d126-3db3-42f4-8c7e-0f596d7c6c25)

> After

![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/753f3dbb-3b8b-4918-8a9f-f9b0fe477033)
> doesn't show anyone because both members got kicked