### PR TITLE
fix: skill average being incorrect 

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -193,7 +193,7 @@ export function getLevelByXp(xp, extra = {}) {
   const xpForNext = level < maxLevel ? Math.ceil(xpTable[level + 1]) : Infinity;
 
   /** the fraction of the way toward the next level */
-  const progress = level >= levelCap ? 1 : Math.max(0, Math.min(xpCurrent / xpForNext, 1));
+  const progress = level >= levelCap ? (extra.ignoreCap ? 1 : 0) : Math.max(0, Math.min(xpCurrent / xpForNext, 1));
 
   /** a floating point value representing the current level for example if you are half way to level 5 it would be 4.5 */
   const levelWithProgress = level + progress;


### PR DESCRIPTION
## Description

Fixes https://canary.discord.com/channels/738971489411399761/738990246825427084/1135681563749785771

## Preview

> Before

![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/06029dfb-1773-4c51-9b8e-934debd3a758)

> After 

![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/32f9a0a6-559e-4662-a8d2-ab58351e2a03)
