### PR TITLE
fix: profile switching not working because new profile_id length

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -3777,7 +3777,7 @@ export async function getProfile(
   let skyBlockProfiles = [];
 
   if (paramProfile) {
-    if (paramProfile.length == 32) {
+    if (paramProfile.length == 36) {
       skyBlockProfiles = allSkyBlockProfiles.filter((a) => a.profile_id.toLowerCase() == paramProfile);
     } else {
       skyBlockProfiles = allSkyBlockProfiles.filter((a) => a.cute_name.toLowerCase() == paramProfile);

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -741,7 +741,7 @@ const metaDescription = getMetaDescription()
           <% for(let profile_id in calculated.profiles){ %>
           <% let _profile = calculated.profiles[profile_id]; %>
           <li>
-            <a class="goto" href="/stats/<%= calculated.uuid %>/<%= _profile.cute_name %><%= Object.keys(req.query).length > 0 ? '?' + new URLSearchParams(req.query).toString() : '' %>">
+            <a class="goto" href="/stats/<%= calculated.uuid %>/<%= _profile.profile_id %><%= Object.keys(req.query).length > 0 ? '?' + new URLSearchParams(req.query).toString() : '' %>">
               <%= _profile.cute_name %>
               <% if (_profile.game_mode == 'ironman') { %>
               <img src="/resources/img/icons/ironman.png" class="emoji">

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -741,7 +741,7 @@ const metaDescription = getMetaDescription()
           <% for(let profile_id in calculated.profiles){ %>
           <% let _profile = calculated.profiles[profile_id]; %>
           <li>
-            <a class="goto" href="/stats/<%= calculated.uuid %>/<%= _profile.profile_id %><%= Object.keys(req.query).length > 0 ? '?' + new URLSearchParams(req.query).toString() : '' %>">
+            <a class="goto" href="/stats/<%= calculated.uuid %>/<%= _profile.cute_name %><%= Object.keys(req.query).length > 0 ? '?' + new URLSearchParams(req.query).toString() : '' %>">
               <%= _profile.cute_name %>
               <% if (_profile.game_mode == 'ironman') { %>
               <img src="/resources/img/icons/ironman.png" class="emoji">


### PR DESCRIPTION
## Description

https://canary.discord.com/channels/738971489411399761/738990246825427084/1143802468321476708
Hypixel added dashes to `profile_id` so that broke funcionality fully 
