### PR TITLE
fix: bestiary category title being cut out

### DIFF
--- a/public/resources/scss/stats.scss
+++ b/public/resources/scss/stats.scss
@@ -1970,6 +1970,9 @@ inventory-view {
   margin-top: 15px;
   height: 32px;
   line-height: 32px;
+  white-space: nowrap;
+  overflow-x: scroll;
+  overflow-y: hidden;
 }
 
 .category-header-maxed {


### PR DESCRIPTION
## Description

Fixes https://canary.discord.com/channels/738971489411399761/738990246825427084/1148447616888213514

## Preview

> Before

![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/194372cf-66ff-40d2-8c37-a56c0c524052)

> After

https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/d3f512b0-22e2-47a4-98a5-1b8dfb50718c