### PR TITLE
fix: bonus stats being empty

### DIFF
--- a/public/resources/ts/stats-defer.ts
+++ b/public/resources/ts/stats-defer.ts
@@ -915,6 +915,10 @@ export function formatNumber(number: number, floor: boolean, rounding = 10): str
       }
     }
 
+    if (Object.keys(bonusStats).length === 0) {
+      return;
+    }
+
     const node = document.createElement("bonus-stats");
     node.data = bonusStats;
 


### PR DESCRIPTION
## Description

Fixes https://canary.discord.com/channels/738971489411399761/738990246825427084/1150021203860389928

## Preview
> Before

![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/aa8069ac-76a1-4ade-b043-77e5d0d7727d)

> After

![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/c4b3e210-2a1f-465d-8bde-8bf4cbbbdd01)
