### PR TITLE
fix: color codes in item names

### DIFF
--- a/public/resources/ts/globals.d.ts
+++ b/public/resources/ts/globals.d.ts
@@ -696,3 +696,9 @@ interface StatBonusType {
     [key in StatName]?: number;
   };
 }
+
+type ColorCode = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "a" | "b" | "c" | "d" | "e" | "f";
+
+interface RarityColors {
+  [key: string]: ColorCode;
+}

--- a/public/resources/ts/stats-defer.ts
+++ b/public/resources/ts/stats-defer.ts
@@ -5,6 +5,7 @@ import tippy from "tippy.js";
 import { renderLore } from "../../../common/formatting.js";
 
 import { getPlayerStats } from "./calculate-player-stats";
+import { RARITY_COLORS } from "../../../common/constants.js";
 
 import("./elements/inventory-view");
 
@@ -255,11 +256,19 @@ function fillLore(element: HTMLElement) {
     return;
   }
 
+  const itemNameString = ((item as Item).tag?.display?.Name ?? item.display_name ?? "???") as string;
+  const colorCode = itemNameString.match(/^§([0-9a-fklmnor])/i);
+  if (colorCode && colorCode[1]) {
+    itemName.style.backgroundColor = `var(--§${colorCode[1]})`;
+  } else {
+    itemName.style.backgroundColor = `var(--§${(RARITY_COLORS as RarityColors)[item.rarity || "common"]})`;
+  }
+
   itemName.className = `item-name piece-${item.rarity || "common"}-bg nice-colors-dark`;
   const itemNameHtml = renderLore((item as Item).tag?.display?.Name ?? item.display_name ?? "???");
   const isMulticolor = (itemNameHtml.match(/<\/span>/g) || []).length > 1;
   itemNameContent.dataset.multicolor = String(isMulticolor);
-  itemNameContent.innerHTML = isMulticolor ? itemNameHtml : item.display_name ?? "???";
+  itemNameContent.innerHTML = isMulticolor ? itemNameHtml : itemNameString.replace(/§([0-9a-fklmnor])/gi, "") ?? "???";
 
   if (element.hasAttribute("data-pet-index")) {
     itemNameContent.dataset.multicolor = "false";


### PR DESCRIPTION
## Description

Fixes https://canary.discord.com/channels/738971489411399761/738990231348314123/1147478831838535780

## Preview

> Before

![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/ffa14eae-b7bb-43ba-80c7-1eeed3cc9056)

> After

![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/079dc975-72d5-4821-bd70-59287d7ca1ac)
![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/7daf9baa-8428-49ab-92e4-a3a3cfd4f650)
