### PR TITLE
fix: reforge name being mistaken with armor color

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -1410,7 +1410,7 @@ export const getItems = async (
           a.tag?.ExtraAttributes?.modifier == armor[0].tag.ExtraAttributes.modifier
       ).length == 4
     ) {
-      reforgeName = armor[0].display_name.split(" ")[0];
+      reforgeName = armor[0].display_name.replace(/[^A-Za-z0-9 -']/g, "").trim().split(" ")[0];
     }
 
     // Handling normal sets of armor

--- a/src/lib.js
+++ b/src/lib.js
@@ -1410,7 +1410,10 @@ export const getItems = async (
           a.tag?.ExtraAttributes?.modifier == armor[0].tag.ExtraAttributes.modifier
       ).length == 4
     ) {
-      reforgeName = armor[0].display_name.replace(/[^A-Za-z0-9 -']/g, "").trim().split(" ")[0];
+      reforgeName = armor[0].display_name
+        .replace(/[^A-Za-z0-9 -']/g, "")
+        .trim()
+        .split(" ")[0];
     }
 
     // Handling normal sets of armor


### PR DESCRIPTION
## Description

Fixes https://canary.discord.com/channels/738971489411399761/738990246825427084/1150021974324691054

## Preview

> Before

![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/19d0afc3-2c18-4ba3-9d01-5663998b1471)
> After 

![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/e0337570-d908-459e-8da5-05f23281e221)