### PR TITLE
fix: max SkyBlock Level

### DIFF
--- a/src/constants/leveling.js
+++ b/src/constants/leveling.js
@@ -1,3 +1,5 @@
+import { getHighestLeaderboardValue } from "../helper/leaderboards.js";
+
 export const LEVELING_XP = {
   1: 50,
   2: 125,
@@ -61,6 +63,11 @@ export const LEVELING_XP = {
   60: 7000000,
 };
 
+let skyblockLevelCap = Math.floor(Math.max(await getHighestLeaderboardValue("skyblock_level_xp"), 41718) / 100);
+setInterval(async () => {
+  skyblockLevelCap = Math.floor(Math.max(await getHighestLeaderboardValue("skyblock_level_xp"), 41718) / 100);
+}, 1000 * 60 * 60 * 24);
+
 export const DEFAULT_SKILL_CAPS = {
   farming: 50,
   mining: 60,
@@ -73,6 +80,8 @@ export const DEFAULT_SKILL_CAPS = {
   carpentry: 50,
   runecrafting: 25,
   social: 25,
+  dungeoneering: 50,
+  skyblock_level: skyblockLevelCap,
 };
 
 export const MAXED_SKILL_CAPS = {
@@ -186,6 +195,11 @@ export const DUNGEONEERING_XP = {
   48: 75000000,
   49: 93000000,
   50: 116250000,
+  51: 200000000,
+};
+
+export const SKYBLOCK_XP = {
+  1: 100,
 };
 
 export const GUILD_XP = [

--- a/src/helper/leaderboards.js
+++ b/src/helper/leaderboards.js
@@ -8,3 +8,12 @@ export async function getLeaderboardPosition(lb, data) {
 
   return results[0][1] || 0;
 }
+
+export async function getHighestLeaderboardValue(lb) {
+  const multi = redisClient.pipeline();
+  multi.zrange(`lb_${lb}`, -1, -1, "WITHSCORES");
+
+  const results = await multi.exec();
+
+  return results[0][1][1] || 0;
+}

--- a/src/lib.js
+++ b/src/lib.js
@@ -1034,7 +1034,6 @@ export const getItems = async (
   output.storage = storage;
   output.hotm = hotm;
   output.candy_bag = candy_bag;
-  output.museum = museum;
 
   output.bingo_card = {};
   if (bingoProfile?.events !== undefined) {

--- a/src/lib.js
+++ b/src/lib.js
@@ -329,7 +329,7 @@ async function getBackpackContents(arraybuf) {
 }
 
 // Process items returned by API
-export async function processItems(base64, source, customTextures = false, packs, cacheOnly = false) {
+async function processItems(base64, source, customTextures = false, packs, cacheOnly = false) {
   // API stores data as base64 encoded gzipped Minecraft NBT data
   const buf = Buffer.from(base64, "base64");
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -3205,7 +3205,12 @@ export async function getDungeons(userProfile, hypixelProfile) {
     output[type] = {
       id: dungeon_id,
       visited: true,
-      level: getLevelByXp(dungeon.experience, { type: "dungeoneering", skill: "dungeoneering", ignoreCap: true, infinite: true }),
+      level: getLevelByXp(dungeon.experience, {
+        type: "dungeoneering",
+        skill: "dungeoneering",
+        ignoreCap: true,
+        infinite: true,
+      }),
       highest_floor:
         dungeons_data.floors[`${type}_${highest_floor}`] && dungeons_data.floors[`${type}_${highest_floor}`].name
           ? dungeons_data.floors[`${type}_${highest_floor}`].name

--- a/src/lib.js
+++ b/src/lib.js
@@ -75,6 +75,8 @@ function getXpTable(type) {
       return constants.DUNGEONEERING_XP;
     case "hotm":
       return constants.HOTM_XP;
+    case "skyblock_level":
+      return constants.SKYBLOCK_XP;
     default:
       return constants.LEVELING_XP;
   }
@@ -142,9 +144,12 @@ function getXpByLevel(uncappedLevel, extra = {}) {
 /**
  * gets the level and some other information from an xp amount
  * @param {number} xp
- * @param {{type?: string, cap?: number, skill?: string, ignoreCap?: boolean }} extra
+ * @param {{type?: string, cap?: number, skill?: string, ignoreCap?: boolean, infinite?: boolean }} extra
  * @param type the type of levels (used to determine which xp table to use)
  * @param cap override the cap highest level the player can reach
+ * @param skill the id of the skill (used to determine the default cap)
+ * @param ignoreCap whether to ignore the in-game cap or not
+ * @param infinite repeats the last level's experience requirement infinitely
  * @param skill the key of default_skill_caps
  */
 export function getLevelByXp(xp, extra = {}) {
@@ -175,10 +180,12 @@ export function getLevelByXp(xp, extra = {}) {
     }
   }
 
-  /** adds support for catacombs level above 50 */
-  if (extra.type === "dungeoneering") {
-    uncappedLevel += Math.floor(xpCurrent / 200_000_000);
-    xpCurrent %= 200_000_000;
+  /** adds support for infinite leveling (dungeoneering and skyblock level) */
+  if (extra.infinite) {
+    const maxExperience = Object.values(xpTable).at(-1);
+
+    uncappedLevel += Math.floor(xpCurrent / maxExperience);
+    xpCurrent %= maxExperience;
   }
 
   /** the maximum level that any player can achieve (used for gold progress bars) */
@@ -192,10 +199,10 @@ export function getLevelByXp(xp, extra = {}) {
   const level = extra.ignoreCap ? uncappedLevel : Math.min(levelCap, uncappedLevel);
 
   /** the amount amount of xp needed to reach the next level (used for calculation progress to next level) */
-  const xpForNext = level < maxLevel ? Math.ceil(xpTable[level + 1]) : Infinity;
+  const xpForNext = level < maxLevel ? Math.ceil(xpTable[level + 1] ?? Object.values(xpTable).at(-1)) : Infinity;
 
   /** the fraction of the way toward the next level */
-  const progress = level >= levelCap ? (extra.ignoreCap ? 1 : 0) : Math.max(0, Math.min(xpCurrent / xpForNext, 1));
+  const progress = level >= maxLevel ? (extra.ignoreCap ? 1 : 0) : Math.max(0, Math.min(xpCurrent / xpForNext, 1));
 
   /** a floating point value representing the current level for example if you are half way to level 5 it would be 4.5 */
   const levelWithProgress = level + progress;
@@ -322,7 +329,7 @@ async function getBackpackContents(arraybuf) {
 }
 
 // Process items returned by API
-async function processItems(base64, source, customTextures = false, packs, cacheOnly = false) {
+export async function processItems(base64, source, customTextures = false, packs, cacheOnly = false) {
   // API stores data as base64 encoded gzipped Minecraft NBT data
   const buf = Buffer.from(base64, "base64");
 
@@ -1027,6 +1034,7 @@ export const getItems = async (
   output.storage = storage;
   output.hotm = hotm;
   output.candy_bag = candy_bag;
+  output.museum = museum;
 
   output.bingo_card = {};
   if (bingoProfile?.events !== undefined) {
@@ -2169,15 +2177,15 @@ export async function getStats(
     active: userProfile.nether_island_player_data?.abiphone?.active_contacts?.length || 0,
   };
 
-  output.skyblock_level = {
-    xp: userProfile.leveling?.experience || 0,
-    level: Math.floor(userProfile.leveling?.experience / 100 || 0),
-    maxLevel: 416,
-    progress: (userProfile.leveling?.experience % 100) / 100 || 0,
-    xpCurrent: userProfile.leveling?.experience % 100 || 0,
-    xpForNext: 100,
-    rank: await getLeaderboardPosition("skyblock_level_xp", userProfile.leveling?.experience || 0),
-  };
+  const skyblockExperience = userProfile.leveling?.experience ?? 0;
+  output.skyblock_level = getLevelByXp(skyblockExperience, {
+    skill: "skyblock_level",
+    type: "skyblock_level",
+    infinite: true,
+    ignoreCap: true,
+  });
+
+  output.skyblock_level.rank = await getLeaderboardPosition("skyblock_level", skyblockExperience);
 
   // MISC
 
@@ -3197,7 +3205,7 @@ export async function getDungeons(userProfile, hypixelProfile) {
     output[type] = {
       id: dungeon_id,
       visited: true,
-      level: getLevelByXp(dungeon.experience, { type: "dungeoneering", ignoreCap: true }),
+      level: getLevelByXp(dungeon.experience, { type: "dungeoneering", skill: "dungeoneering", ignoreCap: true, infinite: true }),
       highest_floor:
         dungeons_data.floors[`${type}_${highest_floor}`] && dungeons_data.floors[`${type}_${highest_floor}`].name
           ? dungeons_data.floors[`${type}_${highest_floor}`].name
@@ -3222,7 +3230,12 @@ export async function getDungeons(userProfile, hypixelProfile) {
     }
 
     output.classes[className] = {
-      experience: getLevelByXp(data.experience, { type: "dungeoneering", ignoreCap: true }),
+      experience: getLevelByXp(data.experience, {
+        type: "dungeoneering",
+        skill: "dungeoneering",
+        ignoreCap: true,
+        infinite: true,
+      }),
       current: false,
     };
 


### PR DESCRIPTION
## Description

Adds https://canary.discord.com/channels/738971489411399761/738990231348314123/1160841287587598377
Adds https://canary.discord.com/channels/738971489411399761/738990231348314123/1160841468752171089
> Gets rid of hard coding dungeoneering and skyblock level. Uses max skyblock level experience for maxLevel (no need for manual update every skyblock update)