### PR TITLE
Fix: mooshroom cow farming fortune formula

### DIFF
--- a/src/constants/pet-stats.js
+++ b/src/constants/pet-stats.js
@@ -3214,7 +3214,7 @@ class MooshroomCow extends Pet {
   get stats() {
     return {
       health: this.level * 1,
-      farming_fortune: 10 + this.level * 0.7,
+      farming_fortune: 10 + this.level * 1,
     };
   }
 


### PR DESCRIPTION
While the ability was changed from 1 -> .7 the base stats remained at 1 per level, the hypixel patch notes worded it like the base stats changed but in game the pet still gives 1 ff per level. [Missleading Patch Notes](https://hypixel.net/threads/skyblock-patch-0-19-3-crystal-hollows-qol-bug-fixes.5465058/)
>Mushroom Cow Base Stats Farming Fortune Scaling from 1 to 0.7 Farming Fortune per level

Which should probably read "Mushroom Cow Farming Fortune Scaling reduced from 1 to 0.7 Farming Fortune per 20 strength"

Screenshot in game: 
![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/94038482/b5cfc095-15f2-4e09-9833-d1c5c3deb91d)