### PR TITLE
fix: catacombs skill experience calculation

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -3222,7 +3222,6 @@ export async function getDungeons(userProfile, hypixelProfile) {
     };
 
     output[type].level.rank = await getLeaderboardPosition(`dungeons_${type}_xp`, dungeon.experience);
-    if (output[type].level.level > 50) console.log(output[type].level);
   }
 
   // Classes

--- a/src/lib.js
+++ b/src/lib.js
@@ -184,8 +184,9 @@ export function getLevelByXp(xp, extra = {}) {
   if (extra.infinite) {
     const maxExperience = Object.values(xpTable).at(-1);
 
-    uncappedLevel += Math.floor(xpCurrent / maxExperience);
-    xpCurrent %= maxExperience;
+    uncappedLevel += Math.floor(xpRemaining / maxExperience);
+    xpRemaining %= maxExperience; 
+    xpCurrent = xpRemaining;
   }
 
   /** the maximum level that any player can achieve (used for gold progress bars) */
@@ -3221,6 +3222,7 @@ export async function getDungeons(userProfile, hypixelProfile) {
     };
 
     output[type].level.rank = await getLeaderboardPosition(`dungeons_${type}_xp`, dungeon.experience);
+    if (output[type].level.level > 50) console.log(output[type].level);
   }
 
   // Classes

--- a/src/lib.js
+++ b/src/lib.js
@@ -185,7 +185,7 @@ export function getLevelByXp(xp, extra = {}) {
     const maxExperience = Object.values(xpTable).at(-1);
 
     uncappedLevel += Math.floor(xpRemaining / maxExperience);
-    xpRemaining %= maxExperience; 
+    xpRemaining %= maxExperience;
     xpCurrent = xpRemaining;
   }
 


### PR DESCRIPTION
## Description

Fixes https://discord.com/channels/738971489411399761/738990246825427084/1167645238643408977
> Used `xpCurrent` instead of `xpRemaining`