### PR TITLE
refactor: remove `Math.max()` for skyblockLevelCap

### DIFF
--- a/src/constants/leveling.js
+++ b/src/constants/leveling.js
@@ -63,9 +63,9 @@ export const LEVELING_XP = {
   60: 7000000,
 };
 
-let skyblockLevelCap = Math.floor(Math.max(await getHighestLeaderboardValue("skyblock_level_xp"), 41718) / 100);
+let skyblockLevelSkillCap = Math.floor((await getHighestLeaderboardValue("skyblock_level_xp")) / 100);
 setInterval(async () => {
-  skyblockLevelCap = Math.floor(Math.max(await getHighestLeaderboardValue("skyblock_level_xp"), 41718) / 100);
+  skyblockLevelSkillCap = Math.floor((await getHighestLeaderboardValue("skyblock_level_xp")) / 100);
 }, 1000 * 60 * 60 * 24);
 
 export const DEFAULT_SKILL_CAPS = {
@@ -81,7 +81,7 @@ export const DEFAULT_SKILL_CAPS = {
   runecrafting: 25,
   social: 25,
   dungeoneering: 50,
-  skyblock_level: skyblockLevelCap,
+  skyblock_level: skyblockLevelSkillCap,
 };
 
 export const MAXED_SKILL_CAPS = {


### PR DESCRIPTION
## Description

Does https://discord.com/channels/738971489411399761/738990246825427084/1167899407690240110
> New max level exists, top player alr reached it so this is useless (and there's 0% chance of us updating that value after every update drops so yeah..)