### PR TITLE
fix: skyblock level gold bar maxed at lvl instead of xp

### DIFF
--- a/public/resources/ts/globals.d.ts
+++ b/public/resources/ts/globals.d.ts
@@ -163,6 +163,7 @@ interface Level {
   levelWithProgress: number;
   rank?: number;
   unlockableLevelWithProgress: number;
+  maxExperience?: number;
 }
 
 declare namespace constants {

--- a/src/constants/leveling.js
+++ b/src/constants/leveling.js
@@ -68,6 +68,11 @@ setInterval(async () => {
   skyblockLevelSkillCap = Math.floor((await getHighestLeaderboardValue("skyblock_level_xp")) / 100);
 }, 1000 * 60 * 60 * 24);
 
+let skyblockLevelMaxExperience = (await getHighestLeaderboardValue("skyblock_level_xp")) % 100;
+setInterval(async () => {
+  skyblockLevelMaxExperience = (await getHighestLeaderboardValue("skyblock_level_xp")) % 100;
+}, 1000 * 60 * 60 * 24);
+
 export const DEFAULT_SKILL_CAPS = {
   farming: 50,
   mining: 60,
@@ -86,6 +91,10 @@ export const DEFAULT_SKILL_CAPS = {
 
 export const MAXED_SKILL_CAPS = {
   farming: 60,
+};
+
+export const MAXED_SKILL_XP = {
+  skyblock_level: skyblockLevelMaxExperience,
 };
 
 export const RUNECRAFTING_XP = {

--- a/src/lib.js
+++ b/src/lib.js
@@ -193,6 +193,9 @@ export function getLevelByXp(xp, extra = {}) {
   const maxLevel =
     extra.ignoreCap && uncappedLevel >= levelCap ? uncappedLevel : constants.MAXED_SKILL_CAPS[extra.skill] ?? levelCap;
 
+  /** the maximum amount of experience that any player can acheive (used for skyblock level gold progress bar) */
+  const maxExperience = constants.MAXED_SKILL_XP[extra.skill];
+
   // not sure why this is floored but I'm leaving it in for now
   xpCurrent = Math.floor(xpCurrent);
 
@@ -200,7 +203,8 @@ export function getLevelByXp(xp, extra = {}) {
   const level = extra.ignoreCap ? uncappedLevel : Math.min(levelCap, uncappedLevel);
 
   /** the amount amount of xp needed to reach the next level (used for calculation progress to next level) */
-  const xpForNext = level < maxLevel ? Math.ceil(xpTable[level + 1] ?? Object.values(xpTable).at(-1)) : Infinity;
+  const xpForNext =
+    level < maxLevel ? Math.ceil(xpTable[level + 1] ?? Object.values(xpTable).at(-1)) : maxExperience ?? Infinity;
 
   /** the fraction of the way toward the next level */
   const progress = level >= maxLevel ? (extra.ignoreCap ? 1 : 0) : Math.max(0, Math.min(xpCurrent / xpForNext, 1));
@@ -211,11 +215,14 @@ export function getLevelByXp(xp, extra = {}) {
   /** a floating point value representing the current level ignoring the in-game unlockable caps for example if you are half way to level 5 it would be 4.5 */
   const unlockableLevelWithProgress = extra.cap ? Math.min(uncappedLevel + progress, maxLevel) : levelWithProgress;
 
+  console.log(xpForNext);
+
   return {
     xp,
     level,
     maxLevel,
     xpCurrent,
+    maxExperience,
     xpForNext,
     progress,
     levelCap,


### PR DESCRIPTION
## Description

Fixes https://canary.discord.com/channels/738971489411399761/738990231348314123/1169378435706134588

## Preview

> Before

![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/e86fa198-6ceb-46a7-899b-b8eded438b81)

> After

![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/212245e3-0703-4a7b-ae00-e90e1ce6a5a2)
