### PR TITLE
fix: boss collections being incorrect and missing info

### DIFF
--- a/src/constants/collections.js
+++ b/src/constants/collections.js
@@ -227,4 +227,30 @@ export const BOSS_COLLECTIONS = [
       },
     ],
   },
+  {
+    name: "Kuudra",
+    texture: "/head/82ee25414aa7efb4a2b4901c6e33e5eaa705a6ab212ebebfd6a4de984125c7a0",
+    rewards: [
+      {
+        name: "Kuudra Pet",
+        required: 10,
+      },
+      {
+        name: "Kuudra Chunk",
+        required: 100,
+      },
+      {
+        name: "Meaty Kuudra Chunk",
+        required: 500,
+      },
+      {
+        name: "Hardened Kuudra Chunk",
+        required: 2000,
+      },
+      {
+        name: "Enriched Kuudra Chunk",
+        required: 5000,
+      },
+    ],
+  },
 ];

--- a/src/stats/collections.js
+++ b/src/stats/collections.js
@@ -119,13 +119,20 @@ function getBossCollections(dungeons, kuudra) {
 
     const { name, texture } = collection;
 
-    const amount = bossCompletions[index] ?? 0;
+    let amount = bossCompletions[index] ?? 0;
+    if (name === "Kuudra" && kuudra?.kuudra?.tiers !== undefined) {
+      amount = Object.values(kuudra.kuudra.tiers).reduce((a, b, index) => {
+        return a + (index + 1) * b.completions;
+      }, 0);
+    }
 
     const maxAmount = collection.rewards[collection.rewards.length - 1]?.required;
 
     const tier = collection.rewards.filter((a) => a.required <= amount).length ?? 0;
 
     const maxTier = collection.rewards.length;
+
+    const rewards = collection.rewards.filter((reward) => reward.required <= amount);
 
     output.push({
       name,
@@ -134,21 +141,7 @@ function getBossCollections(dungeons, kuudra) {
       maxAmount,
       tier,
       maxTier,
-    });
-  }
-
-  if (kuudra?.kuudra?.tiers) {
-    const completions = Object.values(kuudra.kuudra.tiers).reduce((a, b, index) => {
-      return a + (index + 1) * b.completions;
-    }, 0);
-
-    output.push({
-      name: "Kuudra",
-      texture: "/head/82ee25414aa7efb4a2b4901c6e33e5eaa705a6ab212ebebfd6a4de984125c7a0",
-      amount: completions,
-      maxAmount: 5000,
-      tier: Math.min(Math.floor(completions / 500), 5), // TODO: Fix this (it's not accurate)
-      maxTier: 5,
+      rewards,
     });
   }
 

--- a/views/sections/stats/collections.ejs
+++ b/views/sections/stats/collections.ejs
@@ -29,7 +29,13 @@
 
           if (collection.amounts !== undefined) { 
             amountsTooltip = collection.amounts.map(amount => `<span class="stat-name">${amount.username}: </span><span class="stat-value">${amount.amount.toLocaleString()}</span>`).join('<br>') + `<br><br><span class="stat-name">Total: </span><span class="stat-value">${collection.totalAmount.toLocaleString()}</span>`;
+          } else if (collection.rewards !== undefined) {
+            amountsTooltip = `<span class="stat-name">Rewards:</span>`;
+            for (const reward of collection.rewards) {
+              amountsTooltip += `<br><span class="stat-value">- ${reward.name}</span>`;
+            }
           } %>
+
           <div class="chip" data-tippy-content='<%= amountsTooltip %>' data-missing="<%= collection.totalAmount === 0 %>">
             <div class="chip-icon-wrapper">
               <div style="background-image:url(<%= collection.texture %>)" class="item-icon custom-icon"></div>


### PR DESCRIPTION
## Description

Fixes wrong tier calculation for Kuudra colleciton and adds back rewards on hover

## Preview

![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/f8f4a46b-2700-41f5-9f68-9b5cb9f8da4e)
