### PR TITLE
fix: dwarven mines data being hidden if player hasn't entered c hollows

### DIFF
--- a/views/sections/stats/skills/mining.ejs
+++ b/views/sections/stats/skills/mining.ejs
@@ -79,7 +79,7 @@ function itemIcon(item, classes) { %>
     </div>
   <% } %>
 
-  <% if (mining.core === undefined || calculated.visited_modes.includes("crystal_hollows") === false || calculated.visited_modes.includes("mining_3") === false) { %>
+  <% if (mining.core === undefined || (calculated.visited_modes.includes("crystal_hollows") === false && calculated.visited_modes.includes("mining_3") === false)) { %>
     <p class="no-access">
       <%= calculated.display_name %> hasn't visited Dwarven Mines or Crystal Hollows yet.
     </p>


### PR DESCRIPTION
## Description

Fixes https://canary.discord.com/channels/738971489411399761/738990246825427084/1180053888586502175

## Preview

> Before

![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/de404424-74dd-4046-9126-53ac448e8c10)

> After 

![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/f9386f1b-f9d1-4b5c-b258-2df5c68e15b4)
