### PR TITLE
[URGENT] fix: museum lore causing memory leaks

### DIFF
--- a/src/stats/items/museum.js
+++ b/src/stats/items/museum.js
@@ -114,7 +114,8 @@ export async function getMuseumItems(profile, customTextures, packs, options = {
     output[i] = helper.generateItem({ id: undefined });
   }
 
-  for (const item of constants.MUSEUM.inventory) {
+  for (const itemData of constants.MUSEUM.inventory) {
+    const item = _.cloneDeep(itemData);
     updateMuseumItemProgress(item, museum);
 
     output[item.position] = helper.generateItem(item);


### PR DESCRIPTION
## Description

Fixes https://canary.discord.com/channels/738971489411399761/738990246825427084/1188411718469165066
> Not confirmed but yeah, if it would add 3 lines to description on each profile load (any) that would make memory increase by quite a lot after some time

