### PR TITLE
fix: rarity order in auctions

### DIFF
--- a/src/stats/misc.js
+++ b/src/stats/misc.js
@@ -270,6 +270,18 @@ export function getMisc(profile, userProfile, hypixelProfile) {
 
   if ("auctions" in userProfile.player_stats) {
     misc.auctions = userProfile.player_stats.auctions;
+    
+    misc.auctions.total_sold = Object.entries(misc.auctions.total_sold)
+      .sort((a, b) => {
+        return constants.RARITIES.indexOf(a[0].toLowerCase()) - constants.RARITIES.indexOf(b[0].toLowerCase());
+      })
+      .reduce((obj, [key, value]) => ({ ...obj, [key]: value }), {});
+
+    misc.auctions.total_bought = Object.entries(misc.auctions.total_bought)
+      .sort((a, b) => {
+        return constants.RARITIES.indexOf(a[0].toLowerCase()) - constants.RARITIES.indexOf(b[0].toLowerCase());
+      })
+      .reduce((obj, [key, value]) => ({ ...obj, [key]: value }), {});
   }
 
   if (hypixelProfile.claimed_items) {

--- a/src/stats/misc.js
+++ b/src/stats/misc.js
@@ -270,7 +270,7 @@ export function getMisc(profile, userProfile, hypixelProfile) {
 
   if ("auctions" in userProfile.player_stats) {
     misc.auctions = userProfile.player_stats.auctions;
-    
+
     misc.auctions.total_sold = Object.entries(misc.auctions.total_sold)
       .sort((a, b) => {
         return constants.RARITIES.indexOf(a[0].toLowerCase()) - constants.RARITIES.indexOf(b[0].toLowerCase());

--- a/views/sections/stats/misc/auctions.ejs
+++ b/views/sections/stats/misc/auctions.ejs
@@ -28,6 +28,10 @@
     <% if (calculated.misc.auctions.total_sold !== undefined) { %>
       <% let tooltip = "";
       for (const [rarity, amount] of Object.entries(calculated.misc.auctions.total_sold)) {
+        if (rarity === "total") {
+          continue;
+        }
+
         tooltip += `
           <span class="stat-name piece-${rarity.toLowerCase()}-fg">${helper.capitalizeFirstLetter(rarity)}: </span>
           <span class="stat-value">${amount.toLocaleString()}</span>
@@ -87,6 +91,10 @@
     <% if (calculated.misc.auctions.total_bought !== undefined) { %>
       <% tooltip = "";
       for (const [rarity, amount] of Object.entries(calculated.misc.auctions.total_bought)) {
+        if (rarity === "total") {
+          continue;
+        }
+        
         tooltip += `
           <span class="stat-name piece-${rarity.toLowerCase()}-fg">${helper.capitalizeFirstLetter(rarity)}: </span>
           <span class="stat-value">${amount.toLocaleString()}</span>


### PR DESCRIPTION
## Description

Fixes https://canary.discord.com/channels/738971489411399761/1185051678630740063/1185051683345141940

## Preview

![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/72bd2373-40d1-4e20-b23b-fbad0e73f5e7)

![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/1ad99b0d-fc9a-4124-ad63-2a951edd8eda)
