### PR TITLE
fix: hide Uncategorized values if they're 0

### DIFF
--- a/views/sections/stats/misc/uncategorized.ejs
+++ b/views/sections/stats/misc/uncategorized.ejs
@@ -8,7 +8,11 @@
   </div>
 
   <p class="stat-raw-values">
-    <% for (const [key, value] of Object.entries(calculated.misc.uncategorized)) { %>
+    <% for (const [key, value] of Object.entries(calculated.misc.uncategorized)) {
+      if (value.raw === 0) {
+        continue;
+      } %>
+
       <% max = value.maxed === true ? 'golden-text': '' %>
       <span class="stat-name <%= max %>"><%= helper.capitalizeFirstLetter(key.split("_").join(" ")); %>: </span>
       <span class="stat-value <%= max %>"><%= value.formatted %> </span>


### PR DESCRIPTION
## Descripiton

Fixes https://canary.discord.com/channels/738971489411399761/738990246825427084/1188961189473026078

## Preview

![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/de930c96-d177-422f-8969-b26fe483e4f4)
