### PR TITLE
fix: formatLore() not working on specific cases

### DIFF
--- a/common/formatting.js
+++ b/common/formatting.js
@@ -37,7 +37,7 @@ export function renderLore(text) {
   const formats = new Set();
 
   // @ts-ignore - this regex always matches so we don't need to check for null
-  for (let part of text.match(/(§[0-9A-Fa-fk-orLl])*[^§]*/g)) {
+  for (let part of text.match(/(§[0-9A-Fa-fk-orL])*[^§]*/g)) {
     formats.clear();
     while (part.charAt(0) === "§") {
       const code = part.charAt(1).toLowerCase();

--- a/common/formatting.js
+++ b/common/formatting.js
@@ -37,7 +37,7 @@ export function renderLore(text) {
   const formats = new Set();
 
   // @ts-ignore - this regex always matches so we don't need to check for null
-  for (let part of text.match(/(§[0-9A-Fa-fk-or])*[^§]*/g)) {
+  for (let part of text.match(/(§[0-9A-Fa-fk-orLl])*[^§]*/g)) {
     formats.clear();
     while (part.charAt(0) === "§") {
       const code = part.charAt(1).toLowerCase();


### PR DESCRIPTION
## Description

Fixes issue with regex (*Hypixel moment cough cough-*


## Preview
> Before

![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/9dd6474b-7744-4c95-9b86-2ceceef9cddc)
> After

![image](https://github.com/SkyCryptWebsite/SkyCrypt/assets/75372052/737594bb-716b-4318-abc4-cb52d7ca41fd)
