### PR TITLE
Fix max level for Rainbow enchant

### DIFF
--- a/common/constants/enchantments.js
+++ b/common/constants/enchantments.js
@@ -68,6 +68,8 @@ export const MAX_ENCHANTS = new Set([
   "Protection VII",
   "Punch II",
   "Quantum V",
+  "Rainbow I",
+  "Rainbow II",
   "Rainbow III",
   "Reflection V",
   "Rejuvenate V",

--- a/common/constants/enchantments.js
+++ b/common/constants/enchantments.js
@@ -68,7 +68,7 @@ export const MAX_ENCHANTS = new Set([
   "Protection VII",
   "Punch II",
   "Quantum V",
-  "Rainbow I",
+  "Rainbow III",
   "Reflection V",
   "Rejuvenate V",
   "Replenish I",


### PR DESCRIPTION
Rainbow II and III exist, though it's basically just for fun beyond I, with II being once per profile and III being century raffle exclusive (but it generally sells for very cheap on AH for normal profiles), so not sure if y'all want to mark any lower levels as "max" or this is fine, up to y'all.