### PR TITLE
fix: fixed issue with stats calculator

### DIFF
--- a/public/resources/ts/calculate-player-stats.ts
+++ b/public/resources/ts/calculate-player-stats.ts
@@ -49,7 +49,7 @@ export function getPlayerStats() {
 
   // Bestiary
   if (calculated.bestiary?.milestone !== undefined) {
-    stats.strength.bestiary = calculated.bestiary.milestone * 2;
+    stats.health.bestiary = Math.floor(calculated.bestiary.milestone / 10);
   }
 
   // Unique Pets


### PR DESCRIPTION
Currently, the stats calculator adds the Bestiary milestone value multiplied by twenty to strength, and no value from the Bestiary to health:
<img width="1333" alt="Screenshot 2024-03-07 at 9 18 24 PM" src="https://github.com/SkyCryptWebsite/SkyCrypt/assets/68354378/afaeb36b-411f-45f4-bb22-6f1229354917">
<img width="1333" alt="Screenshot 2024-03-07 at 9 18 36 PM" src="https://github.com/SkyCryptWebsite/SkyCrypt/assets/68354378/18ea06f4-18b3-421a-b4bf-479d22541d45">

This does not match the in game behavior, where no value from the Bestiary milestone is added to strength, and the Bestiary milestone value is directly added to health stat. This is the fix I have made, which can be observed in the screenshots below. The fix makes the calculator's behavior more closely match that of the game.
<img width="1335" alt="Screenshot 2024-03-07 at 9 18 47 PM" src="https://github.com/SkyCryptWebsite/SkyCrypt/assets/68354378/30d37335-b79f-4e97-8107-3c6dddf42fea">
<img width="1337" alt="Screenshot 2024-03-07 at 9 18 58 PM" src="https://github.com/SkyCryptWebsite/SkyCrypt/assets/68354378/f1bb3424-8bd8-4e7c-bb8b-942f29e94c2a">
