### PR TITLE
Fix rank plus background gap

### DIFF
--- a/includes/header.ejs
+++ b/includes/header.ejs
@@ -66,7 +66,7 @@
           <ul>
             <li><a rel="noreferrer" href="https://github.com/Senither/hypixel-skyblock-facade" target="_blank">Hypixel SkyBlock Facade</a> by <span class="name">Senither</span></li>
             <li><a rel="noreferrer" href="https://github.com/Antonio32A/lilyweight" target="_blank">lilyweight</a> by <span class="name">LappySheep</span> and <span class="name">Antonio32A</span></li>
-            <li><a rel="noreferrer" href="https://elitebot.dev/" target="_blank">Farming Weight</a> by <span class="name">Elite</span></li>
+            <li><a rel="noreferrer" href="https://elitebot.dev/" target="_blank">Farming Weight</a> by <span class="name">Elite Farmers</span></li>
           </ul>
         </li>
         <li>Networth: <a rel="noreferrer" href="https://www.npmjs.com/package/skyhelper-networth" target="_blank">SkyHelper Networth</a> by <span class="name">SkyHelper</span></li>

--- a/public/resources/scss/stats.scss
+++ b/public/resources/scss/stats.scss
@@ -482,7 +482,7 @@
       z-index: -1;
       position: absolute;
       top: 0;
-      bottom: 0;
+      bottom: -4px;
       left: -7px;
       right: 0;
       transform: skew(-20deg);


### PR DESCRIPTION
This is a very small change that hopefully fixes the annoying pixel bug on the rank plus color background.

I can reproduce this bug on one of my monitors consistently, the others it doesn't show up on. This fix doesn't seem to affect the look of it on screens that don't display the issue for me.

Before         |  After
:-------------------------:|:-------------------------:
![image](https://github.com/user-attachments/assets/21c140c7-a749-4b29-8a70-66ab2eb72744) |  ![image](https://github.com/user-attachments/assets/652eeab9-15a2-49c1-8c41-46999485683b)


I'm sure a better solution is possible, but this seems to fix it for me and I tested at different scaling and resolutions, and it looks good in all of them.

(Also, I changed my credit of "Farming Weight by Elite" to "Farming Weight by Elite Farmers" because that sounds better I think)