### PR TITLE
Add cache times to credentials.json

### DIFF
--- a/src/cachetimes.js
+++ b/src/cachetimes.js
@@ -1,0 +1,47 @@
+import credentials from './credentials.js';
+
+/**
+ * Check if a resource is expired based on the cache time
+ * @param {number} unixMs Unix timestamp in milliseconds
+ * @param {number} cacheTime The cache time in seconds
+ * @returns {boolean} Whether the cache is expired
+ */
+export function isCacheExpired(unixMs, cacheTime) {
+  return Date.now() - unixMs > cacheTime * 1000;
+}
+
+/**
+ * Check if a profile cache is expired based on the configured cache time
+ * @param {number} unixMs Unix timestamp in milliseconds
+ * @returns {boolean} Whether the cache is expired
+ */
+export function isProfileCacheExpired(unixMs) {
+  return isCacheExpired(unixMs, credentials.cache.profiles);
+}
+
+/**
+ * Check if a museum cache is expired based on the configured cache time
+ * @param {number} unixMs Unix timestamp in milliseconds
+ * @returns {boolean} Whether the cache is expired
+ */
+export function isMuseumCacheExpired(unixMs) {
+  return isCacheExpired(unixMs, credentials.cache.museum);
+}
+
+/**
+ * Check if a guild cache is expired based on the configured cache time
+ * @param {number} unixMs Unix timestamp in milliseconds
+ * @returns {boolean} Whether the cache is expired
+ */
+export function isGuildCacheExpired(unixMs) {
+  return isCacheExpired(unixMs, credentials.cache.guild);
+}
+
+/**
+ * Check if a bingo profile cache is expired based on the configured cache time
+ * @param {number} unixMs Unix timestamp in milliseconds
+ * @returns {boolean} Whether the cache is expired
+ */
+export function isBingoProfileCacheExpired(unixMs) {
+  return isCacheExpired(unixMs, credentials.cache.bingoProfiles);
+}

--- a/src/cachetimes.js
+++ b/src/cachetimes.js
@@ -16,7 +16,7 @@ export function isCacheExpired(unixMs, cacheTime) {
  * @returns {boolean} Whether the cache is expired
  */
 export function isProfileCacheExpired(unixMs) {
-  return isCacheExpired(unixMs, credentials.cache.profiles);
+  return isCacheExpired(unixMs, credentials.cacheSeconds.profiles);
 }
 
 /**
@@ -25,7 +25,7 @@ export function isProfileCacheExpired(unixMs) {
  * @returns {boolean} Whether the cache is expired
  */
 export function isMuseumCacheExpired(unixMs) {
-  return isCacheExpired(unixMs, credentials.cache.museum);
+  return isCacheExpired(unixMs, credentials.cacheSeconds.museum);
 }
 
 /**
@@ -34,7 +34,7 @@ export function isMuseumCacheExpired(unixMs) {
  * @returns {boolean} Whether the cache is expired
  */
 export function isGuildCacheExpired(unixMs) {
-  return isCacheExpired(unixMs, credentials.cache.guild);
+  return isCacheExpired(unixMs, credentials.cacheSeconds.guild);
 }
 
 /**
@@ -43,5 +43,5 @@ export function isGuildCacheExpired(unixMs) {
  * @returns {boolean} Whether the cache is expired
  */
 export function isBingoProfileCacheExpired(unixMs) {
-  return isCacheExpired(unixMs, credentials.cache.bingoProfiles);
+  return isCacheExpired(unixMs, credentials.cacheSeconds.bingoProfiles);
 }

--- a/src/cachetimes.js
+++ b/src/cachetimes.js
@@ -1,4 +1,4 @@
-import credentials from './credentials.js';
+import credentials from "./credentials.js";
 
 /**
  * Check if a resource is expired based on the cache time

--- a/src/credentials.js
+++ b/src/credentials.js
@@ -23,8 +23,8 @@ const defaultCredentials = {
     profiles: 60 * 5, // 5 minutes
     bingoProfile: 60 * 5, // 5 minutes
     museum: 60 * 30, // 30 minutes
-    guild: 60 * 60 * 24 // 24 hours
-  }
+    guild: 60 * 60 * 24, // 24 hours
+  },
 };
 
 /**

--- a/src/credentials.js
+++ b/src/credentials.js
@@ -56,6 +56,15 @@ for (const key in defaultCredentials) {
     CREDENTIALS[key] = defaultCredentials[key];
     hasBeenModified = true;
   }
+
+  if (typeof defaultCredentials[key] === "object") {
+    for (const subKey in defaultCredentials[key]) {
+      if (CREDENTIALS[key][subKey] == undefined) {
+        CREDENTIALS[key][subKey] = defaultCredentials[key][subKey];
+        hasBeenModified = true;
+      }
+    }
+  }
 }
 
 if (hasBeenModified) {

--- a/src/credentials.js
+++ b/src/credentials.js
@@ -19,7 +19,7 @@ const defaultCredentials = {
   get session_secret() {
     return randomBytes(32).toString("hex");
   },
-  cache: {
+  cacheSeconds: {
     profiles: 60 * 5, // 5 minutes
     bingoProfile: 60 * 5, // 5 minutes
     museum: 60 * 30, // 30 minutes
@@ -88,19 +88,19 @@ if (process.env.DISCORD_WEBHOOK) {
 }
 
 if (process.env.CACHE_PROFILES && isFinite(parseInt(process.env.CACHE_PROFILES))) {
-  CREDENTIALS.cache.profiles = parseInt(process.env.CACHE_PROFILES);
+  CREDENTIALS.cacheSeconds.profiles = parseInt(process.env.CACHE_PROFILES);
 }
 
 if (process.env.CACHE_MUSEUM && isFinite(parseInt(process.env.CACHE_MUSEUM))) {
-  CREDENTIALS.cache.museum = parseInt(process.env.CACHE_MUSEUM);
+  CREDENTIALS.cacheSeconds.museum = parseInt(process.env.CACHE_MUSEUM);
 }
 
 if (process.env.CACHE_GUILD && isFinite(parseInt(process.env.CACHE_GUILD))) {
-  CREDENTIALS.cache.guild = parseInt(process.env.CACHE_GUILD);
+  CREDENTIALS.cacheSeconds.guild = parseInt(process.env.CACHE_GUILD);
 }
 
 if (process.env.CACHE_BINGO_PROFILE && isFinite(parseInt(process.env.CACHE_BINGO_PROFILE))) {
-  CREDENTIALS.cache.bingoProfile = parseInt(process.env.CACHE_BINGO_PROFILE);
+  CREDENTIALS.cacheSeconds.bingoProfile = parseInt(process.env.CACHE_BINGO_PROFILE);
 }
 
 export default CREDENTIALS;

--- a/src/credentials.js
+++ b/src/credentials.js
@@ -19,6 +19,12 @@ const defaultCredentials = {
   get session_secret() {
     return randomBytes(32).toString("hex");
   },
+  cache: {
+    profiles: 60 * 5, // 5 minutes
+    bingoProfile: 60 * 5, // 5 minutes
+    museum: 60 * 30, // 30 minutes
+    guild: 60 * 60 * 24 // 24 hours
+  }
 };
 
 /**
@@ -70,6 +76,22 @@ if (process.env.REDIS_CONNECTION_STRING) {
 
 if (process.env.DISCORD_WEBHOOK) {
   CREDENTIALS.discord_webhook = process.env.DISCORD_WEBHOOK;
+}
+
+if (process.env.CACHE_PROFILES && isFinite(parseInt(process.env.CACHE_PROFILES))) {
+  CREDENTIALS.cache.profiles = parseInt(process.env.CACHE_PROFILES);
+}
+
+if (process.env.CACHE_MUSEUM && isFinite(parseInt(process.env.CACHE_MUSEUM))) {
+  CREDENTIALS.cache.museum = parseInt(process.env.CACHE_MUSEUM);
+}
+
+if (process.env.CACHE_GUILD && isFinite(parseInt(process.env.CACHE_GUILD))) {
+  CREDENTIALS.cache.guild = parseInt(process.env.CACHE_GUILD);
+}
+
+if (process.env.CACHE_BINGO_PROFILE && isFinite(parseInt(process.env.CACHE_BINGO_PROFILE))) {
+  CREDENTIALS.cache.bingoProfile = parseInt(process.env.CACHE_BINGO_PROFILE);
 }
 
 export default CREDENTIALS;

--- a/src/lib.js
+++ b/src/lib.js
@@ -277,9 +277,7 @@ export async function getProfile(
 
   const lastCachedSave = profileObject.last_update;
 
-  if (
-    !options.cacheOnly && (cacheTimes.isProfileCacheExpired(lastCachedSave) || lastCachedSave === 0)
-  ) {
+  if (!options.cacheOnly && (cacheTimes.isProfileCacheExpired(lastCachedSave) || lastCachedSave === 0)) {
     try {
       profileObject.last_update = Date.now();
       response = await retry(
@@ -501,9 +499,7 @@ export async function getBingoProfile(
   };
 
   const lastCachedSave = profileData.last_save ?? 0;
-  if (
-    !options.cacheOnly && (cacheTimes.isBingoProfileCacheExpired(lastCachedSave) || lastCachedSave === 0)
-  ) {
+  if (!options.cacheOnly && (cacheTimes.isBingoProfileCacheExpired(lastCachedSave) || lastCachedSave === 0)) {
     try {
       const response = await retry(
         async () => {


### PR DESCRIPTION
Adds configurable cache times (in seconds) to the credentials file. 

While I don't really think the credentials file is a great place for this, there's not really a better spot and this functionality definitely needed to go somewhere.

I also added a `cachetimes.js` file which exports helper functions to check if a cache on a specific resource is expired. These functions are then used to make the cache checks in `lib.js` much easier to understand.

Default cache times might want to be changed, there were some very confusing checks that I replaced with this PR, so make sure to double-check those.

Right now they're defined in the credentials file like this:
```js
cacheSeconds: {
  profiles: 60 * 5, // 5 minutes
  bingoProfile: 60 * 5, // 5 minutes
  museum: 60 * 30, // 30 minutes
  guild: 60 * 60 * 24, // 24 hours
},
```