### PR TITLE
Replace Plancke integration with nadeshiko

### DIFF
--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -466,8 +466,8 @@ const metaDescription = getMetaDescription()
 
         <guild-button class="additional-player-stat"></guild-button>
 
-        <!-- Placnke Button-->
-        <a href="https://plancke.io/hypixel/player/stats/<%= calculated.display_name %>" target="_blank" rel="noreferrer" class="additional-player-stat external-link">Plancke</a>
+        <!-- nadeshiko Button-->
+        <a href="https://nadeshiko.io/player/<%= calculated.display_name %>" target="_blank" rel="noreferrer" class="additional-player-stat external-link">nadeshiko</a>
 
         <!-- Elite Button-->
         <a href="https://elitebot.dev/@<%= calculated.display_name %>/<%= calculated.profile.profile_id  %>" target="_blank" rel="noreferrer" class="additional-player-stat external-link">Elite</a>


### PR DESCRIPTION
I propose replacing the Plancke integration on SkyCrypt with an integration to the Hypixel stats site [nadeshiko](https://nadeshiko.io). nadeshiko is a more modern, accessible, feature-rich, and efficient alternative to Plancke.

Plancke is often slow to update with new games, and is missing some features/stats entirely in some places. For example, Plancke is missing Pit entirely, a game which many SkyBlock players also enjoy. Plancke is missing many important features when compared to nadeshiko, such as questing and a good cards system. 

In testing, nadeshiko is much faster and more efficient than Plancke. nadeshiko updates almost instantly with new games and achievements, and it shares a similar design language to SkyCrypt, making it a more sensible integration.  


_Full disclosure: I am a developer of the nadeshiko project._