### PR TITLE
fix: Core of the Mountain showing incorrect powder type

### DIFF
--- a/src/constants/hotm.js
+++ b/src/constants/hotm.js
@@ -1282,7 +1282,7 @@ class CoreOfTheMountain extends Node {
     this.name = nodeNames[this.id];
     this.position = 49;
     this.max_level = 10;
-    this.upgrade_type = data.level < 4 ? "mithril_powder" : data.level < 8 ? "gemstone_powder" : "glacite_powder"; // Mithril -> 1-3, Gemstone -> 4-7, Glacite -> 8-10
+    this.upgrade_type = data.level < 3 ? "mithril_powder" : data.level < 7 ? "gemstone_powder" : "glacite_powder"; // Mithril -> 1-3, Gemstone -> 4-7, Glacite -> 8-10
     this.requires = ["mole" /*, "keep_it_cool"*/];
     this.nodeType = "special";
     this.positionType = "peak_of_the_mountain";


### PR DESCRIPTION
Fixes an oversight in #2287 where the thresholds for determining the powder type were incorrect.
Adjusts the levels at which Mithril, Gemstone, and Glacite powder types are shown.
![image](https://github.com/user-attachments/assets/9a4663ad-3818-4c59-a9d3-85b1769a7554)
![image](https://github.com/user-attachments/assets/71aa1b14-2ed8-42d4-9e93-cf2f1095bfe5)