### PR TITLE
Add new Bal stats + fix cold resistance typo

### DIFF
--- a/common/constants/stats.js
+++ b/common/constants/stats.js
@@ -358,10 +358,10 @@ export const STATS_DATA = {
     nameTiny: "SR",
     symbol: "Ⓢ",
   },
-  cold_resistence: {
-    name: "Cold Resistence",
-    nameLore: "Cold Resistence",
-    nameShort: "Cold Resistence",
+  cold_resistance: {
+    name: "Cold Resistance",
+    nameLore: "Cold Resistance",
+    nameShort: "Cold Resistance",
     nameTiny: "CR",
     symbol: "❄",
   },

--- a/src/constants/hotm.js
+++ b/src/constants/hotm.js
@@ -918,7 +918,7 @@ class WarmHeart extends Node {
 
   perk(level) {
     const val = round(level * 0.4, 1);
-    return [`§7Grants §b+${val} ${SYMBOLS.cold_resistence} Cold Resistance§7.`];
+    return [`§7Grants §b+${val} ${SYMBOLS.cold_resistance} Cold Resistance§7.`];
   }
 }
 
@@ -967,7 +967,7 @@ class MineshaftMayhem extends Node {
       "§8 ■ §a+5% §7chance to find a §9Suspicious Scrap§7.",
       `§8 ■ §7Gain §6+100 ${SYMBOLS.mining_fortune} Mining Fortune`,
       `§8 ■ §7Gain §6+200 ${SYMBOLS.mining_speed} Mining Speed`,
-      `§8 ■ §7Gain §b+10 ${SYMBOLS.cold_resistence} Cold Resistance`,
+      `§8 ■ §7Gain §b+10 ${SYMBOLS.cold_resistance} Cold Resistance`,
       "§8 ■ §7Reduce Pickaxe Ability cooldowns by §a-25%§7.",
     ];
   }

--- a/src/constants/pet-stats.js
+++ b/src/constants/pet-stats.js
@@ -139,8 +139,11 @@ class Pet {
         case "swing_range":
           list.push(`§7Swing Range: ${formatStat(newStats[stat])}`);
           break;
-        case "cold_resistence":
-          list.push(`§7Cold Resistence: ${formatStat(newStats[stat])}`);
+        case "cold_resistance":
+          list.push(`§7Cold Resistance: ${formatStat(newStats[stat])}`);
+          break;
+        case "heat_resistance":
+          list.push(`§7Heat Resistance: ${formatStat(newStats[stat])}`);
           break;
         default:
           list.push(`§cUNKNOWN: ${stat}`);
@@ -994,8 +997,8 @@ class WitherSkeleton extends Pet {
 class Bal extends Pet {
   get stats() {
     return {
-      ferocity: this.level * 0.1,
-      strength: this.level * 0.25,
+      mining_fortune: this.level * 1,
+      heat_resistance: this.level * 1.5,
     };
   }
 
@@ -1011,30 +1014,30 @@ class Bal extends Pet {
   }
 
   get first() {
+    const mult = getValue(this.rarity, { epic: 0.02, legendary: 0.03 });
     return {
-      name: "§6Protective Skin",
-      desc: [`§7§7Gives §cheat immunity§7.`],
+      name: "§6Furnace",
+      desc: [
+        `§7Grants §5+${round(this.level * mult, 1)} ${SYMBOLS.pristine} Pristine§7 while in the §cMagma Fields§7.`,
+      ],
     };
   }
 
   get second() {
-    const mult = getValue(this.rarity, { epic: 0.1 });
+    const mult = getValue(this.rarity, { epic: 0.04 });
     return {
-      name: "§6Fire Whip",
+      name: "§6Dispersion",
       desc: [
-        `§7Every §a5s §7while in combat on public islands, Bal will strike nearby enemies with his fire whip dealing §c${round(
-          this.level * mult,
-          1,
-        )}% §7of your damage as §ftrue damage§7.`,
+        `§7While in the §5Crystal Hollows§7, killing mobs reduces your §c${SYMBOLS.heat_resistance} Heat§7 by §c${floor(this.level * mult, 1)}§7.`,
       ],
     };
   }
 
   get third() {
-    const mult = getValue(this.rarity, { legendary: 0.15 });
+    const mult = getValue(this.rarity, { legendary: 0.1 });
     return {
-      name: "§6Made of Lava",
-      desc: [`§7Gain §a${round(this.level * mult, 1)}% §7on ALL stats when inside the §cMagma Fields§7.`],
+      name: "§6Chimney",
+      desc: [`§7Reduce Pickaxe Ability cooldowns by §a${floor(this.level * mult, 1)}%§7.`],
     };
   }
 }
@@ -3874,7 +3877,7 @@ class Penguin extends Pet {
     return {
       name: "§6Thick Blubber",
       desc: [
-        `§7Each time you catch a Sea Creature, reduce your §b${SYMBOLS.cold_resistence} Cold §7by §a${round(1 + floor(this.level / val), 1)}§7.`,
+        `§7Each time you catch a Sea Creature, reduce your §b${SYMBOLS.cold_resistance} Cold §7by §a${round(1 + floor(this.level / val), 1)}§7.`,
       ],
     };
   }
@@ -3904,7 +3907,7 @@ class Mammoth extends Pet {
   get stats() {
     return {
       defense: 0.5 * this.level,
-      cold_resistence: 0.1 * this.level,
+      cold_resistance: 0.1 * this.level,
     };
   }
 
@@ -3920,7 +3923,7 @@ class Mammoth extends Pet {
     return {
       name: "§6Wooly Coat",
       desc: [
-        `§7Gain a §a${round(this.level * mult, 1)}% §7chance for mobs to not inflict §b${SYMBOLS.cold_resistence} Cold §7when damaging you in the §bGlacite Mineshafts§7.`,
+        `§7Gain a §a${round(this.level * mult, 1)}% §7chance for mobs to not inflict §b${SYMBOLS.cold_resistance} Cold §7when damaging you in the §bGlacite Mineshafts§7.`,
       ],
     };
   }
@@ -3998,7 +4001,7 @@ class GlaciteGolem extends Pet {
   get stats() {
     return {
       mining_speed: 1.25 * this.level,
-      cold_resistence: 0.05 * this.level,
+      cold_resistance: 0.05 * this.level,
     };
   }
 

--- a/src/constants/pets.js
+++ b/src/constants/pets.js
@@ -424,7 +424,7 @@ export const PET_DATA = {
   },
   BAL: {
     head: "/head/c469ba2047122e0a2de3c7437ad3dd5d31f1ac2d27abde9f8841e1d92a8c5b75",
-    type: "combat",
+    type: "mining",
     maxTier: "legendary",
     maxLevel: 100,
     emoji: "🧨",
@@ -999,5 +999,10 @@ export const PET_ITEMS = {
     tier: "UNCOMMON",
     description:
       "§7Adds particles matching your §c+ §7color to your pet and yourself, defaulting to red. §8Editable in Hypixel lobbies.",
+  },
+  PET_ITEM_TITANIUM_MINECART: {
+    name: "Titanium Minecart",
+    tier: "RARE",
+    description: `§7Grants §6+33.3 ${SYMBOLS.mining_fortune} Mining Fortune§7 when mining Titanium Ore.`,
   },
 };

--- a/src/constants/pets.js
+++ b/src/constants/pets.js
@@ -1003,6 +1003,6 @@ export const PET_ITEMS = {
   PET_ITEM_TITANIUM_MINECART: {
     name: "Titanium Minecart",
     tier: "RARE",
-    description: `§7Grants §6+33.3 ${SYMBOLS.mining_fortune} Mining Fortune§7 when mining Titanium Ore.`,
+    description: `§7Grants §6+33.3 ${SYMBOLS.mining_fortune} Mining Fortune§7 when mining §fTitanium Ore§7.`,
   },
 };


### PR DESCRIPTION
- Change the typo of `cold resistence` to `cold resistance` (in all files).
- Add `heat resistance` in the stats file.
- Update `Bal Pet` to new version (combat -> mining) with all new abilities and stats.
- Add `Titanium Minecart` pet item.