### PR TITLE
Updating rift constants for new Skyblock update

### DIFF
--- a/src/constants/rift.js
+++ b/src/constants/rift.js
@@ -68,6 +68,12 @@ export const RIFT_TIMECHARMS = [
     id: 152,
     damage: 0,
   },
+  {
+    name: "Celestial Timecharm",
+    type: "celestial",
+    id: 22,
+    damage: 0,
+  }
 ];
 
 export const RIFT_ENIGMA_SOULS = 42;

--- a/src/constants/rift.js
+++ b/src/constants/rift.js
@@ -79,6 +79,6 @@ export const RIFT_TIMECHARMS = [
   }
 ];
 
-export const RIFT_ENIGMA_SOULS = 42;
+export const RIFT_ENIGMA_SOULS = 52;
 
 export const MAX_GRUBBER_STACKS = 5;

--- a/src/constants/rift.js
+++ b/src/constants/rift.js
@@ -26,6 +26,7 @@ export const RIFT_EYES = [
   {
     name: "The 7th Sin",
     texture: "17db1923d03c4ef4e9f6e872c5a6ad2578b1aff2b281fbc3ffa7466c825fb9",
+  },
 ];
 
 export const RIFT_TIMECHARMS = [
@@ -76,7 +77,7 @@ export const RIFT_TIMECHARMS = [
     type: "celestial",
     id: 22,
     damage: 0,
-  }
+  },
 ];
 
 export const RIFT_ENIGMA_SOULS = 52;

--- a/src/constants/rift.js
+++ b/src/constants/rift.js
@@ -74,7 +74,7 @@ export const RIFT_TIMECHARMS = [
   },
   {
     name: "Celestial Timecharm",
-    type: "celestial",
+    type: "mountaintop",
     id: 22,
     damage: 0,
   },

--- a/src/constants/rift.js
+++ b/src/constants/rift.js
@@ -23,6 +23,9 @@ export const RIFT_EYES = [
     name: "The Prince",
     texture: "f26bde45049c7b7d34605d806a06829b6f955b856a5991fd33e7eabce44c0834",
   },
+  {
+    name: "The 7th Sin",
+    texture: "17db1923d03c4ef4e9f6e872c5a6ad2578b1aff2b281fbc3ffa7466c825fb9",
 ];
 
 export const RIFT_TIMECHARMS = [

--- a/src/constants/rift.js
+++ b/src/constants/rift.js
@@ -74,7 +74,7 @@ export const RIFT_TIMECHARMS = [
   },
   {
     name: "Celestial Timecharm",
-    type: "mountaintop",
+    type: "mountain",
     id: 22,
     damage: 0,
   },


### PR DESCRIPTION
Hypixel Skyblock 0.21 was recently released, and with it came updates to the Rift.  
**Warning:** Check the Hypixel API for compatibility with the `celestial` id of the timecharm
**Note:** First-time contributor; I am familiar with neither this project nor the Hypixel API very well.

# Changed:
- Added the *Pohrtal* Eye *The 7th Sin*
- Updated max Enigma Souls from **42** to **52**
- Added the **Celestial Timecharm**
  
## Question/Possible Issue (Unchanged):
Currently, *The Prince* eye currently has a texture id of [*f26bde45049c7b7d34605d806a06829b6f955b856a5991fd33e7eabce44c0834*] (a discolored, dark eye) rather than the common eye texture [*17db1923d03c4ef4e9f6e872c5a6ad2578b1aff2b281fbc3ffa7466c825fb9*] shared between the other *Pohrtal* eyes. As far as I know, *The Prince* is not textured this way after unlocking in-game, and the discolored eye texture is only displayed in-game before eyes have been unlocked, while SkyCrypt doesn't display anything before it has been unlocked. **Is the different texture intentional?**
  
[src/constants/rift.js](https://github.com/SkyCryptWebsite/SkyCrypt/blob/development/src/constants/rift.js):
```
16    texture: "17db1923d03c4ef4e9f6e872c5a6ad2578b1aff2b281fbc3ffa7466c825fb9",

...

20     texture: "17db1923d03c4ef4e9f6e872c5a6ad2578b1aff2b281fbc3ffa7466c825fb9",

...

22  {
23      name: "The Prince",
24      texture: "f26bde45049c7b7d34605d806a06829b6f955b856a5991fd33e7eabce44c0834",
25  },
```